### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+build/*/_cache


### PR DESCRIPTION
Mainly to avoid uploading tons of build cache to the docker daemon

Signed-off-by: Ken Simon <ninkendo@gmail.com>