### PR TITLE
Always write a done file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,13 +94,13 @@ See [Parameter Reference][3] for a more detailed description of each setting.
 }
 ```
 ### Parameter reference
-| Key  | Type | Default | Meaning  |  
+| Key  | Type | Default | Meaning  |
 |---|---|---|---|
-|  UUID | String |  A randomly generated UUID | Used to name the directory where Sonobuoy-collected data is saved (e.g. `sonobuoy_<UUID>`)  |   
+|  UUID | String |  A randomly generated UUID | Used to name the directory where Sonobuoy-collected data is saved (e.g. `sonobuoy_<UUID>`)  |
 | Description | String | "DEFAULT" | Metadata for keeping track of configs and their use cases |
 | Version | String | `buildInfo.version` (comes from the compilation of the Docker image) | The Sonobuoy version that the config uses for its schema |
 | Kubeconfig | String | ""<br><br>*NOT necessary for containerized Sonobuoy, which will default to the in-cluster config* | Allows Sonobuoy to communicate with and gather info from the Kubernetes cluster |
-| ResultsDir | String | "./results" | The directory in which Sonobuoy writes its results |
+| ResultsDir | String | "./results" | The directory in which Sonobuoy writes its results as well as the [done file][18]. Can be customized with `RESULTS_DIR` environment variable. |
 | Resources | String Array | An array containing all possible resources | *See the [sample JSON][2] above for a list of all available resource types.*<br><br>Indicates to Sonobuoy what type of data it should be recording |
 | Filters.LabelSelector | String | "" | Uses standard Kubernetes [label selector syntax][14] to filter which resource objects are recorded |
 | Filters.Namespaces | String | ".*" | Uses regex on namespaces to filter which resource objects are recorded |
@@ -113,7 +113,7 @@ See [Parameter Reference][3] for a more detailed description of each setting.
 
 ## Plugin configuration
 
-If you have the appropriate plugin definition (third-party or your own), you can easily opt into it by adding a *Plugin Selection* to the main Sonobuoy config's "Plugin" section.  
+If you have the appropriate plugin definition (third-party or your own), you can easily opt into it by adding a *Plugin Selection* to the main Sonobuoy config's "Plugin" section.
 
 The following code snippet, for example, selects the `e2e` and `systemd_logs` plugins:
 
@@ -143,7 +143,9 @@ If you are using the provided manifests as a basis for your own, *you will not n
 
 ### Pod
 
+#### The `done` file
 
+The sonobuoy pod will generate a done file in the ResultsDir after the results get written to disk. This file can be used to react to the results that sonobuoy generates.
 
 However, ensure that your pod declaration has addressed the following aspects, which may be unique to your cluster:
 * **Image Name**
@@ -182,3 +184,4 @@ However, ensure that your pod declaration has addressed the following aspects, w
 [15]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/
 [16]: /plugins.d/e2e.yaml
 [17]: plugins.d/systemdlogs.yaml
+[18]: #the-done-file

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -72,6 +72,11 @@ func LoadConfig() (*Config, error) {
 	// 4 - Any other settings
 	cfg.Version = buildinfo.Version
 
+	// Make the results dir overridable with an environment variable
+	if resultsDir, ok := os.LookupEnv("RESULTS_DIR"); ok {
+		cfg.ResultsDir = resultsDir
+	}
+
 	// Use the exact user config for resources, if set. Viper merges in
 	// arrays, making this part necessary.  This way, if they leave out the
 	// Resources section altogether they get the default set, but if they

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/golang/glog"
@@ -77,6 +78,17 @@ func Run(kubeClient kubernetes.Interface, cfg *config.Config) []error {
 		err = os.RemoveAll(outpath)
 	}
 	if err != nil {
+		errlst = append(errlst, err)
+	}
+
+	// 8. Always write the done file
+	doneFile := cfg.ResultsDir + "/done"
+	absoluteFilepath, err := filepath.Abs(tb)
+	glog.Infof("Writing the done file: %v", doneFile)
+	if err != nil {
+		errlst = append(errlst, err)
+	}
+	if err = ioutil.WriteFile(doneFile, []byte(absoluteFilepath), 0644); err != nil {
 		errlst = append(errlst, err)
 	}
 


### PR DESCRIPTION
The master node will now write a done file when it has finished writing the results.
The contents of the done file will be the name of the results file that sonobuoy has written.

The idea here is that you can react to the results being generated using a second
container that knows to look for a `done` file in some directory.

An example of this would be uploading the results to s3 after sonobuoy master finishes.

Signed-off-by: Chuck Ha <chuck@heptio.com>