### PR TITLE
Fix the build

### DIFF
--- a/build/kube-conformance/Makefile
+++ b/build/kube-conformance/Makefile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Note the only reason we are creating this is because upstream 
-# does not yet publish a released e2e container 
-# https://github.com/kubernetes/kubernetes/issues/47920 
+# Note the only reason we are creating this is because upstream
+# does not yet publish a released e2e container
+# https://github.com/kubernetes/kubernetes/issues/47920
 
 TARGET = kube-conformance
 GOTARGET = github.com/heptio/$(TARGET)
@@ -43,14 +43,14 @@ _cache/kubernetes.tar.gz: _cache
 
 _cache:
 	mkdir -p _cache
-	
+
 container: e2e.test kubectl
 	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest -t $(REGISTRY)/$(TARGET):$(KVER) .
 
 push:
 	gcloud docker -- push $(REGISTRY)/$(TARGET):latest $(REGISTRY)/$(TARGET):$(KVER)
 
-.PHONY: all container 
+.PHONY: all container
 
 clean:
 	rm -rf _cache

--- a/build/sonobuoy/Makefile
+++ b/build/sonobuoy/Makefile
@@ -27,7 +27,7 @@ DOCKER ?= docker
 
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= golang:1.8
-BUILDCMD = go build -v -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET)"
+BUILDCMD = go build -o build/sonobuoy/$(TARGET) -v -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET)"
 BUILD = $(BUILDCMD) $(GOTARGET)/cmd/sonobuoy
 
 TESTARGS ?= -v -timeout 60s


### PR DESCRIPTION
When we build sonobuoy with the docker container we need the output binary to
end up in the Dockerfile context for sonobuoy. In otherwords, we need to put
the built sonobuoy binary in the build/sonobuoy directory.