### PR TITLE
Implement the done file interface

### DIFF
--- a/build/sonobuoy/run_master.sh
+++ b/build/sonobuoy/run_master.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+##########################################################################
 # Copyright 2017 Heptio Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM buildpack-deps:jessie-scm
-MAINTAINER Timothy St. Clair "tstclair@heptio.com"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy}"
+# It's ok for these env vars to be unbound
+RESULTS_DIR="${RESULTS_DIR}" SONOBUOY_CONFIG="${SONOBUOY_CONFIG}" SONOBUOY_ADVERTISE_IP="${SONOBUOY_ADVERTISE_IP}" /sonobuoy master -v 3 --logtostderr
 
-RUN apt-get update && apt-get -y --no-install-recommends install \
-    ca-certificates \
-    && rm -rf /var/cache/apt/* \
-    && rm -rf /var/lib/apt/lists/*
-ADD sonobuoy /sonobuoy
-ADD run_master.sh /run_master.sh
-#USER nobody:nobody
-
-CMD ["/bin/sh", "-c", "/run_master.sh"]
+echo -n "${RESULTS_DIR}/$(ls -t "${RESULTS_DIR}" | grep -v done | head -n 1)" > "${RESULTS_DIR}"/done

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -59,7 +59,7 @@ func LoadConfig() (*Config, error) {
 
 	// 3 - figure out what address we will tell pods to dial for aggregation
 	if cfg.Aggregation.AdvertiseAddress == "" {
-		if ip, ok := os.LookupEnv("SONOBUOY_ADVERTISE_IP"); ok {
+		if ip := os.Getenv("SONOBUOY_ADVERTISE_IP"); ip != "" {
 			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("%v:%d", ip, cfg.Aggregation.BindPort)
 		} else {
 			hostname, _ := os.Hostname()


### PR DESCRIPTION
Once Sonobuoy is finished running it writes the path of the results tarball
into a done file located in the results directory (as configured via
the config file or an env var).

The goal of this is to be able to react to a finished sonobuoy run and
do something interesting with the results. For instance, one could
upload the results to S3 for permanent storage and need not create a long
lived volume for sonobuoy specifically.

Signed-off-by: Chuck Ha <chuck@heptio.com>