### PR TITLE
[docs] Clarify Quickstart conformance tests and potential error after kubectl apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ Its selective data dumps of Kubernetes resource objects and cluster nodes allow 
 * Workload debugging
 * Custom data collection via extensible plugins
 
-## Install and Configure
+## Quickstart
 
-Heptio provides prebuilt Sonobuoy container images in its Google Container Registry (*gcr.io/heptio-images*). For the sake of faster setup on your cluster, **this quickstart pulls from this registry to skip the container build process**. You can use this same process to deploy Sonobuoy to production.
+> Heptio provides prebuilt Sonobuoy container images in its Google Container Registry (*gcr.io/heptio-images*). For the sake of faster setup on your cluster, **this quickstart pulls from this registry to skip the container build process**. You can use this same process to deploy Sonobuoy to production.
+>
+> See [Build From Scratch][4] for instructions on building Sonobuoy yourself.
 
-See [Build From Scratch][4] for instructions on building Sonobuoy yourself.
-
+This guide executes a Sonobuoy run on your cluster, and records the following results:
+* Basic info about your cluster's hosts, Kubernetes resources, and versions.
+* *(Via plugin)* [`systemd`][14] logs from each host
+* *(Via plugin)* The results of a single e2e conformance test ("Pods should be submitted and removed"). See the [conformance guide][13] for configuration details.
 
 ### 0. Prerequisites
 
@@ -48,11 +52,14 @@ You can view actively running pods with the following command:
 kubectl get pods -l component=sonobuoy --namespace=heptio-sonobuoy
 ```
 
-To verify that Sonobuoy has completed successfuly, check the logs:
+To verify that Sonobuoy has completed successfully, check the logs:
 ```
 kubectl logs -f sonobuoy --namespace=heptio-sonobuoy
 ```
 If you see the log line `no-exit was specified, sonobuoy is now blocking`, the Sonobuoy pod is done running.
+
+*Note*: If you see the error `plugin <name> does not exist`, delete
+the `sonobuoy` pod via `kubectl delete pod sonobuoy --namespace heptio-sonobuoy` and rerun the `kubectl apply` command above. This error occurs when Sonobuoy's ConfigMap creations are not completed before its pod creation. While the YAML files in `examples/quickstart` use numeric prefixes ("00-", "10-", etc.) to specify the order of resource creation, `kubectl apply` is asynchronous and can result in dependency issues.
 
 To view the output, copy the output directory from the main Sonobuoy pod to somewhere local:
 ```
@@ -103,8 +110,8 @@ developer certificate of origin that we require.
 See [the list of releases](/CHANGELOG.md) to find out about feature changes.
 
 [0]: https://github.com/heptio
-[1]: https://jenkins.i.heptio.com/buildStatus/icon?job=sonobuoy-master-deployer
-[2]: https://jenkins.i.heptio.com/job/sonobuoy-master-deployer/
+[1]: https://jenkins.i.heptio.com/buildStatus/icon?job=sonobuoy-tag-deployer
+[2]: https://jenkins.i.heptio.com/job/sonobuoy-tag-deployer/
 [3]: https://github.com/kubernetes/kubernetes
 [4]: /docs/build-from-scratch.md
 [5]: http://docs.heptio.com/content/tutorials/aws-cloudformation-k8s.html
@@ -116,3 +123,4 @@ See [the list of releases](/CHANGELOG.md) to find out about feature changes.
 [11]: /CONTRIBUTING.md
 [12]: /CODE_OF_CONDUCT.md
 [13]: /docs/conformance-testing.md
+[14]: https://github.com/systemd/systemd

--- a/docs/build-from-scratch.md
+++ b/docs/build-from-scratch.md
@@ -10,7 +10,7 @@ Sonobuoy can run as (1) **a standalone program** on a node in your cluster, or (
 ## 0. Prerequisites
 
 ### General
-In addition to the handling the prerequisites mentioned in [Install and Configure][4], you should have [Go][5] installed (minimum version 1.8).
+In addition to the handling the prerequisites mentioned in the [Quickstart][4], you should have [Go][5] installed (minimum version 1.8).
 
 ### Standalone
 > **Make sure that you are SSHed into one of the nodes on your cluster.** The subsequent instructions assume that this is the case.

--- a/docs/conformance-testing.md
+++ b/docs/conformance-testing.md
@@ -32,11 +32,11 @@ To customize the set of tests that will be run as part of the report, the follow
 
 | Variable | Default Value | Description |
 |---|---|---|
-| `E2E_FOCUS` | "Conformance" | The test suite to run |
+| `E2E_FOCUS` | "Conformance" | The test suite to run.<br><br>*NOTE*: Because the real conformance suite can take up to half an hour to run, the quickstart example's [e2e config][8] specifies just a single test, "Pods should be submitted and removed". |
 | `E2E_SKIP` | "Alpha&#124;Disruptive&#124;Feature&#124;Flaky&#124;Kubectl" | Which subset of tests to skip |
 | `E2E_PROVIDER` | "local" | The platform that the cluster is running on |
 
-*NOTE: The provided e2e config in the quickstart example has `E2E_FOCUS` set to “Pods should be submitted and removed” rather than "Conformance", for the sake of convenience. The real conformance suite can take up to half an hour to run; to avoid this, the example runs just a single test. To run the "Conformance" suite you can simply comment out the [env section][8] of the quickstart.  Also, the length of time it takes to run conformance can vary based on the size of your cluster---the timeout can be adjusted [here][9].*
+*NOTE: The length of time it takes to run conformance can vary based on the size of your cluster---the timeout can be adjusted in the [Server.timeoutseconds][9] field of the Sonobuoy `config.json`.*
 
 [0]: #overview
 [1]: #integration-with-sonobuoy

--- a/examples/quickstart/10-configmaps.yaml
+++ b/examples/quickstart/10-configmaps.yaml
@@ -184,6 +184,7 @@ data:
         # env section.
         env:
         - name: E2E_FOCUS
+          # Specifies a single conformance test. See above comment for details.
           value: "Pods should be submitted and removed"
         volumeMounts:
         - name: results

--- a/examples/quickstart/20-pod.yaml
+++ b/examples/quickstart/20-pod.yaml
@@ -54,7 +54,7 @@ spec:
       configMap:
         name: sonobuoy-plugins-cm
     # NOTE: This will drop the results on the hostpath of the machine as an example.
-    # We recommend using a persistent volumes for more perminant recording.
+    # We recommend using a persistent volume for more permanent recording.
     - name: output-volume
       hostPath:
         path: /tmp/sonobuoy


### PR DESCRIPTION
@timothysc @kensimon PTAL

This PR:
* Updates the build status button to `tag-deployer` instead of `master-deployer`. Let me know if this doesn't make sense.
* Attempts to clarify the YAML/`kubectl apply` issue around https://github.com/heptio/sonobuoy/issues/30.
* Attempts to clarify conformance tests configs in the Quickstart, based on feedback in https://github.com/heptio/sonobuoy/issues/26.
* Fixes some typos.

Signed-off-by: Jessica Yao <jessica@heptio.com>