### PR TITLE
Don't mount /tmp as host volume in example pod

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ However, ensure that your pod declaration has addressed the following aspects, w
 
 * **Output Volume Mount**
   * Sonobuoy output should be persisted by writing to [Persistent Volume Claims (PVC)][15].
-  * However, for the sake of prototyping (as in the example), you can mount via `hostPath`. This allows you to later inspect Sonobuoy's results by SSHing directly into the pod's node.
+  * However, for the sake of prototyping (as in the example), you can mount via `emptyDir`. This allows you to later inspect Sonobuoy's results by copying them to your local machine with `kubectl cp`.
 
 
 * **Advertise IP (env variable)**

--- a/examples/quickstart/20-pod.yaml
+++ b/examples/quickstart/20-pod.yaml
@@ -53,11 +53,11 @@ spec:
     - name: sonobuoy-plugins-volume
       configMap:
         name: sonobuoy-plugins-cm
-    # NOTE: This will drop the results on the hostpath of the machine as an example.
-    # We recommend using a persistent volume for more permanent recording.
+    # NOTE: This will drop the results in a temporary directory that only lasts
+    # while the pod is still running. We recommend using a persistent volume
+    # for more permanent recording.
     - name: output-volume
-      hostPath:
-        path: /tmp/sonobuoy
+      emptyDir: {}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
We're encouraging using `kubectl cp` in the meantime, using host mounts
was a temporary measure.

This fixes an issue where the documented `kubectl cp` command is
bringing in tarballs from previous runs.