### PR TITLE
[docs] README clarifications for error handling and sonobuoy no-exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,25 @@ To verify that Sonobuoy has completed successfully, check the logs:
 ```
 kubectl logs -f sonobuoy --namespace=heptio-sonobuoy
 ```
-If you see the log line `no-exit was specified, sonobuoy is now blocking`, the Sonobuoy pod is done running.
+If you see the log line `no-exit was specified, sonobuoy is now blocking`, the Sonobuoy pod has completed its data collection.
 
-*Note*: If you see the error `plugin <name> does not exist`, delete
-the `sonobuoy` pod via `kubectl delete pod sonobuoy --namespace heptio-sonobuoy` and rerun the `kubectl apply` command above. This error occurs when Sonobuoy's ConfigMap creations are not completed before its pod creation. While the YAML files in `examples/quickstart` use numeric prefixes ("00-", "10-", etc.) to specify the order of resource creation, `kubectl apply` is asynchronous and can result in dependency issues.
+> *Notes*:
+>
+> * **The Sonobuoy pod in this example continues to run after it finishes data collection**, due to the `--no-exit` flag in its YAML manifest. This allows you to easily grab the results tarball.
+>
+> * **Sonobuoy collects one data report per run**---each time you want a new report you need to delete the existing Sonobuoy YAML files and reapply them (see the [tear down step][15]).
+>
+> * **In practice, you should make sure that the Sonobuoy pod writes its results to a Persistent Volume.** The quickstart example writes its output to an `emptyDir` volume for simplicity.
+>
+> *Troubleshooting errors from `kubectl logs`*:
+>    * `plugin <name> does not exist`
+>           
+>       * Delete the `sonobuoy` pod via `kubectl delete pod sonobuoy --namespace heptio-sonobuoy` and rerun the `kubectl apply` command above. This error occurs when Sonobuoy's ConfigMap creations are not completed before its pod creation. While the YAML files in `examples/quickstart` use numeric prefixes ("00-", "10-", etc.) to specify the order of resource creation, `kubectl apply` is asynchronous and can result in dependency issues.
+>
+>    * Other errors
+>
+>        * If you are able to debug and resolve the issue on your own, *make sure to delete and reapply Sonobuoy's YAML manifests*. Otherwise, [file an issue][10].
+>
 
 To view the output, copy the output directory from the main Sonobuoy pod to somewhere local:
 ```
@@ -72,14 +87,10 @@ There should a collection of tarballs inside of `./results` , where each tarball
 
 ### 3. Tear down
 
-Sonobuoy is not a persistent, background process---each time you want a new data report you will need to re-run it.
-
 To clean up Kubernetes objects created by Sonobuoy, run the following commands:
 ```
 kubectl delete -f examples/quickstart/
 ```
-You may also want to clear the contents of the results directory that the Sonobuoy pod wrote to.
-
 
 ## Further documentation
 
@@ -124,3 +135,4 @@ See [the list of releases](/CHANGELOG.md) to find out about feature changes.
 [12]: /CODE_OF_CONDUCT.md
 [13]: /docs/conformance-testing.md
 [14]: https://github.com/systemd/systemd
+[15]: #3-tear-down

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -149,10 +149,10 @@ spec:
 
 The current, default set of Sonobuoy plugins are available in the `plugins.d` directory within this repo. You can also use the list below as a reference:
 
-| Plugin | Overview | Env Variables (Config) |
+| Plugin | Overview | Source Code Repository | Env Variables (Config) |
 | --- | --- | --- |
-| [`systemd_logs`][11] | Gather the latest system logs from each node, using systemd's `journalctl` command. | (1) `RESULTS_DIR`<br>(2)`CHROOT_DIR`<br>(3)`LOG_MINUTES`|
-| [`e2e`][9] | Run Kubernetes end-to-end tests (e.g. conformance) and gather the results. | `E2E_*` variables configure the end-to-end tests. See the [conformance testing guide][15] for details. |
+| [`systemd_logs`][11] | Gather the latest system logs from each node, using systemd's `journalctl` command. | [heptio/sonobuoy-plugin-systemd-logs][16] | (1) `RESULTS_DIR`<br>(2)`CHROOT_DIR`<br>(3)`LOG_MINUTES`|
+| [`e2e`][9] | Run Kubernetes end-to-end tests (e.g. conformance) and gather the results. | [heptio/kube-conformance][17] | `E2E_*` variables configure the end-to-end tests. See the [conformance testing guide][15] for details. |
 
 See the [`/build`][14] directory for the source code used to build these plugins (specifically, their "producer" containers).
 
@@ -172,3 +172,5 @@ See the [`/build`][14] directory for the source code used to build these plugins
 [13]: /build/systemd-logs/get_systemd_logs.sh
 [14]: /build
 [15]: conformance-testing.md#integration-with-sonobuoy
+[16]: https://github.com/heptio/sonobuoy-plugin-systemd-logs
+[17]: https://github.com/heptio/kube-conformance


### PR DESCRIPTION
@kensimon @timothysc PTAL This is meant to address the confusion raised in https://github.com/heptio/sonobuoy/issues/42.

Please see the [formatted markdown](https://github.com/abiogenesis-now/sonobuoy/blob/20870e11b922b0f6d07beb55f1c7b825d4303a93/README.md#2-run)! I'm not 100% sure that the quote block works----I wanted to visually highlight some important points and also show that they weren't "part of the steps". Let me know your thoughts.