### PR TITLE
Improve error handling with pkg/errors lib

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -199,8 +199,8 @@
 		},
 		{
 			"ImportPath": "github.com/pkg/errors",
-			"Comment": "v0.7.0-13-ga221380",
-			"Rev": "a22138067af1c4942683050411a841ade67fe1eb"
+			"Comment": "v0.8.0-5-gc605e28",
+			"Rev": "c605e284fe17294bda444b34710735b29d1a9d90"
 		},
 		{
 			"ImportPath": "github.com/pkg/sftp",

--- a/cmd/sonobuoy/app/master.go
+++ b/cmd/sonobuoy/app/master.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/discovery"
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/spf13/cobra"
 )
 
@@ -46,24 +47,19 @@ func runMaster(cmd *cobra.Command, args []string) {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		glog.Error(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 
 	// Load a kubernetes client
 	kubeClient, err := config.LoadClient(cfg)
 	if err != nil {
-		glog.Error(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 
 	// Run Discovery (gather API data, run plugins)
-	if errlist := discovery.Run(kubeClient, cfg); errlist != nil {
-		for _, err := range errlist {
-			if err != nil {
-				glog.Error(err)
-			}
-		}
+	if errcount := discovery.Run(kubeClient, cfg); errcount > 0 {
 		exit = 1
 	}
 

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -20,12 +20,14 @@ import (
 	"flag"
 	"os"
 
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	// import `flag` flags into this command to support glog flags
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	RootCmd.PersistentFlags().BoolVarP(&errlog.DebugOutput, "debug", "d", false, "Enable debug output (includes stack traces)")
 }
 
 // RootCmd is the root command that is executed when sonobuoy is run without

--- a/cmd/sonobuoy/app/worker.go
+++ b/cmd/sonobuoy/app/worker.go
@@ -17,13 +17,13 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/worker"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -61,23 +61,23 @@ func runGather(cmd *cobra.Command, args []string) {
 func loadAndValidateConfig() (*plugin.WorkerConfig, error) {
 	cfg, err := worker.LoadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error loading agent configuration: %v", err)
+		return nil, errors.Wrap(err, "error loading agent configuration")
 	}
 
-	var errors []string
+	var errlst []string
 	if cfg.MasterURL == "" {
-		errors = append(errors, "MasterURL not set")
+		errlst = append(errlst, "MasterURL not set")
 	}
 	if cfg.ResultsDir == "" {
-		errors = append(errors, "ResultsDir not set")
+		errlst = append(errlst, "ResultsDir not set")
 	}
 	if cfg.ResultType == "" {
-		errors = append(errors, "ResultsType not set")
+		errlst = append(errlst, "ResultsType not set")
 	}
 
-	if len(errors) > 0 {
-		joinedErrs := strings.Join(errors, ", ")
-		return nil, fmt.Errorf("errors in agent configuration: (%v)", joinedErrs)
+	if len(errlst) > 0 {
+		joinedErrs := strings.Join(errlst, ", ")
+		return nil, errors.Errorf("invalid agent configuration: (%v)", joinedErrs)
 	}
 
 	return cfg, nil
@@ -86,7 +86,7 @@ func loadAndValidateConfig() (*plugin.WorkerConfig, error) {
 func runGatherSingleNode(cmd *cobra.Command, args []string) {
 	cfg, err := loadAndValidateConfig()
 	if err != nil {
-		glog.Errorln(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 
@@ -96,7 +96,7 @@ func runGatherSingleNode(cmd *cobra.Command, args []string) {
 
 	err = worker.GatherResults(cfg.ResultsDir+"/done", url)
 	if err != nil {
-		glog.Errorln(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 
@@ -105,7 +105,7 @@ func runGatherSingleNode(cmd *cobra.Command, args []string) {
 func runGatherGlobal(cmd *cobra.Command, args []string) {
 	cfg, err := loadAndValidateConfig()
 	if err != nil {
-		glog.Errorln(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 
@@ -115,7 +115,7 @@ func runGatherGlobal(cmd *cobra.Command, args []string) {
 
 	err = worker.GatherResults(cfg.ResultsDir+"/done", url)
 	if err != nil {
-		glog.Errorln(err)
+		errlog.LogError(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -23,6 +23,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	pluginloader "github.com/heptio/sonobuoy/pkg/plugin/loader"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -49,12 +50,12 @@ func LoadConfig() (*Config, error) {
 
 	// 1 - Read in the config file.
 	if err = viper.ReadInConfig(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// 2 - Unmarshal the Config struct
 	if err = viper.Unmarshal(cfg); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// 3 - figure out what address we will tell pods to dial for aggregation
@@ -106,7 +107,7 @@ func LoadClient(cfg *Config) (kubernetes.Interface, error) {
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// 2 - creates the clientset from kubeconfig
@@ -139,7 +140,7 @@ func loadAllPlugins(cfg *Config) error {
 		}
 
 		if !found {
-			return fmt.Errorf("Configured plugin %v does not exist", sel.Name)
+			return errors.Errorf("Configured plugin %v does not exist", sel.Name)
 		}
 	}
 

--- a/pkg/discovery/utils.go
+++ b/pkg/discovery/utils.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -53,7 +54,7 @@ func SerializeObj(obj interface{}, outpath string, file string) error {
 			err = ioutil.WriteFile(outpath+"/"+file, eJSONBytes, 0644)
 		}
 	}
-	return err
+	return errors.WithStack(err)
 }
 
 // SerializeArrayObj will write out an array of object
@@ -64,7 +65,7 @@ func SerializeArrayObj(objs []interface{}, outpath string, file string) error {
 			err = ioutil.WriteFile(outpath+"/"+file, eJSONBytes, 0644)
 		}
 	}
-	return err
+	return errors.WithStack(err)
 }
 
 // SerializeObjAppend will serialize an object and append to the end of file
@@ -74,5 +75,5 @@ func SerializeObjAppend(f *os.File, obj interface{}) error {
 		_, err = f.Write(blob)
 		_, err = f.WriteString(",")
 	}
-	return err
+	return errors.WithStack(err)
 }

--- a/pkg/errlog/errlog.go
+++ b/pkg/errlog/errlog.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errlog
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+)
+
+var DebugOutput = false
+
+func LogError(err error) {
+	if DebugOutput {
+		// Print the error message (%v) and the stack trace (%+v) of
+		// the error in the same log statement
+		glog.ErrorDepth(1, fmt.Sprintf("%v\n%+v", err, err))
+	} else {
+		glog.ErrorDepth(1, err.Error())
+	}
+}

--- a/pkg/plugin/aggregation/aggregator.go
+++ b/pkg/plugin/aggregation/aggregator.go
@@ -29,7 +29,9 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/pkg/errors"
 	"github.com/viniciuschiele/tarx"
 )
 
@@ -201,7 +203,8 @@ func (a *Aggregator) handleResult(result *plugin.Result) error {
 	resultsDir := path.Dir(resultsFile)
 	glog.Infof("Creating directory %v", resultsDir)
 	if err := os.MkdirAll(resultsDir, 0755); err != nil {
-		glog.Errorf("Could not make directory %v: %v", resultsDir, err)
+		err = errors.Wrapf(err, "could not make directory %v", resultsDir)
+		errlog.LogError(err)
 		return err
 	}
 
@@ -209,7 +212,8 @@ func (a *Aggregator) handleResult(result *plugin.Result) error {
 	err := func() error {
 		f, err := os.Create(resultsFile)
 		if err != nil {
-			glog.Errorf("Could not open output file %v for writing: %v", resultsFile, err)
+			err = errors.Wrapf(err, "could not open output file %v for writing", resultsFile)
+			errlog.LogError(err)
 			return err
 		}
 		defer f.Close()
@@ -217,7 +221,8 @@ func (a *Aggregator) handleResult(result *plugin.Result) error {
 		// Copy the request body into the file
 		_, err = io.Copy(f, result.Body)
 		if err != nil {
-			glog.Errorf("Error writing plugin result: %v", err)
+			err = errors.Wrapf(err, "error writing plugin result")
+			errlog.LogError(err)
 			return err
 		}
 
@@ -233,7 +238,8 @@ func (a *Aggregator) handleResult(result *plugin.Result) error {
 
 		err = tarx.Extract(resultsFile, resultsDir, &tarx.ExtractOptions{})
 		if err != nil {
-			glog.Errorf("Could not extract tar file %v: %v", resultsFile, err)
+			err = errors.Wrapf(err, "could not extract tar file %v", resultsFile)
+			errlog.LogError(err)
 			return err
 		}
 

--- a/pkg/plugin/aggregation/server.go
+++ b/pkg/plugin/aggregation/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/pkg/errors"
 )
 
 // Server is a net/http server that can handle API requests for aggregation of
@@ -95,7 +96,7 @@ func (s *Server) Start() error {
 	l, err := net.Listen("tcp", s.BindAddr)
 
 	if err != nil {
-		return fmt.Errorf("could not listen on %v: %v", s.BindAddr, err)
+		return errors.Errorf("could not listen on %v: %v", s.BindAddr, err)
 	}
 	defer l.Close()
 

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -31,7 +31,7 @@ type Interface interface {
 	// returns.  It does not block and wait until the plugin has finished.
 	Run(kubeClient kubernetes.Interface) error
 	// Cleanup cleans up all resources created by the plugin
-	Cleanup(kubeClient kubernetes.Interface) []error
+	Cleanup(kubeClient kubernetes.Interface)
 	// Monitor continually checks for problems in the resources created by a
 	// plugin (either because it won't schedule, or the image won't
 	// download, too many failed executions, etc) and sends the errors as

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -18,7 +18,6 @@ package loader
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -32,6 +31,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/daemonset"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/job"
+	"github.com/pkg/errors"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -89,7 +89,7 @@ func loadPlugin(namespace string, dfn plugin.Definition, masterAddress string) (
 		cfg.MasterURL = "http://" + masterAddress + "/api/v1/results/global"
 		return job.NewPlugin(namespace, dfn, cfg), nil
 	default:
-		return nil, fmt.Errorf("Unknown driver %v", dfn.Driver)
+		return nil, errors.Errorf("Unknown driver %v", dfn.Driver)
 	}
 }
 
@@ -160,16 +160,16 @@ func loadJSON(jsonBytes []byte) (*plugin.Definition, error) {
 func loadPluginDefinition(ret *plugin.Definition) error {
 	// Validate it
 	if ret.Driver == "" {
-		return fmt.Errorf("No driver specified in plugin file")
+		return errors.Errorf("No driver specified in plugin file")
 	}
 	if ret.ResultType == "" {
-		return fmt.Errorf("No resultType specified in plugin file")
+		return errors.Errorf("No resultType specified in plugin file")
 	}
 	if ret.Name == "" {
-		return fmt.Errorf("No name specified in plugin file")
+		return errors.Errorf("No name specified in plugin file")
 	}
 	if ret.RawPodSpec == nil {
-		return fmt.Errorf("No pod spec specified in plugin file")
+		return errors.Errorf("No pod spec specified in plugin file")
 	}
 
 	// Construct a pod spec from the ConfigMap data. We can't decode it

--- a/pkg/worker/config.go
+++ b/pkg/worker/config.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
 
@@ -50,11 +51,11 @@ func LoadConfig() (*plugin.WorkerConfig, error) {
 	setConfigDefaults(config)
 
 	if err = viper.ReadInConfig(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if err = viper.Unmarshal(config); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	return config, nil

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 // GatherResults is the consumer of a co-scheduled container that agrees on the following
@@ -62,10 +63,6 @@ func GatherResults(waitfile string, url string) error {
 	// transmit back the results file.
 	return DoRequest(url, func() (io.Reader, error) {
 		outfile, err := os.Open(s)
-		if err != nil {
-			glog.Errorf("Failed to open file (%s)", s)
-			return nil, err
-		}
-		return outfile, err
+		return outfile, errors.WithStack(err)
 	})
 }

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,9 +1,11 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.4.3
-  - 1.5.4
-  - 1.6.2
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
   - tip
 
 script:

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -79,6 +79,14 @@ func (f Frame) Format(s fmt.State, verb rune) {
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace []Frame
 
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':


### PR DESCRIPTION
Goals:

- All errors are either handled and logged, or returned (not both.)
- When we log the errors, the real source line of the actual error can be emitted with a stack trace if --debug is enabled

Whereas before, we would build up an array of errors for any time we could proceed, now we just log them and return nil.  For errors where we can't proceed, we return the error immediately.  Errors making resource queries are serialized into the tarball same as before.

Here's the strategy or how to construct/wrap/forward errors:

- Our own errors are constructed with `errors.Errorf()` to keep track of the stack trace if we need it
- Errors from non-sonobuoy code are wrapped with `errors.Wrap()` if we want to add a context message, or `errors.WithStack()` if we don't.  This guarantees that the stack trace is captured at the innermost point.
- A simple wrapper `errlog.LogError()` is used to log errors, so that errors can optionally include stack traces, depending on whether `--debug` is provided (using "%+v" versus "%v" in the format string)
