### PR TITLE
Fix snapshot docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To view the output, copy the output directory from the main Sonobuoy pod to some
 kubectl cp heptio-sonobuoy/sonobuoy:/tmp/sonobuoy ./results --namespace=heptio-sonobuoy
 ```
 
-There should a collection of tarballs inside of `./results` , where each tarball corresponds to a single Sonobuoy run. If you unzip one of these data dumps, you should see sub-directories containing info about `hosts`, `plugins`, `resources`, and `serverversion`. If you have time, look through these directories to get a sense for Sonobuoy's capabilities.
+This should copy a single `.tar.gz` snapshot from the Sonobuoy pod into your local `./results` directory.  For information on the contents of the snapshot see the [snapshot documentation](docs/snapshot.md).
 
 *NOTE: At this time, the layout of the contents of the tarball is subject to change.*
 


### PR DESCRIPTION
- There's always one tarball now that we switched to emptyDir for the
  example
- Link to the snapshot docs

Signed-off-by: Ken Simon <ninkendo@gmail.com>