### PR TITLE
Fix link for E2E_Focus so it points to the right line

### DIFF
--- a/docs/conformance-testing.md
+++ b/docs/conformance-testing.md
@@ -46,6 +46,6 @@ To customize the set of tests that will be run as part of the report, the follow
 [5]: plugins.md
 [6]: https://github.com/heptio/sonobuoy/blob/master/build/Dockerfile
 [7]: https://github.com/heptio/sonobuoy/blob/master/plugins.d/e2e.yaml
-[8]: https://github.com/heptio/sonobuoy/blob/master/examples/quickstart/components/10-configmaps.yaml#L185
+[8]: https://github.com/heptio/sonobuoy/blob/master/examples/quickstart/components/10-configmaps.yaml#L81
 [9]: https://github.com/heptio/sonobuoy/blob/master/examples/quickstart/components/10-configmaps.yaml#L71
 [10]: https://github.com/kubernetes/kubernetes/issues/49313


### PR DESCRIPTION
This just changes the documentation so the link points to the line that actually contains E2E_FOCUS in the quickstart example.