### PR TITLE
Fix tagging for build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DIR := ${CURDIR}
 DOCKER ?= docker
 
 GIT_VERSION ?= $(shell git describe --always --dirty)
-IMAGE_VERSION ?= $(shell git describe --always --dirty | sed 's/^v//')
+IMAGE_VERSION ?= $(shell git describe --always --dirty)
 IMAGE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF = $(shell git rev-parse --short=8 --verify HEAD)
 


### PR DESCRIPTION
Signed-off-by: Timothy St. Clair <timothysc@gmail.com>

@chuckha this will fix the build artifacts to have proper tagging, eg - :v0.9.0 