### PR TITLE
Optionally make the tests quieter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,13 @@ IMAGE_VERSION ?= $(shell git describe --always --dirty)
 IMAGE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF = $(shell git rev-parse --short=8 --verify HEAD)
 
+VERBOSE ?= "-v"
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
-BUILDCMD = go build -o $(TARGET) -v -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET):$(GIT_REF)"
+BUILDCMD = go build -o $(TARGET) $(VERBOSE) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET):$(GIT_REF)"
 BUILD = $(BUILDCMD) $(GOTARGET)/cmd/sonobuoy
 
-TESTARGS ?= -v -timeout 60s
+TESTARGS ?= $(VERBOSE) -timeout 60s
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
 TEST = go test $(TEST_PKGS) $(TESTARGS)
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ developer certificate of origin that we require.
 * There is a [mailing list][16] and [Slack channel][17] if you want to interact with
 other members of the community
 
+#### Testing
+
+You can run sonobuoy's tests with `make test`. This will spin up local docker
+containers to run the test suite.
+
+For quieter tests, use `VERBOSE="" make test`
+
 #### Pull requests
 
 * We welcome pull requests. Feel free to dig through the [issues][10] and jump in.


### PR DESCRIPTION
By default, this change does nothing. But f you run the tests with `VERBOSE=""`, you can quiet most of the test output down to the bare essentials.

Before:

```
make test | tee >(wc -l)
docker run --rm -v /Users/liz/src/github.com/heptio/sonobuoy:/go/src/github.com/heptio/sonobuoy -w /go/src/github.com/heptio/sonobuoy gcr.io/heptio-images/golang:1.9-alpine3.6 /bin/sh -c 'go build -o sonobuoy "-v" -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v0.9.0-12-g1951106 -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=gcr.io/heptio-images/sonobuoy:19511061" github.com/heptio/sonobuoy/cmd/sonobuoy'
github.com/heptio/sonobuoy/pkg/buildinfo
github.com/heptio/sonobuoy/vendor/github.com/gogo/protobuf/proto
github.com/heptio/sonobuoy/vendor/github.com/c2h5oh/datasize
github.com/heptio/sonobuoy/vendor/github.com/gogo/protobuf/sortkeys
github.com/heptio/sonobuoy/vendor/github.com/mailru/easyjson/jlexer
github.com/heptio/sonobuoy/vendor/github.com/mailru/easyjson/buffer
<<< snip >>>
=== RUN   TestRunGlobal_noExtension
time="2017-11-07T20:53:20Z" level=info msg="Listening for incoming results on :8090\n"
time="2017-11-07T20:53:20Z" level=info msg="Waiting on: (/tmp/sonobuoy_test571972316/done)"
time="2017-11-07T20:53:20Z" level=info msg="Detected done file, transmitting: (/tmp/sonobuoy_test571972316/systemd_logs)"
time="2017-11-07T20:53:20Z" level=info msg="got systemd_logs result\n"
time="2017-11-07T20:53:20Z" level=info msg="Creating directory /tmp/sonobuoy_test261346097/systemd_logs"
time="2017-11-07T20:53:20Z" level=info msg="wrote results to /tmp/sonobuoy_test261346097/systemd_logs/results"
--- PASS: TestRunGlobal_noExtension (0.00s)
PASS
ok  	github.com/heptio/sonobuoy/pkg/worker	0.098s
    3143
```

After:

```
$ VERBOSE="" make test | tee >(wc -l)
docker run --rm -v /Users/liz/src/github.com/heptio/sonobuoy:/go/src/github.com/heptio/sonobuoy -w /go/src/github.com/heptio/sonobuoy gcr.io/heptio-images/golang:1.9-alpine3.6 /bin/sh -c 'go build -o sonobuoy  -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v0.9.0-12-g1951106 -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=gcr.io/heptio-images/sonobuoy:19511061" github.com/heptio/sonobuoy/cmd/sonobuoy'
docker run --rm -v /Users/liz/src/github.com/heptio/sonobuoy:/go/src/github.com/heptio/sonobuoy -w /go/src/github.com/heptio/sonobuoy gcr.io/heptio-images/golang:1.9-alpine3.6 /bin/sh -c 'go vet github.com/heptio/sonobuoy/cmd/... github.com/heptio/sonobuoy/pkg/...'
docker run --rm -v /Users/liz/src/github.com/heptio/sonobuoy:/go/src/github.com/heptio/sonobuoy -w /go/src/github.com/heptio/sonobuoy gcr.io/heptio-images/golang:1.9-alpine3.6 /bin/sh -c 'go test github.com/heptio/sonobuoy/cmd/... github.com/heptio/sonobuoy/pkg/...  -timeout 60s'
?   	github.com/heptio/sonobuoy/cmd/sonobuoy	[no test files]
?   	github.com/heptio/sonobuoy/cmd/sonobuoy/app	[no test files]
?   	github.com/heptio/sonobuoy/pkg/buildinfo	[no test files]
ok  	github.com/heptio/sonobuoy/pkg/config	0.150s
?   	github.com/heptio/sonobuoy/pkg/discovery	[no test files]
?   	github.com/heptio/sonobuoy/pkg/errlog	[no test files]
?   	github.com/heptio/sonobuoy/pkg/plugin	[no test files]
ok  	github.com/heptio/sonobuoy/pkg/plugin/aggregation	0.691s
?   	github.com/heptio/sonobuoy/pkg/plugin/driver/daemonset	[no test files]
?   	github.com/heptio/sonobuoy/pkg/plugin/driver/job	[no test files]
?   	github.com/heptio/sonobuoy/pkg/plugin/driver/utils	[no test files]
?   	github.com/heptio/sonobuoy/pkg/plugin/loader	[no test files]
ok  	github.com/heptio/sonobuoy/pkg/worker	0.120s
      16
```

To document this, a short note about testing has been added to the README. 

Signed-off-by: liz <liz@heptio.com>