### PR TITLE
Testing should be quiet by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 install: true
 
-script: make test
+script: VERBOSE=true make test

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,15 @@ IMAGE_VERSION ?= $(shell git describe --always --dirty)
 IMAGE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD | sed 's/\///g')
 GIT_REF = $(shell git rev-parse --short=8 --verify HEAD)
 
-VERBOSE ?= "-v"
+ifneq ($(VERBOSE),)
+VERBOSE_FLAG = -v
+endif
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
-BUILDCMD = go build -o $(TARGET) $(VERBOSE) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET):$(GIT_REF)"
+BUILDCMD = go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION) -X github.com/heptio/sonobuoy/pkg/buildinfo.DockerImage=$(REGISTRY)/$(TARGET):$(GIT_REF)"
 BUILD = $(BUILDCMD) $(GOTARGET)/cmd/sonobuoy
 
-TESTARGS ?= $(VERBOSE) -timeout 60s
+TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
 TEST = go test $(TEST_PKGS) $(TESTARGS)
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ other members of the community
 You can run sonobuoy's tests with `make test`. This will spin up local docker
 containers to run the test suite.
 
-For quieter tests, use `VERBOSE="" make test`
+For noiser tests, use `VERBOSE=true make test`
 
 #### Pull requests
 


### PR DESCRIPTION
By default, `make test` should be quiet. But verbose logging is enabled on Travis, to make errors easier to spot.

Signed-off-by: liz <liz@heptio.com>