### PR TITLE
[docs] Update releases link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Changelog
-
-#### v0.8.0 - 2017-08-03
-  * Initial Release

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For noiser tests, use `VERBOSE=true make test`
 
 ## Changelog
 
-See [the list of releases](/CHANGELOG.md) to find out about feature changes.
+See [the list of releases](https://github.com/heptio/sonobuoy/releases) to find out about feature changes.
 
 [0]: https://github.com/heptio
 [1]: https://jenkins.i.heptio.com/buildStatus/icon?job=sonobuoy-deployer


### PR DESCRIPTION
(Was doing this for ksonnet, and noticed that we're using Github's releases feature instead of a `CHANGELOG.md` file).

Updated the README to match.

@timothysc fyi