### PR TITLE
Make the toleration more flexible

### DIFF
--- a/examples/ksonnet/components/10-configmaps.jsonnet
+++ b/examples/ksonnet/components/10-configmaps.jsonnet
@@ -91,6 +91,7 @@ local sonobuoyConfigData = {
 local tolerations = [
     {
         key: "node-role.kubernetes.io/master",
+        operator: "Exists",
         effect: "NoSchedule",
     },
     {

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -165,6 +165,7 @@ data:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       volumes:
@@ -250,6 +251,7 @@ data:
           tolerations:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+            operator: Exists
           - key: CriticalAddonsOnly
             operator: Exists
           volumes:

--- a/plugins.d/e2e.jsonnet
+++ b/plugins.d/e2e.jsonnet
@@ -24,6 +24,7 @@ local sonobuoyLabels = {
 local tolerations = [
     {
         key: "node-role.kubernetes.io/master",
+        operator: "Exists",
         effect: "NoSchedule",
     },
     {

--- a/plugins.d/e2e.tmpl
+++ b/plugins.d/e2e.tmpl
@@ -51,6 +51,7 @@ spec:
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+    operator: Exists
   - key: CriticalAddonsOnly
     operator: Exists
   volumes:

--- a/plugins.d/heptio-e2e.jsonnet
+++ b/plugins.d/heptio-e2e.jsonnet
@@ -24,6 +24,7 @@ local sonobuoyLabels = {
 local tolerations = [
     {
         key: "node-role.kubernetes.io/master",
+        operator: "Exists",
         effect: "NoSchedule",
     },
     {

--- a/plugins.d/heptio-e2e.tmpl
+++ b/plugins.d/heptio-e2e.tmpl
@@ -48,6 +48,7 @@ spec:
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+    operator: Exists
   - key: CriticalAddonsOnly
     operator: Exists
   volumes:

--- a/plugins.d/systemd_logs.jsonnet
+++ b/plugins.d/systemd_logs.jsonnet
@@ -23,6 +23,7 @@ local sonobuoyLabels = {
 local tolerations = [
     {
         key: "node-role.kubernetes.io/master",
+        operator: "Exists",
         effect: "NoSchedule",
     },
     {

--- a/plugins.d/systemd_logs.tmpl
+++ b/plugins.d/systemd_logs.tmpl
@@ -78,6 +78,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       volumes:


### PR DESCRIPTION
By adding the Exists operator to the toleration we ensure
that we will schedule a systemd pod on the master node in cases
when the master label actually has a value. `...=true:NoSchedule`.

Using the quickstart on an azure cluster I get this output:

```
$ k get po -n heptio-sonobuoy
NAME                                READY     STATUS              RESTARTS   AGE
sonobuoy                            1/1       Running             0          8s
sonobuoy-e2e-job-73ed9d10e8e84d56   0/2       ContainerCreating   0          5s
systemd-logs-1l2rd                  0/2       ContainerCreating   0          5s
systemd-logs-41q5c                  0/2       ContainerCreating   0          5s
systemd-logs-sqspn                  0/2       ContainerCreating   0          5s

$ k get nodes
NAME                    STATUS         AGE       VERSION
k8s-agent-df59102b-0    Ready,agent    1d        v1.7.7
k8s-agent-df59102b-1    Ready,agent    1d        v1.7.7
k8s-agent-df59102b-2    Ready,agent    1d        v1.7.7
k8s-master-df59102b-0   Ready,master   1d        v1.7.7
```

You'll see there are 3 systemd-logs pods and 4 nodes.

With this patch, I reran the quickstart and got:

```
$ k get po -n heptio-sonobuoy
NAME                                READY     STATUS              RESTARTS   AGE
sonobuoy                            1/1       Running             0          4s
sonobuoy-e2e-job-e658a3698dd941ad   0/2       ContainerCreating   0          1s
systemd-logs-7w46d                  0/2       ContainerCreating   0          1s
systemd-logs-bsdqk                  0/2       ContainerCreating   0          1s
systemd-logs-ft569                  0/2       ContainerCreating   0          1s
systemd-logs-v48vm                  0/2       ContainerCreating   0          1s
```

Which is the expected result.
