### PR TITLE
fix YAML syntax error

### DIFF
--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -220,7 +220,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-   targetPort: 8080
+    targetPort: 8080
   selector:
     run: sonobuoy-master
   type: ClusterIP


### PR DESCRIPTION
There is a syntax error in the example. This PR fixes that. Here's the workflow that let me discover this.

```
$ curl -sSL https://raw.githubusercontent.com/heptio/sonobuoy/master/examples/quickstart.yaml | kubectl create -f - 
namespace "heptio-sonobuoy" created
serviceaccount "sonobuoy-serviceaccount" created
clusterrolebinding "sonobuoy-serviceaccount" created
clusterrole "sonobuoy-serviceaccount" created
configmap "sonobuoy-config-cm" created
configmap "sonobuoy-plugins-cm" created
pod "sonobuoy" created
error: error converting YAML to JSON: yaml: line 12: did not find expected key
```

This fix will be helpful for others trying out sonobuoy examples too.