### PR TITLE
Capture all e2e results if a timeout occurs

### DIFF
--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -51,7 +51,7 @@ func TestRun(t *testing.T) {
 			withTempDir(t, func(tmpdir string) {
 				ioutil.WriteFile(tmpdir+"/systemd_logs", []byte("{}"), 0755)
 				ioutil.WriteFile(tmpdir+"/done", []byte(tmpdir+"/systemd_logs"), 0755)
-				err := GatherResults(tmpdir+"/done", URL, srv.Client())
+				err := GatherResults(tmpdir+"/done", URL, srv.Client(), nil)
 				if err != nil {
 					t.Fatalf("Got error running agent: %v", err)
 				}
@@ -78,7 +78,7 @@ func TestRunGlobal(t *testing.T) {
 		withTempDir(t, func(tmpdir string) {
 			ioutil.WriteFile(tmpdir+"/systemd_logs.json", []byte("{}"), 0755)
 			ioutil.WriteFile(tmpdir+"/done", []byte(tmpdir+"/systemd_logs.json"), 0755)
-			err := GatherResults(tmpdir+"/done", url, srv.Client())
+			err := GatherResults(tmpdir+"/done", url, srv.Client(), nil)
 			if err != nil {
 				t.Fatalf("Got error running agent: %v", err)
 			}
@@ -103,7 +103,7 @@ func TestRunGlobal_noExtension(t *testing.T) {
 		withTempDir(t, func(tmpdir string) {
 			ioutil.WriteFile(tmpdir+"/systemd_logs", []byte("{}"), 0755)
 			ioutil.WriteFile(tmpdir+"/done", []byte(tmpdir+"/systemd_logs"), 0755)
-			err := GatherResults(tmpdir+"/done", url, srv.Client())
+			err := GatherResults(tmpdir+"/done", url, srv.Client(), nil)
 			if err != nil {
 				t.Fatalf("Got error running agent: %v", err)
 			}


### PR DESCRIPTION
This commit introduces an aditional 'soft' timeout.
If the aggregator hits the softtimeout without the plugins finishing it will
tell have the plugins clean themselvfes up. This gives the plugins a chance to
react to being deleted.

Unfortunately k8s has no way to kill one container within a pod so we use the
preStop lifecycle hook. The hook will block k8s from sending a SIGTERM to all
the containers in the pod until the hook finishes (preStop is blocking). The
hook we use gracefully exits the e2e job and then hangs which gives the sonobuoy
worker time to react to the results that it just wrote.

Signed-off-by: Chuck Ha <chuck@heptio.com>