### PR TITLE
Cleanup of worker commands

### DIFF
--- a/pkg/plugin/driver/daemonset/template.go
+++ b/pkg/plugin/driver/daemonset/template.go
@@ -32,10 +32,7 @@ spec:
     spec:
       containers:
       - {{.ProducerContainer | indent 8}}
-      - command:
-        - sh
-        - -c
-        - /sonobuoy worker single-node -v 5 --logtostderr && sleep 3600
+      - command: ["/run_single_node_worker.sh"]
         env:
         - name: NODE_NAME
           valueFrom:

--- a/pkg/plugin/driver/job/template.go
+++ b/pkg/plugin/driver/job/template.go
@@ -22,10 +22,8 @@ metadata:
 spec:
   containers:
   - {{.ProducerContainer | indent 4}}
-  - command:
-    - sh
-    - -c
-    - /sonobuoy worker global -v 5 --logtostderr
+  - command: ["/sonobuoy"]
+    args: ["worker", "global", "-v", "5", "--logtostderr"]
     env:
     - name: NODE_NAME
       valueFrom:

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -118,6 +118,7 @@ data:
       env:
       - name: E2E_FOCUS
         value: {{.E2EFocus}}
+      command: ["/run_e2e.sh"]
       image: gcr.io/heptio-images/kube-conformance:latest
       imagePullPolicy: Always
       name: e2e
@@ -131,10 +132,7 @@ data:
       plugin-name: systemd-logs
       result-type: systemd_logs
     spec:
-      command:
-      - sh
-      - -c
-      - /get_systemd_logs.sh && sleep 3600
+      command: ["/bin/sh", "-c", "/get_systemd_logs.sh && sleep 3600"]
       env:
       - name: NODE_NAME
         valueFrom:

--- a/scripts/run_single_node_worker.sh
+++ b/scripts/run_single_node_worker.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+##########################################################################
 # Copyright 2017 Heptio Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/heptio-images/golang:1.9-alpine3.6
-MAINTAINER Timothy St. Clair "tstclair@heptio.com"
-
-RUN apk add --no-cache ca-certificates
-ADD sonobuoy /sonobuoy
-ADD scripts/run_master.sh /run_master.sh
-ADD scripts/run_single_node_worker.sh /run_single_node_worker.sh
-WORKDIR /
-CMD ["/bin/sh", "-c", "/run_master.sh"]
+/sonobuoy worker single-node -v 5 --logtostderr
+sleep 3600


### PR DESCRIPTION
Single node workers need to have a long sleep because after they finish, regardless of their exit status, they are managed by a daemon set. A daemonset requires that pods always be restarted after they finish so we add a sleep. I think what we really want to do is add a taint to the node after they finish running and then clear taints after the whole thing is done. However, we'd need the alpha feature TaintBasedEvictions enabled so until that becomes GA we probably won't go down this road.

Anyway, this is some cleanup that will make my work with managing signals much nicer.

(running a command wrapped in `/bin/sh -c /cmd/to/run` doesn't pass signals down and therefore we can't intercept them and react to them.

* Wraps daemonset sleeps in a bash command
* Call sonobuoy directly so we can handle SIGTERM manually

Signed-off-by: Chuck Ha <chuck@heptio.com>