### PR TITLE
Exit with an error instead of panic

### DIFF
--- a/cmd/sonobuoy/app/master.go
+++ b/cmd/sonobuoy/app/master.go
@@ -61,12 +61,7 @@ func runMaster(cmd *cobra.Command, args []string) {
 	}
 
 	// Run Discovery (gather API data, run plugins)
-	errcount, err := discovery.Run(kubeClient, cfg)
-	if err != nil {
-		errlog.LogError(err)
-		os.Exit(1)
-	}
-	if errcount > 0 {
+	if errcount := discovery.Run(kubeClient, cfg); errcount > 0 {
 		exit = 1
 	}
 

--- a/cmd/sonobuoy/app/master.go
+++ b/cmd/sonobuoy/app/master.go
@@ -61,7 +61,12 @@ func runMaster(cmd *cobra.Command, args []string) {
 	}
 
 	// Run Discovery (gather API data, run plugins)
-	if errcount := discovery.Run(kubeClient, cfg); errcount > 0 {
+	errcount, err := discovery.Run(kubeClient, cfg)
+	if err != nil {
+		errlog.LogError(err)
+		os.Exit(1)
+	}
+	if errcount > 0 {
 		exit = 1
 	}
 

--- a/pkg/discovery/utils.go
+++ b/pkg/discovery/utils.go
@@ -29,21 +29,21 @@ import (
 )
 
 // FilterNamespaces filter the list of namespaces according to the filter string
-func FilterNamespaces(kubeClient kubernetes.Interface, filter string) []string {
+func FilterNamespaces(kubeClient kubernetes.Interface, filter string) ([]string, error) {
 	var validns []string
 	re := regexp.MustCompile(filter)
 	nslist, err := kubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err == nil {
-		for _, ns := range nslist.Items {
-			logrus.Infof("Namespace %v Matched=%v", ns.Name, re.MatchString(ns.Name))
-			if re.MatchString(ns.Name) {
-				validns = append(validns, ns.Name)
-			}
-		}
-	} else {
-		panic(err.Error())
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
-	return validns
+
+	for _, ns := range nslist.Items {
+		logrus.Infof("Namespace %v Matched=%v", ns.Name, re.MatchString(ns.Name))
+		if re.MatchString(ns.Name) {
+			validns = append(validns, ns.Name)
+		}
+	}
+	return validns, nil
 }
 
 // SerializeObj will write out an object


### PR DESCRIPTION
Fixes #257 

```
Sonobuoy has to perform a couple of operations before actually starting
a test. Instead of panicking when one of these ops fails, return an
error and exit with a non-zero exit code.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
```

Failure output sample:
```
INFO[0000] Scanning plugins in ./plugins.d (pwd: /Users/abrand/go/src/github.com/heptio/sonobuoy)
INFO[0000] unknown template type                         filename=e2e.jsonnet
INFO[0000] unknown template type                         filename=heptio-e2e.jsonnet
INFO[0000] unknown template type                         filename=systemd_logs.jsonnet
INFO[0000] Scanning plugins in /etc/sonobuoy/plugins.d (pwd: /Users/abrand/go/src/github.com/heptio/sonobuoy)
INFO[0000] Directory (/etc/sonobuoy/plugins.d) does not exist
INFO[0000] Scanning plugins in ~/sonobuoy/plugins.d (pwd: /Users/abrand/go/src/github.com/heptio/sonobuoy)
INFO[0000] Directory (~/sonobuoy/plugins.d) does not exist
INFO[0000] Loading plugin driver DaemonSet
INFO[0000] Loading plugin driver Job
INFO[0000] Filtering namespaces based on the following regex:.*|heptio-sonobuoy
ERRO[0030] could not filter namespaces: Get https://192.168.99.100:8443/api/v1/namespaces: dial tcp 192.168.99.100:8443: i/o timeout
exit status 1
```