### PR TITLE
Handle signals from kubernetes

### DIFF
--- a/cmd/sonobuoy/app/worker.go
+++ b/cmd/sonobuoy/app/worker.go
@@ -112,7 +112,6 @@ func runGatherSingleNode(cmd *cobra.Command, args []string) {
 		errlog.LogError(err)
 		os.Exit(1)
 	}
-
 }
 
 func runGatherGlobal(cmd *cobra.Command, args []string) {

--- a/pkg/plugin/constants.go
+++ b/pkg/plugin/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+const (
+	// GracefulShutdownPeriod is how long plugins have to cleanly finish before they are terminated.
+	GracefulShutdownPeriod = 60
+)

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -186,7 +186,7 @@ func (p *Plugin) Monitor(kubeclient kubernetes.Interface, _ []v1.Node, resultsCh
 // Cleanup cleans up the k8s Job and ConfigMap created by this plugin instance
 func (p *Plugin) Cleanup(kubeclient kubernetes.Interface) {
 	p.cleanedUp = true
-	gracePeriod := int64(1)
+	gracePeriod := int64(plugin.GracefulShutdownPeriod)
 	deletionPolicy := metav1.DeletePropagationBackground
 
 	listOptions := metav1.ListOptions{


### PR DESCRIPTION
* Handles a SIGTERM (pod deletion) more cleanly
* Increased job grace period to 60 seconds
* Tells plugins to cleanup 60 seconds before shutting down the aggregation server

fixes #214

Signed-off-by: Chuck Ha <chuck@heptio.com>