### PR TITLE
Sonobuoy status

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import "github.com/spf13/cobra"
+
+// AddNamespaceFlag initialises a namespace flag
+func AddNamespaceFlag(str *string, cmd *cobra.Command) {
+	// TODO(timothysc) This variable default needs saner image defaults from ops.f(n) or config
+	cmd.PersistentFlags().StringVarP(
+		str, "namespace", "n", "heptio-sonobuoy",
+		"The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously.",
+	)
+}

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -50,16 +50,15 @@ func AddGenFlags(gen *ops.GenConfig, cmd *cobra.Command) {
 		&mode, "e2e-mode", "", string(ops.Conformance),
 		fmt.Sprintf("What mode to run sonobuoy in. [%s]", strings.Join(ops.GetModes(), ", ")),
 	)
+
+	AddNamespaceFlag(&gen.Namespace, cmd)
+
 	// TODO(timothysc) This variable default needs saner image defaults from ops.f(n) or config
 	cmd.PersistentFlags().StringVarP(
 		&gen.Image, "sonobuoy-image", "", "gcr.io/heptio-images/sonobuoy:master",
 		"Container image override for the sonobuoy worker and container",
 	)
-	// TODO(timothysc) This variable default needs saner image defaults from ops.f(n) or config
-	cmd.PersistentFlags().StringVarP(
-		&gen.Namespace, "namespace", "n", "heptio-sonobuoy",
-		"The namespace to run Sonobuoy in. Only one Sonobuoy run can exist per namespace simultaneously.",
-	)
+
 	// TODO(timothysc) Need to provide ability to override config structure and allow for sane defaults
 	// TODO(timothysc) Need to provide ability to override e2e-focus
 	// TODO(timothysc) Need to provide ability to override e2e-skip

--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -32,7 +32,7 @@ import (
 )
 
 var statusOpts struct {
-	namespace args.Namespace
+	namespace string
 	config    args.Kubeconfig
 }
 
@@ -44,7 +44,7 @@ func init() {
 		Args:  cobra.ExactArgs(0),
 	}
 
-	args.AddNamespaceFlag(&statusOpts.namespace, cmd)
+	AddNamespaceFlag(&statusOpts.namespace, cmd)
 	args.AddKubeconfigFlag(&statusOpts.config, cmd)
 
 	RootCmd.AddCommand(cmd)
@@ -56,7 +56,7 @@ func getStatus(cmd *cobra.Command, args []string) {
 		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
 		os.Exit(1)
 	}
-	namespace := statusOpts.namespace.Get()
+	namespace := statusOpts.namespace
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "couldn't initialise kubernete client"))

--- a/pkg/plugin/aggregation/run.go
+++ b/pkg/plugin/aggregation/run.go
@@ -112,7 +112,7 @@ func Run(client kubernetes.Interface, plugins []plugin.Interface, cfg plugin.Agg
 		doneServ <- srv.ListenAndServeTLS("", "")
 	}()
 
-	updater := NewUpdater(expectedResults, "sonobuoy", namespace, client)
+	updater := newUpdater(expectedResults, namespace, client)
 	ticker := time.NewTicker(annotationUpdateFreq)
 	defer ticker.Stop()
 

--- a/pkg/plugin/aggregation/update_test.go
+++ b/pkg/plugin/aggregation/update_test.go
@@ -13,9 +13,8 @@ func TestCreateUpdater(t *testing.T) {
 		{NodeName: "", ResultType: "e2e"},
 	}
 
-	updater := NewUpdater(
+	updater := newUpdater(
 		expected,
-		"sonobuoy",
 		"heptio-sonobuoy-test",
 		nil,
 	)


### PR DESCRIPTION
Example status:
```
+--------------+-----------------------------+----------+
|    PLUGIN    |            NODE             |  STATUS  |
+--------------+-----------------------------+----------+
| e2e          |                             | running  |
| systemd_logs | ip-10-0-18-159.ec2.internal | complete |
| systemd_logs | ip-10-0-22-130.ec2.internal | complete |
| systemd_logs | ip-10-0-22-8.ec2.internal   | complete |
+--------------+-----------------------------+----------+
|                                              RUNNING  |
+--------------+-----------------------------+----------+
```

closes #209 