### PR TITLE
Adds YAML separator in generated YAML

### DIFF
--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -45,8 +45,8 @@ rules:
   - '*'
   verbs:
   - '*'
----
 {{- end }}
+---
 apiVersion: v1
 data:
   config.json: |


### PR DESCRIPTION
The YAML is missing a `---` without this change and with EnabledRBAC = false.

Signed-off-by: Chuck Ha <chuck@heptio.com>