### PR TITLE
Delete cmd

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -128,3 +128,11 @@ func AddSkipPreflightFlag(flag *bool, cmd *cobra.Command) {
 		"If true, skip all checks before kicking off the sonobuoy run.",
 	)
 }
+
+// AddDeleteAllFlag adds a boolean flag for deleting everything (including E2E tests).
+func AddDeleteAllFlag(flag *bool, cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(
+		flag, "all", false,
+		"In addition to deleting Sonobuoy namespaces, also clean up dangling e2e- namespaces.",
+	)
+}

--- a/cmd/sonobuoy/app/delete.go
+++ b/cmd/sonobuoy/app/delete.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"os"
+
+	"github.com/heptio/sonobuoy/pkg/client"
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+var deleteFlags struct {
+	kubeconfig Kubeconfig
+	namespace  string
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "cleans up a sonobuoy run",
+		Run:   deleteSonobuoyRun,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	AddKubeconfigFlag(&deleteFlags.kubeconfig, cmd)
+	AddNamespaceFlag(&deleteFlags.namespace, cmd)
+
+	RootCmd.AddCommand(cmd)
+}
+
+func deleteSonobuoyRun(cmd *cobra.Command, args []string) {
+	cfg, err := deleteFlags.kubeconfig.Get()
+	if err != nil {
+		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
+		os.Exit(1)
+	}
+
+	kubeclient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes client"))
+		os.Exit(1)
+	}
+
+	if err := client.NewSonobuoyClient().Delete(deleteFlags.namespace, kubeclient); err != nil {
+		errlog.LogError(errors.Wrap(err, "failed to delete sonobuoy resources"))
+		os.Exit(1)
+	}
+
+}

--- a/cmd/sonobuoy/app/delete.go
+++ b/cmd/sonobuoy/app/delete.go
@@ -44,6 +44,7 @@ func init() {
 	AddKubeconfigFlag(&deleteFlags.kubeconfig, cmd)
 	AddNamespaceFlag(&deleteopts.Namespace, cmd)
 	AddRBACModeFlags(&deleteFlags.rbacMode, cmd, DetectRBACMode)
+	AddDeleteAllFlag(&deleteopts.DeleteAll, cmd)
 
 	RootCmd.AddCommand(cmd)
 }

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (c *SonobuoyClient) Delete(namespace string, client kubernetes.Interface) error {
+	return errors.New("not yet implemented")
+}

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -70,9 +70,9 @@ func (c *SonobuoyClient) Delete(cfg *DeleteConfig, client kubernetes.Interface) 
 	}
 
 	for _, namespace := range namespaces.Items {
-		if strings.HasPrefix(e2eNamespacePrefix, namespace.Name) {
+		if strings.HasPrefix(namespace.Name, e2eNamespacePrefix) {
 			if err := client.CoreV1().Namespaces().Delete(namespace.Name, &metav1.DeleteOptions{}); err != nil {
-				return errors.Wrap(err, "failed to delete 2e2 namespace")
+				return errors.Wrap(err, "failed to delete e2e namespace")
 			}
 			logrus.WithField("namespace", namespace.Name).Info("deleted E2E namespace")
 		}

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -21,6 +21,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (c *SonobuoyClient) Delete(namespace string, client kubernetes.Interface) error {
+func (c *SonobuoyClient) Delete(cfg *DeleteConfig, client kubernetes.Interface) error {
 	return errors.New("not yet implemented")
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -91,4 +91,6 @@ type Interface interface {
 	GetStatus(namespace string, client kubernetes.Interface) (*aggregation.Status, error)
 	// GetLogs streams logs from the sonobuoy pod by default to stdout.
 	GetLogs(cfg *LogConfig, client kubernetes.Interface) error
+	// Delete removes a sonobuoy run, namespace, and all associated tests.
+	Delete(namespace string, client kubernetes.Interface) error
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -59,6 +59,7 @@ type RunConfig struct {
 type DeleteConfig struct {
 	Namespace  string
 	EnableRBAC bool
+	DeleteAll  bool
 }
 
 // RetrieveConfig are the options passed to RetrieveResults.
@@ -97,6 +98,6 @@ type Interface interface {
 	GetStatus(namespace string, client kubernetes.Interface) (*aggregation.Status, error)
 	// GetLogs streams logs from the sonobuoy pod by default to stdout.
 	GetLogs(cfg *LogConfig, client kubernetes.Interface) error
-	// Delete removes a sonobuoy run, namespace, and all associated tests.
+	// Delete removes a sonobuoy run, namespace, and all associated resources.
 	Delete(cfg *DeleteConfig, client kubernetes.Interface) error
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -55,6 +55,12 @@ type RunConfig struct {
 	SkipPreflight bool
 }
 
+// DeleteConfig are the input options for cleaning up a Sonobuoy run.
+type DeleteConfig struct {
+	Namespace  string
+	EnableRBAC bool
+}
+
 // RetrieveConfig are the options passed to RetrieveResults.
 type RetrieveConfig struct {
 	// CmdErr is the place to write errors to.
@@ -92,5 +98,5 @@ type Interface interface {
 	// GetLogs streams logs from the sonobuoy pod by default to stdout.
 	GetLogs(cfg *LogConfig, client kubernetes.Interface) error
 	// Delete removes a sonobuoy run, namespace, and all associated tests.
-	Delete(namespace string, client kubernetes.Interface) error
+	Delete(cfg *DeleteConfig, client kubernetes.Interface) error
 }


### PR DESCRIPTION
```
$ sonobuoy run --mode quick
INFO[0000] created object                                name=heptio-sonobuoy namespace= resource=namespaces
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace=heptio-sonobuoy resource=serviceaccounts
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace= resource=clusterrolebindings
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace= resource=clusterroles
INFO[0000] created object                                name=sonobuoy-config-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy-plugins-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy namespace=heptio-sonobuoy resource=pods
INFO[0000] created object                                name=sonobuoy-master namespace=heptio-sonobuoy resource=services
$ sonobuoy delete
$ k apply -f /tmp/file.yaml
namespace "e2e-tests-container-probe-fdqfr" configured
$ sonobuoy delete
INFO[0000] deleted namespace                             namespace=heptio-sonobuoy
INFO[0000] deleted clusterrolebindings and clusterroles
INFO[0000] deleted E2E namespace                         namespace=e2e-tests-container-probe-fdqfr
INFO[0000] deleted E2E namespace                         namespace=e2e-tests-pods-qlpdc
$
```