### PR TITLE
Remove logrus hooks at the end of the run.

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -61,6 +61,10 @@ func Run(kubeClient kubernetes.Interface, cfg *config.Config) (errCount int) {
 
 	logrus.AddHook(hook)
 
+	// Unset all hooks as we exit the Run function
+	defer func() {
+		logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
+	}()
 	// closure used to collect and report errors.
 	trackErrorsFor := func(action string) func(error) {
 		return func(err error) {


### PR DESCRIPTION
Sonobuoy has captured everything interesting and has created the results.
No more logs should be written to disk at this point.

We are stuck referencing the standard logger as that's what we've been using across the rest of sonobuoy.