### PR TITLE
More friendly status messages

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -79,10 +79,10 @@ func getStatus(cmd *cobra.Command, args []string) {
 		errlog.LogError(errors.Wrap(err, "couldn't write status out"))
 		os.Exit(1)
 	}
-	fmt.Printf("\n%s\n", statusAsString(status.Status))
+	fmt.Printf("\n%s\n", humanReadableStatus(status.Status))
 }
 
-func statusAsString(str string) string {
+func humanReadableStatus(str string) string {
 	switch str {
 	case "running":
 		return "Sonobuoy is still running. Runs can take up to 60 minutes."

--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -19,7 +19,6 @@ package app
 import (
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
@@ -75,9 +74,23 @@ func getStatus(cmd *cobra.Command, args []string) {
 	for _, pluginStatus := range status.Plugins {
 		fmt.Fprintf(tw, "%s\t%s\t%s\n", pluginStatus.Plugin, pluginStatus.Node, pluginStatus.Status)
 	}
-	fmt.Fprintf(tw, "\t\t%s\n", strings.ToUpper(status.Status))
+
 	if err := tw.Flush(); err != nil {
 		errlog.LogError(errors.Wrap(err, "couldn't write status out"))
 		os.Exit(1)
+	}
+	fmt.Printf("\n%s\n", statusAsString(status.Status))
+}
+
+func statusAsString(str string) string {
+	switch str {
+	case "running":
+		return "Sonobuoy is still running. Runs can take up to 60 minutes."
+	case "failed":
+		return "Sonobuoy has failed. You can see what happened with `sonobuoy logs`."
+	case "completed":
+		return "Sonobuoy has completed. Use `sonobuoy retrieve` to get results."
+	default:
+		return fmt.Sprintf("Sonobuoy is in unknown state %q. Please report a bug at github.com/heptio/sonobuoy", str)
 	}
 }


### PR DESCRIPTION
```
$ sonobuoy status
PLUGIN		NODE				STATUS
e2e						running
systemd_logs	ip-10-0-11-88.ec2.internal	complete
systemd_logs	ip-10-0-12-235.ec2.internal	complete
systemd_logs	ip-10-0-19-40.ec2.internal	complete

Sonobuoy is still running. Runs can take up to 60 minutes.
```