### PR TITLE
Hardcodes version so `go get` has some state.

### DIFF
--- a/cmd/sonobuoy/app/version.go
+++ b/cmd/sonobuoy/app/version.go
@@ -36,5 +36,4 @@ var versionCmd = &cobra.Command{
 
 func runVersion(cmd *cobra.Command, args []string) {
 	fmt.Println(buildinfo.Version)
-	fmt.Println("Configured docker image:", buildinfo.DockerImage)
 }

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -20,7 +20,7 @@ limitations under the License.
 package buildinfo
 
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
-var Version string
+var Version = "v0.11.0-alpha"
 
 // DockerImage is the full path to the docker image for this build, example gcr.io/heptio-images/sonobuoy
 var DockerImage string


### PR DESCRIPTION
Signed-off-by: Timothy St. Clair <timothysc@gmail.com>

/cc @liztio 