### PR TITLE
Plugin refactor

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,7 +145,8 @@ type Config struct {
 	///////////////////////////////////////////////
 	// sonobuoy configuration
 	///////////////////////////////////////////////
-	WorkerImage string `json:"WorkerImage" mapstructure:"workerImage"`
+	WorkerImage     string `json:"WorkerImage" mapstructure:"WorkerImage"`
+	ImagePullPolicy string `json:"ImagePullPolicy" mapstructure:"ImagePullPolicy"`
 }
 
 // LimitConfig is a configuration on the limits of sizes of various responses.
@@ -252,6 +253,7 @@ func NewWithDefaults() *Config {
 
 	// TODO (timothysc) reference the other consts
 	cfg.WorkerImage = "gcr.io/heptio-images/sonobuoy:latest"
+	cfg.ImagePullPolicy = "Always"
 
 	return &cfg
 }

--- a/pkg/plugin/base.go
+++ b/pkg/plugin/base.go
@@ -1,0 +1,144 @@
+package plugin
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+type Base struct {
+	Definition    Definition
+	SessionID     string
+	Namespace     string
+	SonobuoyImage string
+	CleanedUp     bool
+}
+
+type TemplateData struct {
+	PluginName        string
+	ResultType        string
+	SessionID         string
+	Namespace         string
+	SonobuoyImage     string
+	ProducerContainer string
+	MasterAddress     string
+	CACert            string
+	SecretName        string
+}
+
+// GetSessionID returns the session id associated with the plugin
+func (b *Base) GetSessionID() string {
+	return b.SessionID
+}
+
+// GetName returns the name of this Job plugin
+func (b *Base) GetName() string {
+	return b.Definition.Name
+}
+
+func (b *Base) GetSecretName() string {
+	return fmt.Sprintf("job-%s-%s", b.GetName(), b.GetSessionID())
+}
+
+// GetResultType returns the ResultType for this plugin (to adhere to plugin.Interface)
+func (b *Base) GetResultType() string {
+	return b.Definition.ResultType
+}
+
+//FillTemplate populates the internal Job YAML template with the values for this particular job.
+func (b *Base) GetTemplateData(hostname string, cert *tls.Certificate) (*TemplateData, error) {
+
+	container, err := kuberuntime.Encode(manifest.Encoder, &b.Definition.Spec)
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't reserialize container for job %q", b.Definition.Name)
+	}
+
+	cacert := getCACertPEM(cert)
+
+	return &TemplateData{
+		PluginName:        b.Definition.Name,
+		ResultType:        b.Definition.ResultType,
+		SessionID:         b.SessionID,
+		Namespace:         b.Namespace,
+		SonobuoyImage:     b.SonobuoyImage,
+		ProducerContainer: string(container),
+		MasterAddress:     b.GetMasterAddress(hostname),
+		CACert:            cacert,
+		SecretName:        b.GetSecretName(),
+	}, nil
+}
+
+func (b *Base) GetMasterAddress(hostname string) string {
+	panic("base GetMasterAddress called")
+}
+
+// MakeTLSSecret makes a Kubernetes secret object for the given TLS certificate.
+func (b *Base) MakeTLSSecret(cert *tls.Certificate) (*v1.Secret, error) {
+	rsaKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key not ECDSA")
+	}
+
+	if len(cert.Certificate) <= 0 {
+		return nil, errors.New("no certs in tls.certificate")
+	}
+
+	certDER := cert.Certificate[0]
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyPEM, err := getKeyPEM(rsaKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't PEM encode TLS key")
+	}
+
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.GetSecretName(),
+			Namespace: b.Namespace,
+		},
+		Data: map[string][]byte{
+			v1.TLSPrivateKeyKey: keyPEM,
+			v1.TLSCertKey:       certPEM,
+		},
+		Type: v1.SecretTypeTLS,
+	}, nil
+
+}
+
+// GetCACertPEM extracts the CA cert from a tls.Certificate.
+// If the provided Certificate has only one certificate in the chain, the CA
+// will be the leaf cert.
+func getCACertPEM(cert *tls.Certificate) string {
+	cacert := ""
+	if len(cert.Certificate) > 0 {
+		caCertDER := cert.Certificate[len(cert.Certificate)-1]
+		cacert = string(pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: caCertDER,
+		}))
+	}
+	return cacert
+}
+
+// GetKeyPEM turns an RSA Private Key into a PEM-encoded string
+func getKeyPEM(key *ecdsa.PrivateKey) ([]byte, error) {
+	derKEY, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: derKEY,
+	}), nil
+}

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -1,4 +1,4 @@
-package plugin
+package driver
 
 import (
 	"crypto/ecdsa"
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 
+	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -15,7 +16,7 @@ import (
 )
 
 type Base struct {
-	Definition    Definition
+	Definition    plugin.Definition
 	SessionID     string
 	Namespace     string
 	SonobuoyImage string
@@ -54,7 +55,7 @@ func (b *Base) GetResultType() string {
 }
 
 //FillTemplate populates the internal Job YAML template with the values for this particular job.
-func (b *Base) GetTemplateData(hostname string, cert *tls.Certificate) (*TemplateData, error) {
+func (b *Base) GetTemplateData(masterAddress string, cert *tls.Certificate) (*TemplateData, error) {
 
 	container, err := kuberuntime.Encode(manifest.Encoder, &b.Definition.Spec)
 	if err != nil {
@@ -70,14 +71,10 @@ func (b *Base) GetTemplateData(hostname string, cert *tls.Certificate) (*Templat
 		Namespace:         b.Namespace,
 		SonobuoyImage:     b.SonobuoyImage,
 		ProducerContainer: string(container),
-		MasterAddress:     b.GetMasterAddress(hostname),
+		MasterAddress:     masterAddress,
 		CACert:            cacert,
 		SecretName:        b.GetSecretName(),
 	}, nil
-}
-
-func (b *Base) GetMasterAddress(hostname string) string {
-	panic("base GetMasterAddress called")
 }
 
 // MakeTLSSecret makes a Kubernetes secret object for the given TLS certificate.

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -15,6 +15,7 @@ import (
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
+// Base is the  truct that stores state for plugin drivers and contains helper methods.
 type Base struct {
 	Definition    plugin.Definition
 	SessionID     string
@@ -23,6 +24,7 @@ type Base struct {
 	CleanedUp     bool
 }
 
+// TemplateData is all the fields available to plugin driver templates.
 type TemplateData struct {
 	PluginName        string
 	ResultType        string
@@ -35,26 +37,27 @@ type TemplateData struct {
 	SecretName        string
 }
 
-// GetSessionID returns the session id associated with the plugin
+// GetSessionID returns the session id associated with the plugin.
 func (b *Base) GetSessionID() string {
 	return b.SessionID
 }
 
-// GetName returns the name of this Job plugin
+// GetName returns the name of this Job plugin.
 func (b *Base) GetName() string {
 	return b.Definition.Name
 }
 
+// GetSecretName gets a name for a secret based on the plugin name and session ID.
 func (b *Base) GetSecretName() string {
-	return fmt.Sprintf("job-%s-%s", b.GetName(), b.GetSessionID())
+	return fmt.Sprintf("sonobuoy-plugin-%s-%s", b.GetName(), b.GetSessionID())
 }
 
-// GetResultType returns the ResultType for this plugin (to adhere to plugin.Interface)
+// GetResultType returns the ResultType for this plugin (to adhere to plugin.Interface).
 func (b *Base) GetResultType() string {
 	return b.Definition.ResultType
 }
 
-//FillTemplate populates the internal Job YAML template with the values for this particular job.
+//GetTemplateData fills a TemplateData struct with the passed in and state variables.
 func (b *Base) GetTemplateData(masterAddress string, cert *tls.Certificate) (*TemplateData, error) {
 
 	container, err := kuberuntime.Encode(manifest.Encoder, &b.Definition.Spec)
@@ -113,7 +116,7 @@ func (b *Base) MakeTLSSecret(cert *tls.Certificate) (*v1.Secret, error) {
 
 }
 
-// GetCACertPEM extracts the CA cert from a tls.Certificate.
+// getCACertPEM extracts the CA cert from a tls.Certificate.
 // If the provided Certificate has only one certificate in the chain, the CA
 // will be the leaf cert.
 func getCACertPEM(cert *tls.Certificate) string {
@@ -128,7 +131,7 @@ func getCACertPEM(cert *tls.Certificate) string {
 	return cacert
 }
 
-// GetKeyPEM turns an RSA Private Key into a PEM-encoded string
+// getKeyPEM turns an RSA Private Key into a PEM-encoded string
 func getKeyPEM(key *ecdsa.PrivateKey) ([]byte, error) {
 	derKEY, err := x509.MarshalECPrivateKey(key)
 	if err != nil {

--- a/pkg/plugin/driver/base_test.go
+++ b/pkg/plugin/driver/base_test.go
@@ -1,4 +1,4 @@
-package utils
+package driver
 
 import (
 	"crypto/ecdsa"
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/heptio/sonobuoy/pkg/backplane/ca"
+	"github.com/heptio/sonobuoy/pkg/plugin"
 )
 
 func TestMakeTLSSecret(t *testing.T) {
@@ -17,18 +18,27 @@ func TestMakeTLSSecret(t *testing.T) {
 	}
 	expectedNamespace := "test-namespace"
 	expectedName := "test-name"
+	sessionID := "aaaaaa11111"
 
 	cert, err := auth.ClientKeyPair("")
 	if err != nil {
 		t.Fatalf("unexpected error %v making client pair", err)
 	}
 
-	secret, err := MakeTLSSecret(cert, expectedNamespace, expectedName)
+	driver := &Base{
+		Namespace: expectedNamespace,
+		Definition: plugin.Definition{
+			Name: expectedName,
+		},
+		SessionID: sessionID,
+	}
+
+	secret, err := driver.MakeTLSSecret(cert)
 	if err != nil {
 		t.Fatalf("unexpected error %v making TLS Secret", err)
 	}
 
-	if secret.ObjectMeta.Name != expectedName {
+	if secret.ObjectMeta.Name != driver.GetSecretName() {
 		t.Errorf("expected name %v, got %v", expectedName, secret.ObjectMeta.Name)
 	}
 	if secret.ObjectMeta.Namespace != expectedNamespace {

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -25,7 +25,6 @@ import (
 	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/utils"
-	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	"github.com/pkg/errors"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/api/core/v1"
@@ -39,37 +38,23 @@ import (
 // Plugin is a plugin driver that dispatches containers to each node,
 // expecting each pod to report to the master.
 type Plugin struct {
-	Definition    plugin.Definition
-	SessionID     string
-	Namespace     string
-	SonobuoyImage string
-	cleanedUp     bool
+	plugin.Base
 }
 
 // Ensure DaemonSetPlugin implements plugin.Interface
 var _ plugin.Interface = &Plugin{}
 
-type templateData struct {
-	PluginName        string
-	ResultType        string
-	SessionID         string
-	Namespace         string
-	SonobuoyImage     string
-	ProducerContainer string
-	MasterAddress     string
-	CACert            string
-	SecretName        string
-}
-
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
 // and sonobuoy master address
 func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage string) *Plugin {
 	return &Plugin{
-		Definition:    dfn,
-		SessionID:     utils.GetSessionID(),
-		Namespace:     namespace,
-		SonobuoyImage: sonobuoyImage,
-		cleanedUp:     false,
+		plugin.Base{
+			Definition:    dfn,
+			SessionID:     utils.GetSessionID(),
+			Namespace:     namespace,
+			SonobuoyImage: sonobuoyImage,
+			CleanedUp:     false,
+		},
 	}
 }
 
@@ -87,34 +72,16 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return ret
 }
 
-// GetResultType returns the ResultType for this plugin (to adhere to plugin.Interface)
-func (p *Plugin) GetResultType() string {
-	return p.Definition.ResultType
-}
-
 //FillTemplate populates the internal Job YAML template with the values for this particular job.
 func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, error) {
 	var b bytes.Buffer
-	container, err := kuberuntime.Encode(manifest.Encoder, &p.Definition.Spec)
+
+	tmplData, err := p.GetTemplateData(hostname, cert)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't reserialize container for daemonset %q", p.Definition.Name)
+		return nil, errors.Wrapf(err, "couldn't get template data for %q", p.Definition.Name)
 	}
 
-	cacert := utils.GetCACertPEM(cert)
-
-	vars := templateData{
-		PluginName:        p.Definition.Name,
-		ResultType:        p.Definition.ResultType,
-		SessionID:         p.SessionID,
-		Namespace:         p.Namespace,
-		SonobuoyImage:     p.SonobuoyImage,
-		ProducerContainer: string(container),
-		MasterAddress:     getMasterAddress(hostname),
-		CACert:            cacert,
-		SecretName:        p.getSecretName(),
-	}
-
-	if err := daemonSetTemplate.Execute(&b, vars); err != nil {
+	if err := daemonSetTemplate.Execute(&b, tmplData); err != nil {
 		return nil, errors.Wrapf(err, "couldn't fill template %q", p.Definition.Name)
 	}
 	return b.Bytes(), nil
@@ -132,7 +99,7 @@ func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls
 		return errors.Wrapf(err, "could not decode the executed template into a daemonset. Plugin name: ", p.GetName())
 	}
 
-	secret, err := utils.MakeTLSSecret(cert, p.Namespace, p.getSecretName())
+	secret, err := p.MakeTLSSecret(cert)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't make secret for daemonset plugin %v", p.GetName())
 	}
@@ -151,7 +118,7 @@ func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls
 
 // Cleanup cleans up the k8s DaemonSet and ConfigMap created by this plugin instance
 func (p *Plugin) Cleanup(kubeclient kubernetes.Interface) {
-	p.cleanedUp = true
+	p.CleanedUp = true
 	gracePeriod := int64(1)
 	deletionPolicy := metav1.DeletePropagationBackground
 
@@ -212,7 +179,7 @@ func (p *Plugin) Monitor(kubeclient kubernetes.Interface, availableNodes []v1.No
 		// enough time to create pods
 		time.Sleep(10 * time.Second)
 		// If we've cleaned up after ourselves, stop monitoring
-		if p.cleanedUp {
+		if p.CleanedUp {
 			break
 		}
 
@@ -274,15 +241,6 @@ func (p *Plugin) Monitor(kubeclient kubernetes.Interface, availableNodes []v1.No
 	}
 }
 
-func (p *Plugin) GetSessionID() string {
-	return p.SessionID
-}
-
-// GetName returns the name of this DaemonSet plugin
-func (p *Plugin) GetName() string {
-	return p.Definition.Name
-}
-
-func getMasterAddress(hostname string) string {
+func (p *Plugin) GetMasterAddress(hostname string) string {
 	return fmt.Sprintf("https://%s/api/v1/results/by-node", hostname)
 }

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -46,7 +46,7 @@ type Plugin struct {
 var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
-// and sonobuoy master address
+// and sonobuoy master address.
 func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage string) *Plugin {
 	return &Plugin{
 		driver.Base{
@@ -59,7 +59,7 @@ func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage string) *Plugin {
 	}
 }
 
-// ExpectedResults returns the list of results expected for this daemonset
+// ExpectedResults returns the list of results expected for this daemonset.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	ret := make([]plugin.ExpectedResult, 0, len(nodes))
 
@@ -77,7 +77,7 @@ func getMasterAddress(hostname string) string {
 	return fmt.Sprintf("https://%s/api/v1/results/by-node", hostname)
 }
 
-//FillTemplate populates the internal Job YAML template with the values for this particular job.
+//FillTemplate populates the internal Job YAML template with the values for this particular daemonset.
 func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, error) {
 	var b bytes.Buffer
 
@@ -121,7 +121,7 @@ func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls
 	return nil
 }
 
-// Cleanup cleans up the k8s DaemonSet and ConfigMap created by this plugin instance
+// Cleanup cleans up the k8s DaemonSet and ConfigMap created by this plugin instance.
 func (p *Plugin) Cleanup(kubeclient kubernetes.Interface) {
 	p.CleanedUp = true
 	gracePeriod := int64(1)
@@ -150,11 +150,7 @@ func (p *Plugin) listOptions() metav1.ListOptions {
 	}
 }
 
-func (p *Plugin) getSecretName() string {
-	return fmt.Sprintf("daemonset-%s-%s", p.GetName(), p.SessionID)
-}
-
-// findDaemonSet gets the daemonset that we created, using a kubernetes label search
+// findDaemonSet gets the daemonset that we created, using a kubernetes label search.
 func (p *Plugin) findDaemonSet(kubeclient kubernetes.Interface) (*appsv1beta2.DaemonSet, error) {
 	// TODO(EKF): Move to v1 in 1.11
 	dsets, err := kubeclient.AppsV1beta2().DaemonSets(p.Namespace).List(p.listOptions())

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -36,7 +36,7 @@ import (
 )
 
 // Plugin is a plugin driver that dispatches a single pod to the given
-// kubernetes cluster
+// kubernetes cluster.
 type Plugin struct {
 	driver.Base
 }
@@ -45,7 +45,7 @@ type Plugin struct {
 var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
-// and sonobuoy master address
+// and sonobuoy master address.
 func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage string) *Plugin {
 	return &Plugin{
 		driver.Base{
@@ -70,6 +70,7 @@ func getMasterAddress(hostname string) string {
 	return fmt.Sprintf("https://%s/api/v1/results/global", hostname)
 }
 
+//FillTemplate populates the internal Job YAML template with the values for this particular job.
 func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, error) {
 	var b bytes.Buffer
 
@@ -87,9 +88,7 @@ func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, e
 
 // Run dispatches worker pods according to the Job's configuration.
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate) error {
-	var (
-		job v1.Pod
-	)
+	var job v1.Pod
 
 	b, err := p.FillTemplate(hostname, cert)
 	if err != nil {

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -58,6 +58,7 @@ type Definition struct {
 	ResultType     string
 	Spec           manifest.Container
 	ContainerImage string
+	PullPolicy     string
 }
 
 // ExpectedResult is an expected result that a plugin will submit.  This is so


### PR DESCRIPTION
```
$ sonobuoy run --mode quick --sonobuoy-image gcr.io/liz-heptio/sonobuoy:imagepull
INFO[0000] created object                                name=heptio-sonobuoy namespace= resource=namespaces
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace=heptio-sonobuoy resource=serviceaccounts
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace= resource=clusterrolebindings
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace= resource=clusterroles
INFO[0000] created object                                name=sonobuoy-config-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy-plugins-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy namespace=heptio-sonobuoy resource=pods
INFO[0000] created object                                name=sonobuoy-master namespace=heptio-sonobuoy resource=services
$ watch sonobuoy status
watch sonobuoy status  8.90s user 1.39s system 5% cpu 2:55.29 total
$ sonobuoy status
$ sonobuoy status
PLUGIN	NODE	STATUS
e2e		complete

Sonobuoy is in unknown state "complete". Please report a bug at github.com/heptio/sonobuoy
```

No new features, but will make adding ImagePullPolicy (and all other changes) much easier in the future