### PR TITLE
Use constants for `sonobuoy status` to avoid completed errors

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -27,6 +27,7 @@ import (
 
 	ops "github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
 
 var (
@@ -84,11 +85,11 @@ func getStatus(cmd *cobra.Command, args []string) {
 
 func humanReadableStatus(str string) string {
 	switch str {
-	case "running":
+	case aggregation.RunningStatus:
 		return "Sonobuoy is still running. Runs can take up to 60 minutes."
-	case "failed":
+	case aggregation.FailedStatus:
 		return "Sonobuoy has failed. You can see what happened with `sonobuoy logs`."
-	case "completed":
+	case aggregation.CompleteStatus:
 		return "Sonobuoy has completed. Use `sonobuoy retrieve` to get results."
 	default:
 		return fmt.Sprintf("Sonobuoy is in unknown state %q. Please report a bug at github.com/heptio/sonobuoy", str)


### PR DESCRIPTION
@timothysc I can't remember if we're trying to do any dep limiting in cmd, but I think `sonobuoy master` is gonna pull in aggregation anyway.