### PR TITLE
Log all sonobuoy pods with follow

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -31,6 +31,7 @@ type LogConfig struct {
 	Follow *bool
 	// Namespace is the namespace the sonobuoy aggregator is running in.
 	Namespace string
+	Out       io.Writer
 }
 
 // GenConfig are the input options for generating a Sonobuoy manifest.
@@ -96,8 +97,8 @@ type Interface interface {
 	RetrieveResults(cfg *RetrieveConfig, restConfig *rest.Config) io.Reader
 	// GetStatus determines the status of the sonobuoy run in order to assist the user.
 	GetStatus(namespace string, client kubernetes.Interface) (*aggregation.Status, error)
-	// GetLogs streams logs from the sonobuoy pod by default to stdout.
-	GetLogs(cfg *LogConfig, client kubernetes.Interface) error
+	// StreamLogs streams logs from the sonobuoy pod by default to stdout.
+	StreamLogs(cfg *LogConfig, client kubernetes.Interface) chan error
 	// Delete removes a sonobuoy run, namespace, and all associated resources.
 	Delete(cfg *DeleteConfig, client kubernetes.Interface) error
 }

--- a/pkg/client/logs.go
+++ b/pkg/client/logs.go
@@ -19,59 +19,119 @@ package client
 import (
 	"fmt"
 	"io"
-	"os"
-	"strings"
+	"sync"
 
-	"github.com/heptio/sonobuoy/pkg/config"
-	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-var (
-	podLogSeparator = strings.Repeat("-", 79)
-)
+// message represents a buffer of logs from a container in a pod in a namespace.
+type message struct {
+	// header acts as the header message for the log line and an id to know where the message came from.
+	header string
+	// buffer is the blob that we extracted from the contianer.
+	buffer []byte
+}
 
-// Logs gathers the logs for the containers in the sonobuoy namespace and prints them
+// logStreamer has all the pieces necessary for streaming logs from a container.
+type logStreamer struct {
+	ns, pod, container string
+	errc               chan error
+	logc               chan *message
+	logOpts            *v1.PodLogOptions
+	client             kubernetes.Interface
+}
 
-func (c *SonobuoyClient) GetLogs(cfg *LogConfig, client kubernetes.Interface) error {
-	// TODO(EKF): Stream to a writer instead of just stdout
-	if *cfg.Follow {
-		return streamLogs(client, cfg.Namespace, config.MasterPodName, &v1.PodLogOptions{Follow: true})
+// stream will open a connection to the pod's logs and push messages onto a channel.
+func (l *logStreamer) stream() {
+	req := l.client.CoreV1().Pods(l.ns).GetLogs(l.pod, l.logOpts)
+	readCloser, err := req.Stream()
+	if err != nil {
+		l.errc <- errors.Wrapf(err, "error streaming logs from container [%v]", l.container)
+		return
 	}
+	defer readCloser.Close()
+
+	header := fmt.Sprintf("## Namespace: %v ## Pod: %v ## Container: %v", l.ns, l.pod, l.container)
+
+	buf := make([]byte, 1024)
+	// Loop until EOF (streaming case won't get an EOF)
+	for {
+		n, err := readCloser.Read(buf)
+		if err != nil && err != io.EOF {
+			l.errc <- errors.Wrapf(err, "error reading logs from container [%v]", l.container)
+			return
+		}
+		l.logc <- &message{
+			header: header,
+			buffer: buf[:n],
+		}
+		if err == io.EOF {
+			return
+		}
+	}
+}
+
+// StreamLogs finds all pods in a given namespace and writes them to the configured io.Writer.
+func (c *SonobuoyClient) StreamLogs(cfg *LogConfig, client kubernetes.Interface) chan error {
+	errc := make(chan error)
+	agg := make(chan *message)
+	// waitGroup to make sure we don't exit before we finish reading all of the logs.
+	var wg sync.WaitGroup
 
 	pods, err := client.CoreV1().Pods(cfg.Namespace).List(metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("could not list pods: %v", err)
+		errc <- err
+		close(errc)
+		close(agg)
+		return errc
 	}
+
+	// TODO(chuckha) if we get an error back that the container is still creating maybe we could retry?
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			logrus.WithFields(logrus.Fields{"pod": pod.Name, "container": container.Name}).Info("Printing container logs")
-			err := streamLogs(client, cfg.Namespace, pod.Name, &v1.PodLogOptions{
-				Container: container.Name,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to stream logs: %v", err)
+			wg.Add(1)
+			ls := &logStreamer{
+				ns:        pod.Namespace,
+				pod:       pod.Name,
+				container: container.Name,
+				errc:      errc,
+				logc:      agg,
+				logOpts: &v1.PodLogOptions{
+					Container: container.Name,
+					Follow:    *cfg.Follow,
+				},
+				client: client,
 			}
-			fmt.Println(podLogSeparator)
+
+			go func(w *sync.WaitGroup, ls *logStreamer) {
+				defer w.Done()
+				ls.stream()
+			}(&wg, ls)
 		}
 	}
-	return nil
-}
 
-// TODO(chuckha) the output is a little confusing because our containers already produce structured logs.
+	// Cleanup when finished.
+	go func(wg *sync.WaitGroup, agg chan *message, errc chan error) {
+		wg.Wait()
+		close(agg)
+		close(errc)
+	}(&wg, agg, errc)
 
-func streamLogs(client kubernetes.Interface, namespace, podName string, logOptions *v1.PodLogOptions) error {
-	req := client.CoreV1().Pods(namespace).GetLogs(podName, logOptions)
-	readCloser, err := req.Stream()
-	if err != nil {
-		return fmt.Errorf("could not stream the request: %v", err)
-	}
-	defer readCloser.Close()
-	// In the case of -f this will never return unless there is an error.
-	if _, err = io.Copy(os.Stdout, readCloser); err != nil {
-		return fmt.Errorf("could not copy request body: %v", err)
-	}
-	return nil
+	// Do something with the messages.
+	go func(cfg *LogConfig, agg chan *message) {
+		// Print the header line again whenever we change which container we read from
+		header := ""
+		for message := range agg {
+			if message.header != header {
+				fmt.Fprintln(cfg.Out, message.header)
+				header = message.header
+			}
+			fmt.Fprintf(cfg.Out, string(message.buffer))
+		}
+	}(cfg, agg)
+
+	return errc
 }


### PR DESCRIPTION
This implements 1/2 of #301.

`sonobuoy logs -f` now produces merged streams of logs
from every container in every pod in a namespace.

I think we are going to need a strategy for testing kubernetes.Interface soon.