### PR TITLE
Clean up help text and cases

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -40,9 +40,9 @@ func AddNamespaceFlag(str *string, flags *pflag.FlagSet) {
 // The variables specified by those flags will overlay the defaults provided by the given mode.
 func AddModeFlag(mode *ops.Mode, flags *pflag.FlagSet) {
 	*mode = ops.Conformance // default
-	flags.Var(
-		mode, "mode",
-		fmt.Sprintf("What mode to run sonobuoy in. [%s]", strings.Join(ops.GetModes(), ", ")),
+	flags.VarP(
+		mode, "mode", "m",
+		fmt.Sprintf("What mode to run sonobuoy in. Valid modes are %s.", strings.Join(ops.GetModes(), ", ")),
 	)
 }
 
@@ -50,21 +50,21 @@ func AddModeFlag(mode *ops.Mode, flags *pflag.FlagSet) {
 func AddSonobuoyImage(image *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		image, "sonobuoy-image", config.DefaultImage,
-		"Container image override for the sonobuoy worker and container",
+		"Container image override for the sonobuoy worker and container.",
 	)
 }
 
 // AddKubeconfigFlag adds a kubeconfig flag to the provided command.
 func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	// The default is the empty string (look in the environment)
-	flags.Var(cfg, "kubeconfig", "Explict kubeconfig file")
+	flags.Var(cfg, "kubeconfig", "Path to explict kubeconfig file.")
 }
 
 // AddSonobuoyConfigFlag adds a SonobuoyConfig flag to the provided command.
 func AddSonobuoyConfigFlag(cfg *SonobuoyConfig, flags *pflag.FlagSet) {
 	flags.Var(
 		cfg, "config",
-		"path to a sonobuoy configuration JSON file. Overrides --mode",
+		"Path to a sonobuoy configuration JSON file. Overrides --mode.",
 	)
 }
 
@@ -117,7 +117,8 @@ func AddRBACModeFlags(mode *RBACMode, flags *pflag.FlagSet, defaultMode RBACMode
 	*mode = defaultMode // default
 	flags.Var(
 		mode, "rbac",
-		`Whether to enable rbac on Sonobuoy. Options are "enable", "disable", and "detect" (query the server to see whether to enable Sonobuoy)`,
+		// Doesn't use the map in app.rbacModeMap to preserve order so we can add an explanation for detect.
+		"Whether to enable rbac on Sonobuoy. Valid modes are Enable, Disable, and Detect (query the server to see whether to enable Sonobuoy).",
 	)
 }
 

--- a/cmd/sonobuoy/app/rbac.go
+++ b/cmd/sonobuoy/app/rbac.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -20,11 +21,11 @@ var (
 
 const (
 	// DisableRBACMode means rbac is always disable
-	DisableRBACMode RBACMode = "disable"
+	DisableRBACMode RBACMode = "Disable"
 	// EnabledRBACMode means rbac is always enabled
-	EnabledRBACMode RBACMode = "enabled"
+	EnabledRBACMode RBACMode = "Enabled"
 	// DetectRBACMode means "query the server to see if RBAC is enabled"
-	DetectRBACMode RBACMode = "detect"
+	DetectRBACMode RBACMode = "Detect"
 )
 
 var rbacModeMap = map[string]RBACMode{
@@ -41,7 +42,9 @@ func (r *RBACMode) Type() string { return "RBACMode" }
 
 // Set the RBACMode to the given string, or error if it's not a known RBAC mode.
 func (r *RBACMode) Set(str string) error {
-	mode, ok := rbacModeMap[str]
+	// Allow lowercase on the command line
+	upcase := strings.Title(str)
+	mode, ok := rbacModeMap[upcase]
 	if !ok {
 		return fmt.Errorf("unknown RBAC mode %s", str)
 	}

--- a/pkg/client/mode.go
+++ b/pkg/client/mode.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/heptio/sonobuoy/pkg/plugin"
 )
@@ -14,50 +15,52 @@ type Mode string
 
 const (
 	// Quick runs a single E2E test and the systemd log tests.
-	Quick Mode = "quick"
+	Quick Mode = "Quick"
 	// Conformance runs all of the E2E tests and the systemd log tests.
-	Conformance Mode = "conformance"
+	Conformance Mode = "Conformance"
 	// Extended run all of the E2E tests, the systemd log tests, and
 	// Heptio's E2E Tests.
-	Extended Mode = "extended"
+	Extended Mode = "Extended"
 )
 
 const defaultSkipList = "Alpha|Disruptive|Feature|Flaky|Kubectl"
 
 var modeMap = map[string]Mode{
-	"conformance": Conformance,
-	"quick":       Quick,
-	"extended":    Extended,
+	string(Conformance): Conformance,
+	string(Quick):       Quick,
+	string(Extended):    Extended,
 }
 
 // ModeConfig represents the sonobuoy configuration for a given mode.
 type ModeConfig struct {
-	// E2EConfig is the focus and skip vars for the conformance tests
+	// E2EConfig is the focus and skip vars for the conformance tests.
 	E2EConfig E2EConfig
 	// Selectors are the plugins selected by this mode.
 	Selectors []plugin.Selection
 }
 
 // String needed for pflag.Value
-func (n *Mode) String() string { return string(*n) }
+func (m *Mode) String() string { return string(*m) }
 
 // Type needed for pflag.Value
-func (n *Mode) Type() string { return "Mode" }
+func (m *Mode) Type() string { return "Mode" }
 
-// Set the name with a given string. Returns error on unknown mode
-func (n *Mode) Set(str string) error {
-	mode, ok := modeMap[str]
+// Set the name with a given string. Returns error on unknown mode.
+func (m *Mode) Set(str string) error {
+	// Allow lowercase "conformance", "quick" etc in command line
+	upcase := strings.Title(str)
+	mode, ok := modeMap[upcase]
 	if !ok {
 		return fmt.Errorf("unknown mode %s", str)
 	}
-	*n = mode
+	*m = mode
 	return nil
 }
 
 // Get returns the ModeConfig associated with a mode name, or nil
 // if there's no associated mode
-func (n *Mode) Get() *ModeConfig {
-	switch *n {
+func (m *Mode) Get() *ModeConfig {
+	switch *m {
 	case Conformance:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{


### PR DESCRIPTION
Decided to go with Title Case for things like RBAC Mode, that aligns more with the way the rest of Kubernetes works.

closes #309 