### PR TITLE
Fixes bug that ignored `--mode`

### DIFF
--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -58,7 +58,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 }
 
 func (g *genFlags) Config() (*client.GenConfig, error) {
-	e2ecfg, err := GetE2EConfig(genflags.mode, g.e2eflags)
+	e2ecfg, err := GetE2EConfig(g.mode, g.e2eflags)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve E2E config")
 	}


### PR DESCRIPTION
here is some output from before and after

BEFORE
```
test salazar:sonobuoy cha$ go run main.go run --mode=quick
generating genconfig &{Conformance Alpha|Disruptive|Feature|Flaky|Kubectl}
mode config Quick
FOCUS!!!!!!! Conformance
^Csignal: interrupt
```
AFTER
```
test salazar:sonobuoy cha$ go run main.go run --mode=quick
generating genconfig &{Pods should be submitted and removed Alpha|Disruptive|Feature|Flaky|Kubectl}
mode config Quick
FOCUS!!!!!!! Pods should be submitted and removed
```