### PR TITLE
Sonobuoy existing preflight check

### DIFF
--- a/cmd/sonobuoy/app/e2e.go
+++ b/cmd/sonobuoy/app/e2e.go
@@ -105,7 +105,7 @@ func e2es(cmd *cobra.Command, args []string) {
 	}
 
 	if !e2eflags.skipPreflight {
-		if errs := sonobuoy.PreflightChecks(); len(errs) > 0 {
+		if errs := sonobuoy.PreflightChecks(&client.PreflightConfig{e2eflags.namespace}); len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {
 				errlog.LogError(err)

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -95,7 +95,7 @@ func submitSonobuoyRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !runflags.skipPreflight {
-		if errs := sbc.PreflightChecks(); len(errs) > 0 {
+		if errs := sbc.PreflightChecks(&ops.PreflightConfig{runflags.namespace}); len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {
 				errlog.LogError(err)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -71,6 +71,11 @@ type RetrieveConfig struct {
 	Namespace string
 }
 
+// PreflightConfig are the options passed to PreflightChecks.
+type PreflightConfig struct {
+	Namespace string
+}
+
 // SonobuoyClient is a high-level interface to Sonobuoy operations.
 type SonobuoyClient struct {
 	RestConfig    *rest.Config
@@ -129,5 +134,5 @@ type Interface interface {
 	// Delete removes a sonobuoy run, namespace, and all associated resources.
 	Delete(cfg *DeleteConfig) error
 	// PreflightChecks runs a number of preflight checks to confirm the environment is good for Sonobuoy
-	PreflightChecks() []error
+	PreflightChecks(cfg *PreflightConfig) []error
 }

--- a/pkg/client/preflight.go
+++ b/pkg/client/preflight.go
@@ -22,17 +22,19 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-var preflightChecks = []func(kubernetes.Interface) error{
+var preflightChecks = []func(kubernetes.Interface, *PreflightConfig) error{
 	preflightDNSCheck,
 	preflightVersionCheck,
+	preflightExistingSonobuoy,
 }
 
 // PreflightChecks runs all preflight checks in order, returning the first error encountered.
-func (c *SonobuoyClient) PreflightChecks() []error {
+func (c *SonobuoyClient) PreflightChecks(cfg *PreflightConfig) []error {
 	client, err := c.Client()
 	if err != nil {
 		return []error{err}
@@ -41,7 +43,7 @@ func (c *SonobuoyClient) PreflightChecks() []error {
 	errors := []error{}
 
 	for _, check := range preflightChecks {
-		if err := check(client); err != nil {
+		if err := check(client, cfg); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -54,7 +56,7 @@ const (
 	kubeDNSLabelValue   = "kube-dns"
 )
 
-func preflightDNSCheck(client kubernetes.Interface) error {
+func preflightDNSCheck(client kubernetes.Interface, cfg *PreflightConfig) error {
 	selector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, kubeDNSLabelKey, kubeDNSLabelValue)
 
 	obj, err := client.CoreV1().Pods(kubeSystemNamespace).List(
@@ -76,7 +78,7 @@ var (
 	maximumKubeVersion = version.Must(version.NewVersion(buildinfo.MaximumKubeVersion))
 )
 
-func preflightVersionCheck(client kubernetes.Interface) error {
+func preflightVersionCheck(client kubernetes.Interface, cfg *PreflightConfig) error {
 	versionInfo, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve server version")
@@ -95,5 +97,20 @@ func preflightVersionCheck(client kubernetes.Interface) error {
 		return fmt.Errorf("Maximum kubernetes version is %s, got %s", maximumKubeVersion.String(), versionInfo.String())
 	}
 
+	return nil
+}
+
+func preflightExistingSonobuoy(client kubernetes.Interface, cfg *PreflightConfig) error {
+	_, err := client.CoreV1().Pods(cfg.Namespace).Get("sonobuoy", metav1.GetOptions{})
+	switch {
+	// Pod doesn't exist: great!
+	case apierrors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return errors.Wrap(err, "error checking for Sonobuoy pod")
+	// No error: pod exists
+	case err == nil:
+		return errors.New("sonobuoy run already exists in this namespace")
+	}
 	return nil
 }


### PR DESCRIPTION
Checks to see if a Sonobuoy pod exists in this namespace already.

```
$ sonobuoy run
Running plugins: e2e, systemd-logs
INFO[0000] created object                                name=heptio-sonobuoy namespace= resource=namespaces
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace=heptio-sonobuoy resource=serviceaccounts
INFO[0000] created object                                name=sonobuoy-serviceaccount namespace= resource=clusterrolebindings
INFO[0000] object already exists                         name=sonobuoy-serviceaccount namespace= resource=clusterroles
INFO[0000] created object                                name=sonobuoy-config-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy-plugins-cm namespace=heptio-sonobuoy resource=configmaps
INFO[0000] created object                                name=sonobuoy namespace=heptio-sonobuoy resource=pods
INFO[0000] created object                                name=sonobuoy-master namespace=heptio-sonobuoy resource=services
$ sonobuoy run
Running plugins: e2e, systemd-logs
ERRO[0000] Preflight checks failed
ERRO[0000] sonobuoy run already exists in this namespace
```

Signed-off-by: liz <liz@heptio.com>