### PR TITLE
Parallel e2e

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -78,8 +78,9 @@ func AddSonobuoyConfigFlag(cfg *SonobuoyConfig, flags *pflag.FlagSet) {
 }
 
 const (
-	e2eFocusFlag = "e2e-focus"
-	e2eSkipFlag  = "e2e-skip"
+	e2eFocusFlag    = "e2e-focus"
+	e2eSkipFlag     = "e2e-skip"
+	e2eParallelFlag = "e2e-parallel"
 )
 
 // AddE2EConfigFlags adds two arguments: --e2e-focus and --e2e-skip. These are not taken as pointers, as they are only used by GetE2EConfig. Instead, they are returned as a Flagset which should be passed to GetE2EConfig. The returned flagset will be added to the passed in flag set.
@@ -95,12 +96,16 @@ func AddE2EConfigFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 		e2eSkipFlag, defaultMode.E2EConfig.Skip,
 		"Specify the E2E_SKIP flag to the conformance tests. Overrides --mode.",
 	)
+	e2eFlags.String(
+		e2eParallelFlag, defaultMode.E2EConfig.Parallel,
+		"Specify the E2E_PARALLEL flag to the conformance tests. Overrides --mode.",
+	)
 	flags.AddFlagSet(e2eFlags)
 	return e2eFlags
 }
 
-// GetE2EConfig gets the E2EConfig from the mode, then overrides them with e2e-focus and e2e-skip if they are provided.
-// We can't rely on the zero value of the flags, as "" is a valid  focus or skip value.
+// GetE2EConfig gets the E2EConfig from the mode, then overrides them with e2e-focus, e2e-skip and e2e-parallel if they
+// are provided. We can't rely on the zero value of the flags, as "" is a valid focus, skip or parallel value.
 func GetE2EConfig(mode ops.Mode, flags *pflag.FlagSet) (*ops.E2EConfig, error) {
 	cfg := mode.Get().E2EConfig
 	if flags.Changed(e2eFocusFlag) {
@@ -117,6 +122,14 @@ func GetE2EConfig(mode ops.Mode, flags *pflag.FlagSet) (*ops.E2EConfig, error) {
 			return nil, errors.Wrap(err, "couldn't retrieve skip flag")
 		}
 		cfg.Skip = skip
+	}
+
+	if flags.Changed(e2eParallelFlag) {
+		parallel, err := flags.GetString(e2eParallelFlag)
+		if err != nil {
+			return nil, errors.Wrap(err, "couldn't retrieve parallel flag")
+		}
+		cfg.Parallel = parallel
 	}
 	return &cfg, nil
 }

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -100,6 +100,7 @@ func AddE2EConfigFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 		e2eParallelFlag, defaultMode.E2EConfig.Parallel,
 		"Specify the E2E_PARALLEL flag to the conformance tests. Overrides --mode.",
 	)
+	e2eFlags.MarkHidden(e2eParallelFlag)
 	flags.AddFlagSet(e2eFlags)
 	return e2eFlags
 }

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -55,6 +55,14 @@ func AddSonobuoyImage(image *string, flags *pflag.FlagSet) {
 	)
 }
 
+// AddKubeConformanceImage initialises an image url flag.
+func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		image, "kube-conformance-image", config.DefaultKubeConformanceImage,
+		"Container image override for the kube conformance image.",
+	)
+}
+
 // AddKubeconfigFlag adds a kubeconfig flag to the provided command.
 func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	// The default is the empty string (look in the environment)

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -83,7 +83,13 @@ const (
 	e2eParallelFlag = "e2e-parallel"
 )
 
-// AddE2EConfigFlags adds two arguments: --e2e-focus and --e2e-skip. These are not taken as pointers, as they are only used by GetE2EConfig. Instead, they are returned as a Flagset which should be passed to GetE2EConfig. The returned flagset will be added to the passed in flag set.
+// AddE2EConfigFlags adds three arguments: --e2e-focus, --e2e-skip and
+// --e2e-parallel. These are not taken as pointers, as they are only used by
+// GetE2EConfig. Instead, they are returned as a Flagset which should be passed
+// to GetE2EConfig. The returned flagset will be added to the passed in flag set.
+//
+// e2e-parallel is added as a hidden flag that should only be used by "power"
+// users. Using e2e-parallel incorrectly has the potential to destroy clusters!
 func AddE2EConfigFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 	e2eFlags := pflag.NewFlagSet("e2e", pflag.ExitOnError)
 	modeName := ops.Conformance

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -30,14 +30,15 @@ import (
 )
 
 type genFlags struct {
-	sonobuoyConfig  SonobuoyConfig
-	mode            client.Mode
-	rbacMode        RBACMode
-	kubecfg         Kubeconfig
-	e2eflags        *pflag.FlagSet
-	namespace       string
-	sonobuoyImage   string
-	imagePullPolicy ImagePullPolicy
+	sonobuoyConfig       SonobuoyConfig
+	mode                 client.Mode
+	rbacMode             RBACMode
+	kubecfg              Kubeconfig
+	e2eflags             *pflag.FlagSet
+	namespace            string
+	sonobuoyImage        string
+	kubeConformanceImage string
+	imagePullPolicy      ImagePullPolicy
 }
 
 var genflags genFlags
@@ -53,6 +54,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 
 	AddNamespaceFlag(&cfg.namespace, genset)
 	AddSonobuoyImage(&cfg.sonobuoyImage, genset)
+	AddKubeConformanceImage(&cfg.kubeConformanceImage, genset)
 
 	return genset
 }
@@ -64,12 +66,13 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 	}
 
 	return &client.GenConfig{
-		E2EConfig:       e2ecfg,
-		Config:          GetConfigWithMode(&g.sonobuoyConfig, g.mode),
-		Image:           g.sonobuoyImage,
-		Namespace:       g.namespace,
-		EnableRBAC:      getRBACOrExit(&g.rbacMode, &g.kubecfg),
-		ImagePullPolicy: g.imagePullPolicy.String(),
+		E2EConfig:            e2ecfg,
+		Config:               GetConfigWithMode(&g.sonobuoyConfig, g.mode),
+		Image:                g.sonobuoyImage,
+		Namespace:            g.namespace,
+		EnableRBAC:           getRBACOrExit(&g.rbacMode, &g.kubecfg),
+		ImagePullPolicy:      g.imagePullPolicy.String(),
+		KubeConformanceImage: g.kubeConformanceImage,
 	}, nil
 }
 

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -31,6 +31,7 @@ import (
 type templateValues struct {
 	E2EFocus             string
 	E2ESkip              string
+	E2EParallel          string
 	SonobuoyConfig       string
 	SonobuoyImage        string
 	Version              string
@@ -70,6 +71,7 @@ func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 	tmplVals := &templateValues{
 		E2EFocus:             strings.Replace(cfg.E2EConfig.Focus, "'", "''", -1),
 		E2ESkip:              strings.Replace(cfg.E2EConfig.Skip, "'", "''", -1),
+		E2EParallel:          strings.Replace(cfg.E2EConfig.Parallel, "'", "''", -1),
 		SonobuoyConfig:       string(marshalledConfig),
 		SonobuoyImage:        cfg.Image,
 		Version:              buildinfo.Version,

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -29,14 +29,15 @@ import (
 
 // templateValues are used for direct template substitution for manifest generation.
 type templateValues struct {
-	E2EFocus        string
-	E2ESkip         string
-	SonobuoyConfig  string
-	SonobuoyImage   string
-	Version         string
-	Namespace       string
-	EnableRBAC      bool
-	ImagePullPolicy string
+	E2EFocus             string
+	E2ESkip              string
+	SonobuoyConfig       string
+	SonobuoyImage        string
+	Version              string
+	Namespace            string
+	EnableRBAC           bool
+	ImagePullPolicy      string
+	KubeConformanceImage string
 }
 
 // GenerateManifest fills in a template with a Sonobuoy config
@@ -67,14 +68,15 @@ func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 	// See http://www.yaml.org/spec/1.2/spec.html#id2788097 for more details
 	// on YAML escaping.
 	tmplVals := &templateValues{
-		E2EFocus:        strings.Replace(cfg.E2EConfig.Focus, "'", "''", -1),
-		E2ESkip:         strings.Replace(cfg.E2EConfig.Skip, "'", "''", -1),
-		SonobuoyConfig:  string(marshalledConfig),
-		SonobuoyImage:   cfg.Image,
-		Version:         buildinfo.Version,
-		Namespace:       cfg.Namespace,
-		EnableRBAC:      cfg.EnableRBAC,
-		ImagePullPolicy: cfg.ImagePullPolicy,
+		E2EFocus:             strings.Replace(cfg.E2EConfig.Focus, "'", "''", -1),
+		E2ESkip:              strings.Replace(cfg.E2EConfig.Skip, "'", "''", -1),
+		SonobuoyConfig:       string(marshalledConfig),
+		SonobuoyImage:        cfg.Image,
+		Version:              buildinfo.Version,
+		Namespace:            cfg.Namespace,
+		EnableRBAC:           cfg.EnableRBAC,
+		ImagePullPolicy:      cfg.ImagePullPolicy,
+		KubeConformanceImage: cfg.KubeConformanceImage,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -39,18 +39,20 @@ type LogConfig struct {
 
 // GenConfig are the input options for generating a Sonobuoy manifest.
 type GenConfig struct {
-	E2EConfig       *E2EConfig
-	Config          *config.Config
-	Image           string
-	Namespace       string
-	EnableRBAC      bool
-	ImagePullPolicy string
+	E2EConfig            *E2EConfig
+	Config               *config.Config
+	Image                string
+	Namespace            string
+	EnableRBAC           bool
+	ImagePullPolicy      string
+	KubeConformanceImage string
 }
 
 // E2EConfig is the configuration of the E2E tests.
 type E2EConfig struct {
-	Focus string
-	Skip  string
+	Focus    string
+	Skip     string
+	Parallel string
 }
 
 // RunConfig are the input options for running Sonobuoy.

--- a/pkg/client/mode.go
+++ b/pkg/client/mode.go
@@ -80,8 +80,9 @@ func (m *Mode) Get() *ModeConfig {
 	case Conformance:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
-				Focus: `\[Conformance\]`,
-				Skip:  defaultSkipList,
+				Focus:    `\[Conformance\]`,
+				Skip:     defaultSkipList,
+				Parallel: "1",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},
@@ -91,8 +92,9 @@ func (m *Mode) Get() *ModeConfig {
 	case Quick:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
-				Focus: "Pods should be submitted and removed",
-				Skip:  defaultSkipList,
+				Focus:    "Pods should be submitted and removed",
+				Skip:     defaultSkipList,
+				Parallel: "1",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},
@@ -101,8 +103,9 @@ func (m *Mode) Get() *ModeConfig {
 	case Extended:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
-				Focus: `\[Conformance\]`,
-				Skip:  defaultSkipList,
+				Focus:    `\[Conformance\]`,
+				Skip:     defaultSkipList,
+				Parallel: "1",
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,8 @@ import (
 const (
 	// DefaultNamespace is the namespace where the master and plugin workers will run (but not necessarily the pods created by the plugin workers).
 	DefaultNamespace = "heptio-sonobuoy"
+	// DefaultKubeConformanceImage is the URL of the docker image to run for the kube conformance tests
+	DefaultKubeConformanceImage = "gcr.io/heptio-images/kube-conformance:latest"
 	// MasterPodName is the name of the main pod that runs plugins and collects results.
 	MasterPodName = "sonobuoy"
 	// MasterContainerName is the name of the main container in the master pod.

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -31,7 +31,7 @@ import (
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-// Base is the  truct that stores state for plugin drivers and contains helper methods.
+// Base is the struct that stores state for plugin drivers and contains helper methods.
 type Base struct {
 	Definition      plugin.Definition
 	SessionID       string

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -88,7 +88,7 @@ data:
       - name: E2E_SKIP
         value: '{{.E2ESkip}}'
       command: ["/run_e2e.sh"]
-      image: gcr.io/heptio-images/kube-conformance:latest
+      image: {{.KubeConformanceImage}}
       imagePullPolicy: {{.ImagePullPolicy}}
       name: e2e
       volumeMounts:

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -87,6 +87,8 @@ data:
         value: '{{.E2EFocus}}'
       - name: E2E_SKIP
         value: '{{.E2ESkip}}'
+      - name: E2E_PARALLEL
+        value: '{{.E2EParallel}}'
       command: ["/run_e2e.sh"]
       image: {{.KubeConformanceImage}}
       imagePullPolicy: {{.ImagePullPolicy}}


### PR DESCRIPTION
**What this PR does / why we need it**:

To speed up test runs by enabling option of parallelism via ginkgo (requires heptio/kube-conformance#17 to be merged and released before this to be functional).

This also enables specifying the kube-conformance image which I needed during development cycles, but could be useful for people running other e2e images.

Plus this switches to use single-quotes YAML strings in templates to fix using e.g. `\[Serial\]` in skip/focus (YAML doesn't like non-escaped backslashes in double quotes strings so easier to switch to single-quoted to not require escaping at all.

**Which issue(s) this PR fixes**
Um, I haven't raised one...

**Special notes for your reviewer**:
We'd love to get this in ASAP so we can start using it for all our CI needs. We currently have hand-rolled e2e test 

**Release note**:
```
Parallel e2e tests can be enabled by specifying `--e2e-parallel=y` flag
```
