### PR TITLE
Fix up default focus/skip regexps

### DIFF
--- a/pkg/client/mode.go
+++ b/pkg/client/mode.go
@@ -39,7 +39,7 @@ const (
 	Extended Mode = "Extended"
 )
 
-const defaultSkipList = "Alpha|Disruptive|Feature|Flaky|Kubectl"
+const defaultSkipList = `Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]`
 
 var modeMap = map[string]Mode{
 	string(Conformance): Conformance,
@@ -80,7 +80,7 @@ func (m *Mode) Get() *ModeConfig {
 	case Conformance:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
-				Focus: "Conformance",
+				Focus: `\[Conformance\]`,
 				Skip:  defaultSkipList,
 			},
 			Selectors: []plugin.Selection{
@@ -101,7 +101,7 @@ func (m *Mode) Get() *ModeConfig {
 	case Extended:
 		return &ModeConfig{
 			E2EConfig: E2EConfig{
-				Focus: "Conformance",
+				Focus: `\[Conformance\]`,
 				Skip:  defaultSkipList,
 			},
 			Selectors: []plugin.Selection{

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -84,9 +84,9 @@ data:
     spec:
       env:
       - name: E2E_FOCUS
-        value: "{{.E2EFocus}}"
+        value: '{{.E2EFocus}}'
       - name: E2E_SKIP
-        value: "{{.E2ESkip}}"
+        value: '{{.E2ESkip}}'
       command: ["/run_e2e.sh"]
       image: gcr.io/heptio-images/kube-conformance:latest
       imagePullPolicy: {{.ImagePullPolicy}}


### PR DESCRIPTION
Signed-off-by: Jimmi Dyson <jimmidyson@gmail.com>


**What this PR does / why we need it**:

Current regexps for focus and skip were too loose and could have matched specs that they weren't supposed to match against. For example, old focus default was `Conformance` which would have matched any specs with `Conformance`, whereas this should match against `[Conformance]` as per conformance suite description:

> The standard set of conformance tests is currently those defined by the [Conformance] tag in the kubernetes e2e suite.

This also updates the default skip regexp, without changing the intended set of specs to be skipped.


**Which issue(s) this PR fixes**
- Sorry not created one.

**Special notes for your reviewer**:
Hope that this is self-explanatory. Note also the switch to single quotes in YAML file to remove the need to escape special characters (e.g. backslash, colon, etc) in regexp strings.

**Release note**:
Not sure this needs one? Behaviour should be unchanged, more helping to prevent issues or weird behaviour in future.