### PR TITLE
Version bump for rc.1

### DIFF
--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -20,7 +20,7 @@ limitations under the License.
 package buildinfo
 
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
-var Version = "v0.11.0-alpha.3"
+var Version = "v0.11.0-rc.1"
 
 // MinimumKubeVersion is the lowest API version of Kubernetes this release of Sonobuoy supports.
 var MinimumKubeVersion = "1.8.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the default versions which are used by `go get` operations.

**Special notes for your reviewer**:
none

**Release note**:
```
NONE
```
