### PR TITLE
Goreleaser no longer strips v in version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     - linux
   goarch:
     - amd64
-  ldflags: -s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version={{.Version}}
+  ldflags: -s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v{{.Version}}
 archive:
   format: tar.gz 
   files:


### PR DESCRIPTION
Fixes #383

Signed-off-by: liz <liz@heptio.com>


**What this PR does / why we need it**:

Fixes broken release tagging

**Which issue(s) this PR fixes**
- Fixes #383 

**Special notes for your reviewer**:

**Release note**:
```
```
