### PR TITLE
Don't create release unless the sonobuoy tag matches the travis tag

### DIFF
--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -17,6 +17,14 @@ function gcr_push() {
 }
 
 if [ ! -z "$TRAVIS_TAG" ]; then
+
+    if [ "$(./sonobuoy version)" != "$TRAVIS_TAG"]; then
+        echo "sonobuoy version does not match tagged version!" >&2
+        echo "sonobuoy version is $(./sonobuoy version)" >&2
+        echo "tag is $TRAVIS_TAG" >&2
+        exit 1
+    fi
+
     goreleaser
     gcr_push
 fi


### PR DESCRIPTION
Signed-off-by: liz <liz@heptio.com>


**What this PR does / why we need it**:
This ensures that we never tag a release that doesn't match the release version in `buildinfo`

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
```
