### PR TITLE
Get running plugins list out of config instead of mode

### DIFF
--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -85,11 +85,11 @@ func submitSonobuoyRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	m := runflags.mode.Get()
-	plugins := []string{}
-	for _, plugin := range m.Selectors {
-		plugins = append(plugins, plugin.Name)
+	plugins := make([]string, len(cfg.Config.PluginSelections))
+	for i, plugin := range cfg.Config.PluginSelections {
+		plugins[i] = plugin.Name
 	}
+
 	if len(plugins) > 0 {
 		fmt.Printf("Running plugins: %v\n", strings.Join(plugins, ", "))
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

Right now `sonobuoy run` outputs a message like:

`$ sonobuoy run 
Running plugins: e2e, systemd-logs`

But if you're using a config, this message doesn't take that into account: 
```
 sonobuoy run --config sonobuoy.json
Running plugins: e2e, systemd-logs
...
$ cat sonobuoy.json
{
        "Plugins": [ { "name": "systemd-logs" } ]
}
```

This fixes that issue. 
```
$ sonobuoy run --config sonobuoy.json
Running plugins: systemd-logs
```

**Which issue(s) this PR fixes**
Issue reported by @ivan4th in slack

**Special notes for your reviewer**:

**Release note**:
```
fix bug in reported plugins for `sonobuoy run`
```
