### PR TITLE
Use config defaults with a custom config

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -21,9 +21,12 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/imdario/mergo"
+
 	"github.com/pkg/errors"
 
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
+	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/templates"
 )
 
@@ -43,18 +46,8 @@ type templateValues struct {
 
 // GenerateManifest fills in a template with a Sonobuoy config
 func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
-	if cfg.Image != "" {
-		cfg.Config.WorkerImage = cfg.Image
-	}
-
-	if cfg.ImagePullPolicy != "" {
-		cfg.Config.ImagePullPolicy = cfg.ImagePullPolicy
-	}
-
-	if cfg.Namespace != "" {
-		cfg.Config.Namespace = cfg.Namespace
-	}
-
+	// Set defaults for the config.Config and overwrite fields with the passed in config.
+	mergo.MergeWithOverwrite(cfg.Config, config.New())
 	marshalledConfig, err := json.Marshal(cfg.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't marshall selector")


### PR DESCRIPTION
Start with sensible defaults instead of zero values. If a config
is passed in it will merge into the default config instead of
a zero-value config.

Fixes #390

Signed-off-by: Chuck Ha <chuck@heptio.com>


**What this PR does / why we need it**:
This uses the default config (not the zero value config) as the base config. If no config is supplied, we end up with default values, if a config is supplied we end up with the default values overwritten by any supplied config fields.

**Which issue(s) this PR fixes**
- Fixes #390

**Special notes for your reviewer**:

We already have mergo in our dependency list!

**Release note**:
```
release-note
```
