### PR TITLE
Use provide defaults to a partially customized config

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -21,9 +21,12 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/imdario/mergo"
+
 	"github.com/pkg/errors"
 
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
+	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/templates"
 )
 
@@ -43,18 +46,8 @@ type templateValues struct {
 
 // GenerateManifest fills in a template with a Sonobuoy config
 func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
-	if cfg.Image != "" {
-		cfg.Config.WorkerImage = cfg.Image
-	}
-
-	if cfg.ImagePullPolicy != "" {
-		cfg.Config.ImagePullPolicy = cfg.ImagePullPolicy
-	}
-
-	if cfg.Namespace != "" {
-		cfg.Config.Namespace = cfg.Namespace
-	}
-
+	// Provide defaults but don't overwrite any customized configuration.
+	mergo.Merge(cfg.Config, config.New())
 	marshalledConfig, err := json.Marshal(cfg.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't marshall selector")

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -1,0 +1,135 @@
+package client_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/heptio/sonobuoy/pkg/client"
+	"github.com/heptio/sonobuoy/pkg/config"
+	"github.com/heptio/sonobuoy/pkg/plugin"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestGenerateManifest(t *testing.T) {
+	tcs := []struct {
+		name     string
+		inputcm  *client.GenConfig
+		expected *config.Config
+	}{
+		{
+			name: "easy",
+			inputcm: &client.GenConfig{
+				E2EConfig: &client.E2EConfig{},
+				Config:    &config.Config{},
+			},
+			expected: &config.Config{
+				Aggregation: plugin.AggregationConfig{
+					BindAddress: "0.0.0.0",
+					BindPort:    8080,
+				},
+			},
+		},
+		{
+			name: "override bind address",
+			inputcm: &client.GenConfig{
+				E2EConfig: &client.E2EConfig{},
+				Config: &config.Config{
+					Aggregation: plugin.AggregationConfig{
+						BindAddress: "10.0.0.1",
+					},
+				},
+			},
+			expected: &config.Config{
+				Aggregation: plugin.AggregationConfig{
+					BindAddress: "10.0.0.1",
+					BindPort:    8080,
+				},
+			},
+		},
+		{
+			name: "https://github.com/heptio/sonobuoy/issues/390",
+			inputcm: &client.GenConfig{
+				E2EConfig: &client.E2EConfig{},
+				Config: &config.Config{
+					PluginSelections: []plugin.Selection{
+						plugin.Selection{
+							Name: "systemd-logs",
+						},
+					},
+				},
+			},
+			expected: &config.Config{
+				PluginSelections: []plugin.Selection{
+					plugin.Selection{
+						Name: "systemd-logs",
+					},
+				},
+				Aggregation: plugin.AggregationConfig{
+					BindAddress: "0.0.0.0",
+					BindPort:    8080,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			sbc, err := client.NewSonobuoyClient(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := sbc.GenerateManifest(tc.inputcm)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// TODO(chuckha) this is not my favorite thing.
+			items := bytes.Split(manifest, []byte("---"))
+
+			decoder := scheme.Codecs.UniversalDeserializer()
+			for _, item := range items {
+				o, gvk, err := decoder.Decode(item, nil, nil)
+				if err != nil || gvk.Kind != "ConfigMap" {
+					continue
+				}
+
+				cm, ok := o.(*v1.ConfigMap)
+				if !ok {
+					t.Fatal("was not a config map...")
+				}
+				// Ignore everything but the config map we're looking for
+				if cm.ObjectMeta.Name != "sonobuoy-config-cm" {
+					continue
+				}
+
+				configuration := &config.Config{}
+				fmt.Println(cm.Data["config.json"])
+				err = json.Unmarshal([]byte(cm.Data["config.json"]), configuration)
+				if err != nil {
+					t.Errorf("got error %v", err)
+				}
+				if configuration.UUID == "" {
+					t.Error("Expected UUID to not be empty")
+				}
+				if configuration.Aggregation.BindAddress != tc.expected.Aggregation.BindAddress {
+					t.Errorf("Expected %v but got %v", tc.expected.Aggregation.BindAddress, configuration.Aggregation.BindAddress)
+				}
+				if configuration.Aggregation.BindPort != tc.expected.Aggregation.BindPort {
+					t.Errorf("Expected %v but got %v", tc.expected.Aggregation.BindPort, configuration.Aggregation.BindPort)
+				}
+				if len(configuration.PluginSelections) != len(tc.expected.PluginSelections) {
+					t.Fatalf("Expected %v plugins but found %v", len(configuration.PluginSelections), len(tc.expected.PluginSelections))
+				}
+				for i, ps := range configuration.PluginSelections {
+					if tc.expected.PluginSelections[i] != ps {
+						t.Fatalf("Expected plugin %v but found plugin %v", tc.expected.PluginSelections[i], ps)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Start with sensible defaults instead of zero values. If a config
is passed in it will merge into the default config instead of
a zero-value config.

Also tests said bugfix.

Fixes #390

Signed-off-by: Chuck Ha <chuck@heptio.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #390

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
