### PR TITLE
WIP: Private registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
 BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
-BUILDCMD = go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION)"
+BUILDCMD = CGO_ENABLED=0 go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION)"
 BUILD = $(BUILDCMD) $(GOTARGET)
 
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -69,6 +69,14 @@ func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	flags.Var(cfg, "kubeconfig", "Path to explict kubeconfig file.")
 }
 
+// AddPrivateRegistryConfigFlag adds a PrivateRegistry flag to the provided command.
+func AddPrivateRegistryConfigFlag(privateRegistry *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		privateRegistry, "private-registry", "",
+		"Use a private registry for all e2e images and supported plugins",
+	)
+}
+
 // AddSonobuoyConfigFlag adds a SonobuoyConfig flag to the provided command.
 func AddSonobuoyConfigFlag(cfg *SonobuoyConfig, flags *pflag.FlagSet) {
 	flags.Var(

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -39,6 +39,7 @@ type genFlags struct {
 	sonobuoyImage        string
 	kubeConformanceImage string
 	imagePullPolicy      ImagePullPolicy
+	privateRegistry      string
 }
 
 var genflags genFlags
@@ -54,6 +55,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 
 	AddNamespaceFlag(&cfg.namespace, genset)
 	AddSonobuoyImage(&cfg.sonobuoyImage, genset)
+	AddPrivateRegistryConfigFlag(&cfg.privateRegistry, genset)
 	AddKubeConformanceImage(&cfg.kubeConformanceImage, genset)
 
 	return genset
@@ -73,6 +75,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		EnableRBAC:           getRBACOrExit(&g.rbacMode, &g.kubecfg),
 		ImagePullPolicy:      g.imagePullPolicy.String(),
 		KubeConformanceImage: g.kubeConformanceImage,
+		PrivateRegistry:      g.privateRegistry,
 	}, nil
 }
 

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -39,6 +39,7 @@ type templateValues struct {
 	EnableRBAC           bool
 	ImagePullPolicy      string
 	KubeConformanceImage string
+	PrivateRegistry      string
 }
 
 // GenerateManifest fills in a template with a Sonobuoy config
@@ -67,6 +68,7 @@ func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 		EnableRBAC:           cfg.EnableRBAC,
 		ImagePullPolicy:      cfg.ImagePullPolicy,
 		KubeConformanceImage: cfg.KubeConformanceImage,
+		PrivateRegistry:      cfg.PrivateRegistry,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -46,6 +46,7 @@ type GenConfig struct {
 	EnableRBAC           bool
 	ImagePullPolicy      string
 	KubeConformanceImage string
+	PrivateRegistry      string
 }
 
 // E2EConfig is the configuration of the E2E tests.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"path"
 	"time"
 
@@ -258,10 +259,13 @@ func New() *Config {
 		"~/sonobuoy/plugins.d",
 	}
 
-	// TODO (timothysc) reference the other consts
-	cfg.WorkerImage = "gcr.io/heptio-images/sonobuoy:latest"
+	var custSbImage = os.Getenv("SONOBUOY_IMAGE")
+	if len(custSbImage) == 0 {
+		// TODO (timothysc) reference the other consts
+		custSbImage = "gcr.io/heptio-images/sonobuoy:latest"
+	}
+	cfg.WorkerImage = custSbImage
 	cfg.ImagePullPolicy = "Always"
-
 	return &cfg
 }
 

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -154,6 +154,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_IMAGE
+      value: {{.SonobuoyImage}}
     image: {{.SonobuoyImage}}
     imagePullPolicy: {{.ImagePullPolicy}}
     name: kube-sonobuoy

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -89,6 +89,8 @@ data:
         value: '{{.E2ESkip}}'
       - name: E2E_PARALLEL
         value: '{{.E2EParallel}}'
+      - name: E2E_REGISTRY_OVERRIDE
+        value: '{{.PrivateRegistry}}'
       command: ["/run_e2e.sh"]
       image: {{.KubeConformanceImage}}
       imagePullPolicy: {{.ImagePullPolicy}}
@@ -113,7 +115,7 @@ data:
         value: /tmp/results
       - name: CHROOT_DIR
         value: /node
-      image: gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest
+      image: {{if .PrivateRegistry}}{{.PrivateRegistry}}{{else}}{{"gcr.io/heptio-images"}}{{end}}/sonobuoy-plugin-systemd-logs:latest
       imagePullPolicy: {{.ImagePullPolicy}}
       name: sonobuoy-systemd-logs-config
       securityContext:


### PR DESCRIPTION
**What this PR does / why we need it**:

It informs what's required for using a private registry or running tests in an air-gapped environment.

**Which issue(s) this PR fixes**
- Fixes #160 

**Special notes for your reviewer**:
An early draft - got me out of jail - happy to tidy up if you want to use it.

**Release note**:
```
Adds the --private-registry option to gen and run sub commands and passes through to e2e tests with E2E_REGISTRY_OVERRIDE env option. See dirty hack for upstream - https://github.com/appvia/kube-conformance/pull/1/files
```
