### PR TITLE
Fix CoC and contributing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
 * There is a [mailing list][list] and [Slack channel][slack] if you want to
   interact with other members of the community
 
-[coc]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
-[contrib]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
+[contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
 [list]: https://groups.google.com/forum/#!forum/heptio-sonobuoy
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
 


### PR DESCRIPTION
I was confused when I went to submit another pull request to find the link to the contributing document actually links to the code of conduct. Looks like they just got switched around. This PR makes the CoC link point to the code of conduct, and the contrib link point to the contributing document.

Signed-off-by: Dan Miller <dmiller@windmill.engineering>

