### PR TITLE
Fix format string type error

### DIFF
--- a/cmd/sonobuoy/app/rbac.go
+++ b/cmd/sonobuoy/app/rbac.go
@@ -105,7 +105,7 @@ func checkRBACEnabled(client rest.Interface) (bool, error) {
 
 	groups, ok := result.(*metav1.APIGroupList)
 	if !ok {
-		return false, fmt.Errorf("Unknown type for API group %t", groups)
+		return false, fmt.Errorf("Unknown type for API group %T", groups)
 	}
 
 	for _, group := range groups.Groups {


### PR DESCRIPTION
`groups` is not a boolean (`%t`), but a pointer. I think this was meant
to print the type (`%T`).

Without this change you get the following error when running `go vet` in Go 1.10:

```
cmd/sonobuoy/app/rbac.go:108: Errorf format %t has arg groups of wrong type *github.com/heptio/sonobuoy/vendor/k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList
```

Signed-off-by: Dan Miller <dmiller@windmill.engineering>