### PR TITLE
Switch to upstream Go build images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/heptio-images/golang:1.9-alpine3.6
+FROM golang:1.9-alpine3.6
 MAINTAINER Timothy St. Clair "tstclair@heptio.com"
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates bash
 ADD sonobuoy /sonobuoy
 ADD scripts/run_master.sh /run_master.sh
 ADD scripts/run_single_node_worker.sh /run_single_node_worker.sh

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
+BUILD_IMAGE ?= golang:1.9-alpine3.6
 BUILDCMD = go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION)"
 BUILD = $(BUILDCMD) $(GOTARGET)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Docker base images used for building and running Sonobuoy. It switches away from internal `gcr.io/heptio-images/golang` images to the upstream `golang` image.

These internal `gcr.io/heptio-images/golang` images are deprecated. It looks like `bash` was the only thing that the Sonobuoy runtime image needed that wasn't in the upstream `golang:1.9-alpine3.6` image.
