### PR TITLE
Add missing space in bash releaser

### DIFF
--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -18,7 +18,7 @@ function gcr_push() {
 
 if [ ! -z "$TRAVIS_TAG" ]; then
 
-    if [ "$(./sonobuoy version)" != "$TRAVIS_TAG"]; then
+    if [ "$(./sonobuoy version)" != "$TRAVIS_TAG" ]; then
         echo "sonobuoy version does not match tagged version!" >&2
         echo "sonobuoy version is $(./sonobuoy version)" >&2
         echo "tag is $TRAVIS_TAG" >&2


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuck@heptio.com>

I saw an error in the releaser output. My linter says there needs to be a space here. Bash.