### PR TITLE
Disable cgo for go relesaer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
 - binary: sonobuoy
+  env:
+    - CGO_ENABLED=0
   goos:
     - windows
     - darwin
@@ -8,6 +10,6 @@ builds:
     - amd64
   ldflags: -s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v{{.Version}}
 archive:
-  format: tar.gz 
+  format: tar.gz
   files:
   - LICENSE


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuck@heptio.com>

CGO is enabled for the linux binary because the travis env is linux/amd64 so that build is not technically cross compiled and doesn't disable cgo.

See https://github.com/goreleaser/goreleaser/issues/225
and https://github.com/goreleaser/goreleaser/blob/master/.goreleaser.yml
