### PR TITLE
Bump Go build images to 1.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.9-alpine3.6
+FROM golang:1.10-alpine
 MAINTAINER Timothy St. Clair "tstclair@heptio.com"
 
 RUN apk add --no-cache ca-certificates bash

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.9-alpine3.6
+BUILD_IMAGE ?= golang:1.10-alpine
 BUILDCMD = CGO_ENABLED=0 go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION)"
 BUILD = $(BUILDCMD) $(GOTARGET)
 


### PR DESCRIPTION
Signed-off-by: Bruno Miguel Custodio <brunomcustodio@gmail.com>

**What this PR does / why we need it**:
Bump Go build images to 1.10.

**Which issue(s) this PR fixes**
Fixes #426 

**Special notes for your reviewer**:
None

**Release note**:
None