### PR TITLE
Skip requirement of kubeconfig for e2e & gen

### DIFF
--- a/cmd/sonobuoy/app/e2e.go
+++ b/cmd/sonobuoy/app/e2e.go
@@ -75,12 +75,10 @@ func e2es(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	defer gzr.Close()
-	restConfig, err := e2eflags.kubecfg.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-		os.Exit(1)
-	}
-	sonobuoy, err := client.NewSonobuoyClient(restConfig)
+
+	// Passing in `nil` and no `kubeconfig` because it is not required by the method
+	// for generating any manifests
+	sonobuoy, err := client.NewSonobuoyClient(nil)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)
@@ -105,7 +103,10 @@ func e2es(cmd *cobra.Command, args []string) {
 	}
 
 	if !e2eflags.skipPreflight {
-		if errs := sonobuoy.PreflightChecks(&client.PreflightConfig{e2eflags.namespace}); len(errs) > 0 {
+		errs := sonobuoy.PreflightChecks(&client.PreflightConfig{
+			Namespace: e2eflags.namespace,
+		})
+		if len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {
 				errlog.LogError(err)

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -95,12 +95,9 @@ func genManifest(cmd *cobra.Command, args []string) {
 		errlog.LogError(err)
 		os.Exit(1)
 	}
-	kubeCfg, err := genflags.kubecfg.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
-		os.Exit(1)
-	}
-	sbc, err := client.NewSonobuoyClient(kubeCfg)
+	// Passing in `nil` and no `kubeconfig` because it is not required by the method
+	// for generating any manifests
+	sbc, err := client.NewSonobuoyClient(nil)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)

--- a/pkg/client/e2e.go
+++ b/pkg/client/e2e.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetTests extracts the junit results from a sonobuoy archive and returns the requested tests.
-func (c *SonobuoyClient) GetTests(reader io.Reader, show string) ([]reporters.JUnitTestCase, error) {
+func (*SonobuoyClient) GetTests(reader io.Reader, show string) ([]reporters.JUnitTestCase, error) {
 	read := results.NewReaderWithVersion(reader, "irrelevant")
 	junitResults := reporters.JUnitTestSuite{}
 	err := read.WalkFiles(func(path string, info os.FileInfo, err error) error {

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -42,7 +42,7 @@ type templateValues struct {
 }
 
 // GenerateManifest fills in a template with a Sonobuoy config
-func (c *SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
+func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 	marshalledConfig, err := json.Marshal(cfg.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't marshall selector")


### PR DESCRIPTION
**What this PR does / why we need it**

Earlier `kubeconfig` was needed to use the sub-commands `e2e` and `gen`
which is unnecessary since using these sub-commands does not require
communication to Kubernetes server.

This commit removes that necessity.

**Which issue(s) this PR fixes**
- Fixes #370 

Signed-off-by: Suraj Deshmukh <surajd.service@gmail.com>