### PR TITLE
fixes spelling in status command

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -40,7 +40,7 @@ var statusFlags struct {
 func init() {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Gets a summarizes status of a sonobuoy run",
+		Short: "Gets a summarized status of a sonobuoy run",
 		Run:   getStatus,
 		Args:  cobra.ExactArgs(0),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes spelling in cli status command
**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
