### PR TITLE
1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.9-alpine3.6
+FROM golang:1.10-alpine
 MAINTAINER Timothy St. Clair "tstclair@heptio.com"
 
 RUN apk add --no-cache ca-certificates bash

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.9-alpine3.6
+BUILD_IMAGE ?= golang:1.10-alpine
 BUILDCMD = CGO_ENABLED=0 go build -o $(TARGET) $(VERBOSE_FLAG) -ldflags "-X github.com/heptio/sonobuoy/pkg/buildinfo.Version=$(GIT_VERSION)"
 BUILD = $(BUILDCMD) $(GOTARGET)
 

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -95,7 +95,7 @@ func submitSonobuoyRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !runflags.skipPreflight {
-		if errs := sbc.PreflightChecks(&ops.PreflightConfig{runflags.namespace}); len(errs) > 0 {
+		if errs := sbc.PreflightChecks(&ops.PreflightConfig{Namespace: runflags.namespace}); len(errs) > 0 {
 			errlog.LogError(errors.New("Preflight checks failed"))
 			for _, err := range errs {
 				errlog.LogError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Go build images to 1.10.

**Which issue(s) this PR fixes**
- Fixes #426
- Replaces w/ attribution #433 

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
