### PR TITLE
Return a non-zero status code for failed plugins

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -80,9 +80,20 @@ func getStatus(cmd *cobra.Command, args []string) {
 	} else {
 		err = printSummary(os.Stdout, status)
 	}
+
 	if err != nil {
 		errlog.LogError(err)
 		os.Exit(1)
+	}
+	os.Exit(exitCode(status))
+}
+
+func exitCode(status *aggregation.Status) int {
+	switch status.Status {
+	case aggregation.FailedStatus:
+		return 1
+	default:
+		return 0
 	}
 }
 


### PR DESCRIPTION
Fixes #404

Signed-off-by: Chuck Ha <chuck@heptio.com>

I can't really write a test for this, so it's kind of a best effort deal.

**What this PR does / why we need it**:
This returns a non-zero exit code for `sonobuoy status` when the status is that a plugin has failed.

**Which issue(s) this PR fixes**
- Fixes #404 

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
