### PR TITLE
Log error; do not bail early

### DIFF
--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/heptio/sonobuoy/pkg/config"
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -317,7 +318,8 @@ func QueryNSResources(kubeClient kubernetes.Interface, recorder *QueryRecorder, 
 			start := time.Now()
 			err := gatherPodLogs(kubeClient, ns, opts, cfg)
 			if err != nil {
-				return err
+				errlog.LogError(err)
+				continue
 			}
 			duration := time.Since(start)
 			recorder.RecordQuery("PodLogs", ns, duration, err)


### PR DESCRIPTION
Fixes #455

But adds technical debt addressed by SEP defined in #464

Signed-off-by: Chuck Ha <chuck@heptio.com>


**What this PR does / why we need it**:
When the pod logs fail to query, we were bailing early. We don't want to do that. We want to finish the function.

**Release note**:
```
NONE
```
