### PR TITLE
Default version for results reader

### DIFF
--- a/pkg/client/results/reader.go
+++ b/pkg/client/results/reader.go
@@ -121,7 +121,8 @@ func DiscoverVersion(reader io.Reader) (string, error) {
 	} else if strings.HasPrefix(conf.Version, VersionTen) {
 		version = VersionTen
 	} else {
-		return "", errors.New("cannot discover Sonobuoy archive version")
+		// This should be the version with the most recent sonobuoy tarball layout.
+		version = VersionTen
 	}
 	return version, nil
 }


### PR DESCRIPTION
Fixes #476

Signed-off-by: Chuck Ha <chuck@heptio.com>


**What this PR does / why we need it**:
This PR adds a default so our results reader is making a guess instead of erroring.

```
Improved robustness for results reader
```
