### PR TITLE
Bump default to 180 minutes (3 hours)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -248,7 +248,7 @@ func New() *Config {
 
 	cfg.Aggregation.BindAddress = DefaultAggregationServerBindAddress
 	cfg.Aggregation.BindPort = DefaultAggregationServerBindPort
-	cfg.Aggregation.TimeoutSeconds = 5400 // 90 minutes
+	cfg.Aggregation.TimeoutSeconds = 10800 // 180 minutes
 
 	cfg.PluginSearchPath = []string{
 		"./plugins.d",


### PR DESCRIPTION
Along with the scanner update this Fixes #468

Signed-off-by: Chuck Ha <chuck@heptio.com>

**Release note**:
```
The default timeout increases to 3 hours
```
