### PR TITLE
Autodetect version

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -58,17 +58,25 @@ func AddSonobuoyImage(image *string, flags *pflag.FlagSet) {
 // AddKubeConformanceImage initialises an image url flag.
 func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
 	flags.StringVar(
-		image, "kube-conformance-image", config.DefaultKubeConformanceImage,
+		image, "kube-conformance-image", "",
 		"Container image override for the kube conformance image. Overrides --kube-conformance-image-version.",
 	)
 }
 
 // AddKubeConformanceImageVersion initialises an image version flag.
-func AddKubeConformanceImageVersion(imageVersion *string, flags *pflag.FlagSet) {
-	flags.StringVar(
-		imageVersion, "kube-conformance-image-version", "auto",
-		"Use Heptio's KubeConformance image, but override the version. Default is 'auto', which will be set to your cluster's version.",
-	)
+func AddKubeConformanceImageVersion(imageVersion *ConformanceImageVersion, flags *pflag.FlagSet, defaultVersion ConformanceImageVersion) {
+	help := "Use Heptio's KubeConformance image, but override the version. "
+	switch defaultVersion {
+	case ConformanceImageVersionAuto:
+		help += "Default is 'auto', which will be set to your cluster's version."
+	case ConformanceImageVersionLatest:
+		help += "Default is 'latest', which will run the tests for the most recently released Sonobuoy conformance image."
+	default:
+		help += fmt.Sprintf("Default is '%s'", defaultVersion)
+	}
+
+	*imageVersion = defaultVersion // default
+	flags.Var(imageVersion, "kube-conformance-image-version", help)
 }
 
 // AddKubeconfigFlag adds a kubeconfig flag to the provided command.
@@ -155,7 +163,7 @@ func AddRBACModeFlags(mode *RBACMode, flags *pflag.FlagSet, defaultMode RBACMode
 	flags.Var(
 		mode, "rbac",
 		// Doesn't use the map in app.rbacModeMap to preserve order so we can add an explanation for detect.
-		"Whether to enable rbac on Sonobuoy. Valid modes are Enable, Disable, and Detect (query the server to see whether to enable Sonobuoy).",
+		"Whether to enable rbac on Sonobuoy. Valid modes are Enable, Disable, and Detect (query the server to see whether to enable RBAC).",
 	)
 }
 

--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -59,7 +59,15 @@ func AddSonobuoyImage(image *string, flags *pflag.FlagSet) {
 func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		image, "kube-conformance-image", config.DefaultKubeConformanceImage,
-		"Container image override for the kube conformance image.",
+		"Container image override for the kube conformance image. Overrides --kube-conformance-image-version.",
+	)
+}
+
+// AddKubeConformanceImageVersion initialises an image version flag.
+func AddKubeConformanceImageVersion(imageVersion *string, flags *pflag.FlagSet) {
+	flags.StringVar(
+		imageVersion, "kube-conformance-image-version", "auto",
+		"Use Heptio's KubeConformance image, but override the version. Default is 'auto', which will be set to your cluster's version.",
 	)
 }
 

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -69,7 +69,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		return nil, errors.Wrap(err, "could not retrieve E2E config")
 	}
 
-	kubeclient, kubeError := maybeGetClient(&g.kubecfg)
+	kubeclient, kubeError := getClient(&g.kubecfg)
 
 	rbacEnabled, err := genflags.rbacMode.Enabled(kubeclient)
 	if err != nil {
@@ -93,12 +93,11 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		if err != nil {
 			if errors.Cause(err) == ErrImageVersionNoClient {
 				return nil, errors.Wrap(err, kubeError.Error())
-			} else {
-				return nil, err
 			}
+			return nil, err
 		}
 
-		image = fmt.Sprintf(config.DefaultKubeConformanceImage, imageVersion)
+		image = config.DefaultKubeConformanceImageURL + ":" + imageVersion
 	}
 
 	return &client.GenConfig{
@@ -148,8 +147,8 @@ func genManifest(cmd *cobra.Command, args []string) {
 	os.Exit(1)
 }
 
-// maybeGetClient returns a client if one can be found, and the error attempting to retrieve that client if not.
-func maybeGetClient(kubeconfig *Kubeconfig) (*kubernetes.Clientset, error) {
+// getClient returns a client if one can be found, and the error attempting to retrieve that client if not.
+func getClient(kubeconfig *Kubeconfig) (*kubernetes.Clientset, error) {
 	// Usually we don't need a client. But in this case, we _might_ if we're using detect.
 	// So pass in nil if we get an error, then display the errors from trying to get a client
 	// if it turns out we needed it.

--- a/cmd/sonobuoy/app/imageversion.go
+++ b/cmd/sonobuoy/app/imageversion.go
@@ -64,6 +64,7 @@ func (c *ConformanceImageVersion) Set(str string) error {
 
 // Get retrieves the preset version if there is one, or queries client if the ConformanceImageVersion is set to `auto`.
 // kubernetes.Interface.Discovery() provides ServerVersionInterface.
+// don't require the entire kubernetes.Interface to simplify the required test mocks
 func (c *ConformanceImageVersion) Get(client discovery.ServerVersionInterface) (string, error) {
 	if *c == ConformanceImageVersionAuto {
 		if client == nil {

--- a/cmd/sonobuoy/app/imageversion.go
+++ b/cmd/sonobuoy/app/imageversion.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"strings"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/discovery"
+)
+
+// ConformanceImageVersion represents the version of a conformance image, or "auto" to detect the version
+type ConformanceImageVersion string
+
+const (
+	// ConformanceImageVersionAuto represents detecting the server's kubernetes version.
+	ConformanceImageVersionAuto = "auto"
+	// ConformanceImageVersionLatest represents always using the server's latest version.
+	ConformanceImageVersionLatest = "latest"
+)
+
+// String needed for pflag.Value.
+func (c *ConformanceImageVersion) String() string { return string(*c) }
+
+// Type needed for pflag.Value.
+func (c *ConformanceImageVersion) Type() string { return "ConformanceImageVersion" }
+
+// Set the ImageVersion to either the string "auto" or a version string
+func (c *ConformanceImageVersion) Set(str string) error {
+	if str == ConformanceImageVersionAuto {
+		*c = ConformanceImageVersionAuto
+		return nil
+	} else if str == ConformanceImageVersionLatest {
+		*c = ConformanceImageVersionLatest
+		return nil
+	}
+
+	version, err := version.NewVersion(str)
+	if err != nil {
+		return err
+	}
+
+	if version.Metadata() != "" || version.Prerelease() != "" {
+		return errors.New("version cannot have prelease or metadata")
+	}
+
+	if !strings.HasPrefix(str, "v") {
+		return errors.New("version must start with v")
+	}
+
+	*c = ConformanceImageVersion(str)
+	return nil
+}
+
+// Get retrieves the preset version if there is one, or queries client if the ConformanceImageVersion is set to `auto`.
+// kubernetes.Interface.Discovery() provides ServerVersionInterface.
+func (c *ConformanceImageVersion) Get(client discovery.ServerVersionInterface) (string, error) {
+	if *c == ConformanceImageVersionAuto {
+		version, err := client.ServerVersion()
+		if err != nil {
+			return "", errors.Wrap(err, "couldn't retrieve server version")
+		}
+		return version.GitVersion, nil
+	}
+	return string(*c), nil
+}

--- a/cmd/sonobuoy/app/imageversion_test.go
+++ b/cmd/sonobuoy/app/imageversion_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 )
 
 func TestSetConformanceImageVersion(t *testing.T) {
@@ -87,6 +88,12 @@ func TestGetConformanceImageVersion(t *testing.T) {
 		},
 	}
 
+	betaServerVersion := &fakeServerVersionInterface{
+		version: version.Info{
+			GitVersion: "v1.11.0-beta.2.78+e0b33dbc2bde88",
+		},
+	}
+
 	brokenServerVersion := &fakeServerVersionInterface{
 		err: errors.New("can't connect"),
 	}
@@ -94,7 +101,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 	tests := []struct {
 		name          string
 		version       ConformanceImageVersion
-		serverVersion *fakeServerVersionInterface
+		serverVersion discovery.ServerVersionInterface
 		expected      string
 		error         bool
 	}{
@@ -108,6 +115,12 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			name:          "auto returns error if upstream fails",
 			version:       "auto",
 			serverVersion: brokenServerVersion,
+			error:         true,
+		},
+		{
+			name:          "beta server version throws error",
+			version:       "auto",
+			serverVersion: betaServerVersion,
 			error:         true,
 		},
 		{
@@ -133,6 +146,12 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			version:       "latest",
 			serverVersion: brokenServerVersion,
 			expected:      "latest",
+		},
+		{
+			name:          "nil serverVersion",
+			version:       "auto",
+			serverVersion: nil,
+			error:         true,
 		},
 	}
 

--- a/cmd/sonobuoy/app/imageversion_test.go
+++ b/cmd/sonobuoy/app/imageversion_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestSetConformanceImageVersion(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		version string
+		error   bool
+	}{
+		{
+			name:    "version detect",
+			version: "auto",
+			error:   false,
+		},
+		{
+			name:    "use latest",
+			version: "latest",
+			error:   false,
+		},
+		{
+			name:    "random string",
+			version: "test",
+			error:   true,
+		},
+		{
+			name:    "stable version",
+			version: "v1.11.0",
+			error:   false,
+		},
+		{
+			name:    "version without v",
+			version: "1.11.0",
+			error:   true,
+		},
+		{
+			name:    "empty string",
+			version: "",
+			error:   true,
+		},
+		{
+			name:    "version with addendum",
+			version: "v1.11.0-beta.2.78+e0b33dbc2bde88",
+			error:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var v ConformanceImageVersion
+			err := v.Set(test.version)
+			if test.error && err == nil {
+				t.Error("expected error, got nil")
+			} else if !test.error && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGetConformanceImageVersion(t *testing.T) {
+	workingServerVersion := &fakeServerVersionInterface{
+		version: version.Info{
+			GitVersion: "v1.11.0",
+		},
+	}
+
+	brokenServerVersion := &fakeServerVersionInterface{
+		err: errors.New("can't connect"),
+	}
+
+	tests := []struct {
+		name          string
+		version       ConformanceImageVersion
+		serverVersion *fakeServerVersionInterface
+		expected      string
+		error         bool
+	}{
+		{
+			name:          "auto retrieves server version",
+			version:       "auto",
+			serverVersion: workingServerVersion,
+			expected:      "v1.11.0",
+		},
+		{
+			name:          "auto returns error if upstream fails",
+			version:       "auto",
+			serverVersion: brokenServerVersion,
+			error:         true,
+		},
+		{
+			name:          "set version ignores server version",
+			version:       "v1.10.2",
+			serverVersion: workingServerVersion,
+			expected:      "v1.10.2",
+		},
+		{
+			name:          "set version doesn't call server so ignores errors",
+			version:       "v1.10.2",
+			serverVersion: brokenServerVersion,
+			expected:      "v1.10.2",
+		},
+		{
+			name:          "latest ignores server version",
+			version:       "latest",
+			serverVersion: workingServerVersion,
+			expected:      "latest",
+		},
+		{
+			name:          "latest doesn't call server so ignores errors",
+			version:       "latest",
+			serverVersion: brokenServerVersion,
+			expected:      "latest",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v, err := test.version.Get(test.serverVersion)
+			if test.error && err == nil {
+				t.Fatalf("expected error, got nil")
+			} else if !test.error && err != nil {
+				t.Fatalf("unexpecter error %v", err)
+			}
+
+			if v != test.expected {
+				t.Errorf("expected version %q, got %q", test.expected, v)
+			}
+		})
+	}
+}
+
+type fakeServerVersionInterface struct {
+	err     error
+	version version.Info
+}
+
+func (f *fakeServerVersionInterface) ServerVersion() (*version.Info, error) {
+	return &f.version, f.err
+}

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -39,7 +39,7 @@ var runflags runFlags
 func RunFlagSet(cfg *runFlags) *pflag.FlagSet {
 	runset := pflag.NewFlagSet("run", pflag.ExitOnError)
 	// Default to detect since we need kubeconfig regardless
-	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode))
+	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode, ConformanceImageVersionAuto))
 	AddSkipPreflightFlag(&cfg.skipPreflight, runset)
 	return runset
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ const (
 	// DefaultNamespace is the namespace where the master and plugin workers will run (but not necessarily the pods created by the plugin workers).
 	DefaultNamespace = "heptio-sonobuoy"
 	// DefaultKubeConformanceImage is the URL of the docker image to run for the kube conformance tests.
-	DefaultKubeConformanceImage = "gcr.io/heptio-images/kube-conformance:latest"
+	DefaultKubeConformanceImage = "gcr.io/heptio-images/kube-conformance:%s"
 	// DefaultAggregationServerBindPort is the default port for the aggregation server to bind to.
 	DefaultAggregationServerBindPort = 8080
 	// DefaultAggregationServerBindAddress is the default address for the aggregation server to bind to.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,8 +29,11 @@ import (
 const (
 	// DefaultNamespace is the namespace where the master and plugin workers will run (but not necessarily the pods created by the plugin workers).
 	DefaultNamespace = "heptio-sonobuoy"
-	// DefaultKubeConformanceImage is the URL of the docker image to run for the kube conformance tests.
-	DefaultKubeConformanceImage = "gcr.io/heptio-images/kube-conformance:%s"
+
+	// DefaultKubeConformanceImageURL is the URL of the docker image to run for the kube conformance tests.
+	DefaultKubeConformanceImageURL = "gcr.io/heptio-images/kube-conformance"
+	// DefaultKubeConformanceImageTag is the default tag of the conformance image
+	DefaultKubeConformanceImageTag = "latest"
 	// DefaultAggregationServerBindPort is the default port for the aggregation server to bind to.
 	DefaultAggregationServerBindPort = 8080
 	// DefaultAggregationServerBindAddress is the default address for the aggregation server to bind to.
@@ -43,8 +46,12 @@ const (
 	MasterResultsPath = "/tmp/sonobuoy"
 )
 
-// DefaultImage is the URL of the docker image to run for the aggregator and workers
-var DefaultImage = "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version
+var (
+	// DefaultKubeConformanceImage is the URL and tag of the docker image to run for the kube conformance tests.
+	DefaultKubeConformanceImage = DefaultKubeConformanceImageURL + ":" + DefaultKubeConformanceImageTag
+	// DefaultImage is the URL of the docker image to run for the aggregator and workers
+	DefaultImage = "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version
+)
 
 ///////////////////////////////////////////////////////
 // Note: The described resources are a 1:1 match


### PR DESCRIPTION
**What this PR does / why we need it**:
Sonobuoy will now detect the server's version and try to run the appropriate conformance container

**Which issue(s) this PR fixes**
- Fixes #444 

**Special notes for your reviewer**:

**Release note**:
```
sonobuoy run automatically detects server version, gen uses latest

--kube-conformance-image-version has several possible arguments:
auto queries the server version and uses that
latest uses the `latest` tag
a literal version (e.g. v1.10.2) always uses that
```
