### PR TITLE
use 'Enable' vs 'Enabled' for RBAC mode

### DIFF
--- a/cmd/sonobuoy/app/rbac.go
+++ b/cmd/sonobuoy/app/rbac.go
@@ -39,7 +39,7 @@ const (
 	// DisableRBACMode means rbac is always disable
 	DisableRBACMode RBACMode = "Disable"
 	// EnabledRBACMode means rbac is always enabled
-	EnabledRBACMode RBACMode = "Enabled"
+	EnabledRBACMode RBACMode = "Enable"
 	// DetectRBACMode means "query the server to see if RBAC is enabled"
 	DetectRBACMode RBACMode = "Detect"
 )


### PR DESCRIPTION
The usage information for `--rbac` is incorrect. It specifies `Enable` instead of `Enabled` as the correct argument value. This updates the `EnabledRBACMode` value from `Enabled` to `Enable` to maintain consistency with the `Disable` and `Detect` RBAC modes.
