### PR TITLE
Sets version image to use vMajor.Minor b/c we don't match all .Patch releases

### DIFF
--- a/cmd/sonobuoy/app/imageversion.go
+++ b/cmd/sonobuoy/app/imageversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -79,7 +80,10 @@ func (c *ConformanceImageVersion) Get(client discovery.ServerVersionInterface) (
 			return "", err
 		}
 
-		return version.GitVersion, nil
+		// NOTE: Until the kube-conformance container is pushed upstream we can't
+		// guarantee alignment with exact versioning see https://github.com/heptio/kube-conformance/issues/25
+		// for more details
+		return fmt.Sprintf("v%s.%s", version.Major, version.Minor), nil
 	}
 	return string(*c), nil
 }

--- a/cmd/sonobuoy/app/imageversion_test.go
+++ b/cmd/sonobuoy/app/imageversion_test.go
@@ -84,12 +84,16 @@ func TestSetConformanceImageVersion(t *testing.T) {
 func TestGetConformanceImageVersion(t *testing.T) {
 	workingServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
+			Major:      "1",
+			Minor:      "11",
 			GitVersion: "v1.11.0",
 		},
 	}
 
 	betaServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
+			Major:      "1",
+			Minor:      "11",
 			GitVersion: "v1.11.0-beta.2.78+e0b33dbc2bde88",
 		},
 	}
@@ -109,7 +113,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			name:          "auto retrieves server version",
 			version:       "auto",
 			serverVersion: workingServerVersion,
-			expected:      "v1.11.0",
+			expected:      "v1.11",
 		},
 		{
 			name:          "auto returns error if upstream fails",


### PR DESCRIPTION
**What this PR does / why we need it**:
Bug fix on run b/c we don't release *.patch versions

**Special notes for your reviewer**:
See https://github.com/heptio/kube-conformance/issues/25

**Release note**:
```
None
```

/assign @chuckha @liztio 
