### PR TITLE
Quick fix for an empty config SEGV on nil rest.Config bug

### DIFF
--- a/cmd/sonobuoy/app/common.go
+++ b/cmd/sonobuoy/app/common.go
@@ -9,9 +9,13 @@ import (
 )
 
 func getSonobuoyClient(cfg *rest.Config) (*client.SonobuoyClient, error) {
-	skc, err := sonodynamic.NewAPIHelperFromRESTConfig(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't get sonobuoy api helper")
+	var skc *sonodynamic.APIHelper
+	var err error
+	if cfg != nil {
+		skc, err = sonodynamic.NewAPIHelperFromRESTConfig(cfg)
+		if err != nil {
+			return nil, errors.Wrap(err, "couldn't get sonobuoy api helper")
+		}
 	}
 	return client.NewSonobuoyClient(cfg, skc)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a condition where getSonobuoyClient(cfg *rest.Config) can be called with a nil cfg 

Which is a normal condition that can occur for offline tarball analysis.

**Which issue(s) this PR fixes**
- Fixes #498

**Special notes for your reviewer**:
none

**Release note**:
```
None
```

/assign @chuckha 
/cc @scottslowe 