### PR TITLE
Update to v0.11.5

### DIFF
--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -20,7 +20,7 @@ limitations under the License.
 package buildinfo
 
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
-var Version = "v0.11.4"
+var Version = "v0.11.5"
 
 // MinimumKubeVersion is the lowest API version of Kubernetes this release of Sonobuoy supports.
 var MinimumKubeVersion = "1.9.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the latest revision to v0.11.5 

**Release note**:
```
NONE
```
