### PR TITLE
Add ipv6 support to sonobuoy

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -58,7 +58,7 @@ func LoadConfig() (*Config, error) {
 	// 3 - figure out what address we will tell pods to dial for aggregation
 	if cfg.Aggregation.AdvertiseAddress == "" {
 		if ip := os.Getenv("SONOBUOY_ADVERTISE_IP"); ip != "" {
-			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("%v:%d", ip, cfg.Aggregation.BindPort)
+			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", ip, cfg.Aggregation.BindPort)
 		} else {
 			hostname, _ := os.Hostname()
 			if hostname != "" {


### PR DESCRIPTION
This change adds brackets around the ip address when it is learned. This
is compatible with ipv4 and ipv6 setups.

Before this change if you ran sonobuoy in an ipv6 cluster the
aggregation mechanism would break with logs like:
```
13:10 $ sonobuoy e2e ipv4_with_ipv6_fix.tar.gz --show passed
passed tests
[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]
```

preventing the sonobuoy pod from marking any plugin complete.

After this change the url passed to the aggregator handler will have the
ip address bracketed.

This was tested with kubeadm-dind in both ipv4 and ipv6 configurations.

An example sonobuoy container with this fix is located here:
quay.io/mauilion/sonobuoy:ipv6_fix

You can test this locally with:
```
wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.11.sh
$ chmod +x dind-cluster-v1.11.sh
$ export IP_MODE=ipv6
$ ./dind-cluster-v1.11.sh up
$ sonobuoy run -m Quick --sonobuoy-image=quay.io/mauilion/sonobuoy:ipv6_fix
```

Signed-off-by: Duffie Cooley <dcooley@heptio.com>



**Which issue(s) this PR fixes**
- Fixes #542 

**Special notes for your reviewer**:

**Release note**:
```
add ipv6 support for aggregator in sonobuoy
```
