### PR TITLE
Add metrics and logs non-resource URLs to RBAC rules

### DIFF
--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -61,6 +61,12 @@ rules:
   - '*'
   verbs:
   - '*'
+- nonResourceURLs:
+  - '/metrics'
+  - '/logs'
+  - '/logs/*'
+  verbs:
+  - 'get'
 {{- end }}
 {{- if .SSHKey }}
 ---


### PR DESCRIPTION
Some tests in the Kuberentes E2E suite require hitting
non-resource URLs which have to be listed as separate
rules in the ClusterRole definition.


**What this PR does / why we need it**:
There are some E2E tests that require access to non-resource URLs. Ticket #526 listed one of them which was the basis for choosing this set of URLs.

**Which issue(s) this PR fixes**
- Fixes #526

**Special notes for your reviewer**:
The ticket originally mentions needing just `/metrics` but when retesting with that added the tests would complain about `/logs` and after adding that it complained about needing `/logs/`.

I left the changes with this minimal set of added privileges but I would understand if we'd rather just add more to try and prevent other situations similar to this. I'm not sure how the team feels about adding extra, potentially unnecessary privileges.

The test case I ran to recreate this problem (and confirm its resolution) was:
```
sonobuoy run --e2e-focus="static URL paths for " --sonobuoy-image gcr.io/heptio-images/sonobuoy:v0.12.1
```

**Release note**:
```
release-note
Added the ability for Sonobuoy to GET certain non-resource URLs, increasing the number of E2E tests that can run successfully.
```