### PR TITLE
add the sonobuoy serviceaccount to daemonsets

### DIFF
--- a/pkg/plugin/driver/daemonset/template.go
+++ b/pkg/plugin/driver/daemonset/template.go
@@ -85,6 +85,7 @@ spec:
       hostIPC: true
       hostNetwork: true
       hostPID: true
+      serviceAccountName: sonobuoy-serviceaccount
       tolerations:
       - operator: Exists
       volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the sonobuoy serviceaccount to the daemonsets so they have same permission as jobs
**Which issue(s) this PR fixes**
- Fixes #551 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
