### PR TITLE
Version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for the following use cases:
 * Workload debugging
 * Custom data collection via extensible plugins
 
-Sonobuoy supports Kubernetes versions 1.10, 1.11 and 1.12.
+Sonobuoy supports Kubernetes versions 1.11, 1.12 and 1.13.
 
 [k8s]: https://github.com/kubernetes/kubernetes
 [e2e]: /docs/conformance-testing.md

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -20,15 +20,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/heptio/sonobuoy/pkg/client"
+	"github.com/heptio/sonobuoy/pkg/config"
+	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/heptio/sonobuoy/pkg/client"
-	"github.com/heptio/sonobuoy/pkg/config"
-	"github.com/heptio/sonobuoy/pkg/errlog"
 )
 
 type genFlags struct {

--- a/cmd/sonobuoy/app/imageversion_test.go
+++ b/cmd/sonobuoy/app/imageversion_test.go
@@ -52,12 +52,12 @@ func TestSetConformanceImageVersion(t *testing.T) {
 		},
 		{
 			name:    "stable version",
-			version: "v1.11.0",
+			version: "v1.13.0",
 			error:   false,
 		},
 		{
 			name:    "version without v",
-			version: "1.11.0",
+			version: "1.13.0",
 			error:   true,
 		},
 		{
@@ -67,12 +67,12 @@ func TestSetConformanceImageVersion(t *testing.T) {
 		},
 		{
 			name:    "version with addendum",
-			version: "v1.11.0-beta.2.78+e0b33dbc2bde88",
+			version: "v1.13.0-beta.2.78+e0b33dbc2bde88",
 			error:   false,
 		},
 		{
 			name:    "version with plus",
-			version: "v1.10+",
+			version: "v1.11+",
 			error:   true,
 		},
 	}
@@ -98,24 +98,24 @@ func TestGetConformanceImageVersion(t *testing.T) {
 	workingServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
 			Major:      "1",
-			Minor:      "11",
-			GitVersion: "v1.11.0",
+			Minor:      "13",
+			GitVersion: "v1.13.0",
 		},
 	}
 
 	betaServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
 			Major:      "1",
-			Minor:      "11",
-			GitVersion: "v1.11.0-beta.2.78+e0b33dbc2bde88",
+			Minor:      "13",
+			GitVersion: "v1.13.0-beta.2.78+e0b33dbc2bde88",
 		},
 	}
 
 	gkeServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
 			Major:      "1",
-			Minor:      "10+",
-			GitVersion: "v1.10.5-gke.3",
+			Minor:      "11+",
+			GitVersion: "v1.11.5-gke.3",
 		},
 	}
 
@@ -135,7 +135,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			name:          "auto retrieves server version",
 			version:       "auto",
 			serverVersion: workingServerVersion,
-			expected:      "v1.11",
+			expected:      "v1.13",
 		},
 		{
 			name:          "auto returns error if upstream fails",
@@ -148,25 +148,25 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			version:       "auto",
 			serverVersion: betaServerVersion,
 			warning:       true,
-			expected:      "v1.11",
+			expected:      "v1.13",
 		},
 		{
 			name:          "gke server strips plus sign",
 			version:       "auto",
 			serverVersion: gkeServerVersion,
-			expected:      "v1.10",
+			expected:      "v1.11",
 		},
 		{
 			name:          "set version ignores server version",
-			version:       "v1.10.2",
+			version:       "v1.11.2",
 			serverVersion: workingServerVersion,
-			expected:      "v1.10.2",
+			expected:      "v1.11.2",
 		},
 		{
 			name:          "set version doesn't call server so ignores errors",
-			version:       "v1.10.2",
+			version:       "v1.11.2",
 			serverVersion: brokenServerVersion,
-			expected:      "v1.10.2",
+			expected:      "v1.11.2",
 		},
 		{
 			name:          "latest ignores server version",

--- a/docs/conformance-testing.md
+++ b/docs/conformance-testing.md
@@ -1,4 +1,4 @@
-# Conformance Testing - [1.10+][6]
+# Conformance Testing - [1.11+][6]
 
 ## Overview
 

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -20,10 +20,10 @@ limitations under the License.
 package buildinfo
 
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
-var Version = "v0.12.1"
+var Version = "v0.13.0"
 
 // MinimumKubeVersion is the lowest API version of Kubernetes this release of Sonobuoy supports.
-var MinimumKubeVersion = "1.10.0"
+var MinimumKubeVersion = "1.11.0"
 
 // MaximumKubeVersion is the highest API version of Kubernetes this release of Sonobuoy supports.
-var MaximumKubeVersion = "1.12.99"
+var MaximumKubeVersion = "1.13.99"


### PR DESCRIPTION
Signed-off-by: Ruben Orduz <rubenoz@gmail.com>


**What this PR does / why we need it**:
It updates sonobuoy to support version 1.13

**Which issue(s) this PR fixes**
- Fixes #561 

**Special notes for your reviewer**:

**Release note**:
```
Sonobuoy has been updated to support Kubernetes version 1.13.x. Support for Kubernetes version 1.10.x has been removed.
```
