### PR TITLE
Fix front matter issue

### DIFF
--- a/latest/README.md
+++ b/latest/README.md
@@ -1,10 +1,8 @@
----
-title: Sonobuoy
----
-
-# Sonobuoy [![Build Status][status]][travis]
+# Sonobuoy
 
 <img src="../assets/img/vmw-os-lgo-heptio-sonobuoy.png" width="100px" >
+
+[![Build Status][status]][travis]
 
 [heptio]: https://github.com/heptio
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master


### PR DESCRIPTION
Last commit added front matter to the readme page which
broke the preprocessor. This change removes that.

It also moves the build status line below the header so that
the title in the browser does not include that markdown (a
jekyll plugin is creating the title from the first header).

So this gets the site up and fixes the title with the
cost of having the github pages build status shown in a
slightly different place than on the github repo page.
