### PR TITLE
Acknowledge state between plugins complete and done

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -105,6 +105,8 @@ func humanReadableStatus(str string) string {
 		return "Sonobuoy has failed. You can see what happened with `sonobuoy logs`."
 	case aggregation.CompleteStatus:
 		return "Sonobuoy has completed. Use `sonobuoy retrieve` to get results."
+	case aggregation.PostProcessingStatus:
+		return "Sonobuoy plugins have completed. Preparing results for download."
 	default:
 		return fmt.Sprintf("Sonobuoy is in unknown state %q. Please report a bug at github.com/heptio/sonobuoy", str)
 	}

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -17,13 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
 
@@ -33,28 +26,5 @@ func (c *SonobuoyClient) GetStatus(namespace string) (*aggregation.Status, error
 		return nil, err
 	}
 
-	if _, err := client.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{}); err != nil {
-		return nil, errors.Wrap(err, "sonobuoy namespace does not exist")
-	}
-
-	pod, err := client.CoreV1().Pods(namespace).Get(aggregation.StatusPodName, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve sonobuoy pod")
-	}
-
-	if pod.Status.Phase != corev1.PodRunning {
-		return nil, fmt.Errorf("pod has status %q", pod.Status.Phase)
-	}
-
-	statusJSON, ok := pod.Annotations[aggregation.StatusAnnotationName]
-	if !ok {
-		return nil, fmt.Errorf("missing status annotation %q", aggregation.StatusAnnotationName)
-	}
-
-	var status aggregation.Status
-	if err := json.Unmarshal([]byte(statusJSON), &status); err != nil {
-		return nil, errors.Wrap(err, "couldn't unmarshal the JSON status annotation")
-	}
-
-	return &status, nil
+	return aggregation.GetStatus(client, namespace)
 }

--- a/pkg/plugin/aggregation/status_test.go
+++ b/pkg/plugin/aggregation/status_test.go
@@ -25,14 +25,14 @@ func TestUpdateStatus(t *testing.T) {
 		expectedStatus string
 	}{
 		{
-			name:           "empty is complete",
+			name:           "empty is post-processing",
 			pluginStatuses: []string{},
-			expectedStatus: "complete",
+			expectedStatus: "post-processing",
 		},
 		{
-			name:           "all completed is complete",
+			name:           "all completed is post-processing",
 			pluginStatuses: []string{"complete", "complete", "complete"},
-			expectedStatus: "complete",
+			expectedStatus: "post-processing",
 		},
 		{
 			name:           "one running is running",

--- a/pkg/plugin/aggregation/update.go
+++ b/pkg/plugin/aggregation/update.go
@@ -109,7 +109,7 @@ func (u *updater) Annotate(results map[string]*plugin.Result) error {
 		return errors.Wrap(err, "couldn't serialize status")
 	}
 
-	patch := getPatch(str)
+	patch := GetPatch(str)
 	bytes, err := json.Marshal(patch)
 	if err != nil {
 		return errors.Wrap(err, "couldn't encode patch")
@@ -146,7 +146,9 @@ func (u *updater) ReceiveAll(results map[string]*plugin.Result) {
 	}
 }
 
-func getPatch(annotation string) map[string]interface{} {
+// GetPatch takes a json encoded string and creates a map which can be used as
+// a patch to indicate the Sonobuoy status.
+func GetPatch(annotation string) map[string]interface{} {
 	return map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
If your plugin artifacts are large then it will take
a few seconds for the tarball to be created. However,
the aggregator marks the pod status as done and
therefore there can be a few seconds where the
status reports that results are ready for download
but you will wither get a "file does not exist" error
or a tarball locally that is only partially complete
and most likely corrupted.

**Which issue(s) this PR fixes**
Fixes #572

**Special notes for your reviewer**:
In order to repro this you need to have large artifacts (as if you had a multi-node cluster running tests for numerous hours. This can easily be repro'd by using a custom kube-conformance image I created which took a dryrun result and then repeated it 2^15 times (image is available publicly at `schnake/kube-conformance:big`). The file ends up being ~1G before being tar'd. I scripted a little test where I watched for each status change and saw that in this case I had around 8s of time where I could get errors after the `sonobuoy status` output would report that results were available. Part of that time I'd get "no file" errors and the other times I was getting partial tar files.

**Release note**:
```
Fixed a bug which could cause the tarball from sonobuoy retrieve to not exist or be corrupted.
```
