### PR TITLE
Update version command to print GitSHA, Min/Max K8S Versions

### DIFF
--- a/cmd/sonobuoy/app/version.go
+++ b/cmd/sonobuoy/app/version.go
@@ -20,20 +20,76 @@ import (
 	"fmt"
 
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(versionCmd)
+type versionFlags struct {
+	kubecfg Kubeconfig
 }
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print sonobuoy version",
-	Run:   runVersion,
-	Args:  cobra.ExactArgs(0),
+var versionflags versionFlags
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print sonobuoy version",
+		Run:   runVersion,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	AddKubeconfigFlag(&versionflags.kubecfg, cmd.Flags())
+
+	RootCmd.AddCommand(cmd)
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	fmt.Println(buildinfo.Version)
+
+	fmt.Println(fmt.Sprintf("Sonobuoy Version: %s", buildinfo.Version))
+	fmt.Println(fmt.Sprintf("MinimumKubeVersion: %s", buildinfo.MinimumKubeVersion))
+	fmt.Println(fmt.Sprintf("MaximumKubeVersion: %s", buildinfo.MaximumKubeVersion))
+	fmt.Println(fmt.Sprintf("GitSHA: %s", buildinfo.GitSHA))
+
+	// Get Kubernetes version, this is last so that the regular version information
+	// will be shown even if the API server cannot be contacted and throws an error
+	apiVersion, skipk8sCheck := getK8Sversion()
+	if !skipk8sCheck {
+		fmt.Println("API Version: ", apiVersion)
+	} else {
+		fmt.Println("API Version check skipped due to missing `--kubeconfig` or other error")
+	}
+}
+
+func getK8Sversion() (string, bool) {
+
+	if versionflags.kubecfg.String() != "" {
+		cfg, err := versionflags.kubecfg.Get()
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
+			return "", true
+		}
+
+		sbc, err := getSonobuoyClient(cfg)
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
+			return "", true
+		}
+
+		client, err := sbc.Client()
+		if err != nil {
+			errlog.LogError(err)
+			return "", true
+		}
+
+		apiVersion, err := client.Discovery().ServerVersion()
+		if err != nil {
+			errlog.LogError(err)
+			return "", true
+		}
+
+		return apiVersion.GitVersion, false
+	}
+
+	return "", true
 }

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -22,6 +22,9 @@ package buildinfo
 // Version is the current version of Sonobuoy, set by the go linker's -X flag at build time
 var Version = "v0.13.0"
 
+// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
+var GitSHA string
+
 // MinimumKubeVersion is the lowest API version of Kubernetes this release of Sonobuoy supports.
 var MinimumKubeVersion = "1.11.0"
 


### PR DESCRIPTION
Fixes #518 by adding additional version information:

- MinimumKubeVersion supported by this version of Sonobuoy
- MaximumKubeVersion supported by this version of Sonobuoy
- GitSHA
- K8S version (if kubeconfig is passed)

Signed-off-by: Steve Sloka <slokas@vmware.com>
