### PR TITLE
Run E2E tests inside a kind cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ examples/dev.yaml
 
 # Unencrypted credentials
 heptio-images-ee4b0474b93e.json
+
+# Dynamic Dockerfiles
+Dockerfile-amd64
+Dockerfile-arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,35 @@ go:
     - "1.10"
 
 services:
-- docker
+  - docker
 
 install: true
 
-script: VERBOSE=true make test int
+script: 
+  - VERBOSE=true make test int 
+  - ./travis-ci.sh 
 
 before_install:
-# Install gcloud cli here so it gets cached
-- if [ ! -d ${HOME}/google-cloud-sdk ]; then
-    curl https://sdk.cloud.google.com | bash /dev/stdin --disable-prompts;
-  fi
+  # Download and install Kind
+  - go get sigs.k8s.io/kind
+  - kind create cluster --config kind-config.yaml
+  - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+
+
+before_deploy:
+  # Install gcloud cli here so it gets cached
+  - if [ ! -d ${HOME}/google-cloud-sdk ]; then
+      curl https://sdk.cloud.google.com | bash /dev/stdin --disable-prompts;
+    fi 
 
 deploy:
-- provider: script
-  skip_cleanup: true
-  script: ./travis-deploy.sh
-  on:
-    repo: heptio/sonobuoy
-    all_branches: true
+  - provider: script
+    skip_cleanup: true
+    script: ./travis-deploy.sh
+    on:
+      repo: heptio/sonobuoy
+      all_branches: true
   
 env:
   secure: AsGb+4LLxBE9fo8eJMfuwUK3QTt61TC+HDP+GbzRaYPB27usaSouAvqeLJI2jxDU/oNaDlNarb3A43gZIqbZe+0uT8jdrqnv5pGmX4CooNm52zF4QEQrFpERvfFAdbUKkZ11NLXav3S0iLVb8/iWopF0/yvt7h0ohBzNX/tMs7vYeZ5KbKUF8v7Uwg3VmjIHsvfSmtaEvWPi3302O/lo5J1tB6TH8b/bAXWweU8GKmQnQKES/+tUern+zOT0S47/fyRbvG6KbLdttol9k7KbzWZxG2iHcC65ogmdHD2azZmLyL8s5khDkA2rO4ovnOqse2kxmxn7da7y8k93vWaN1y98RpXw4H6brsH15BzoGoYBaMLg/Kn/JbTkSxPkPr/+6WGJ6lFeGgvArkwCXVyRPpecSH55+kvKmD8wxGnXaQp086cNKBiZYgN4C+T/8XXO011CxgjzLCsyyqr2KGI7c1VXvdiDt+fjVUeE/ftbHFdHH8Oc809U+6sa+6UWFxDcg3fsyIDKqUAh+cOYdjL+8+OpNWiV8p7/Yu+QntbfMuRmkyQz9boYZU58uzFGe0B87nu0Y9O6nIKJWu07nPiPP11CU3iv2aYDfg2y1wvyvk5rWSgnBnD82nHf7ip2/bykbsajK2fcX1sIA/3c7NzWtKauxnfTXLxxqBRbZFkOuoE=

--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,6 @@ clean:
 	for arch in $(LINUX_ARCH); do \
 		$(MAKE) clean_image TARGET=$(TARGET)-$$arch; \
 	done
+
+deploy_kind:
+	kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+- role: control-plane
+- role: worker
+  replicas: 3

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Don't fail silently when a step doesn't succeed
+set -e
+
+make container deploy_kind
+
+echo "|---- Creating new Sonobuoy run/waiting for results..."
+./sonobuoy run --image-pull-policy=IfNotPresent -m Quick --wait
+
+outFile=$(./sonobuoy retrieve)
+results=$(./sonobuoy e2e $outFile)
+
+echo $results
+
+if echo $results | grep --quiet "failed tests: 0"; then
+    echo "|---- Success!"
+else
+    echo "|---- Failure: E2E tests failed"
+    exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR now builds a kind cluster inside travis, runs the E2E tests and checks for a valid result. We'll need to see if this should be a 2nd job or have a bot only run occasionally since it will take some time to run. 

**Which issue(s) this PR fixes**
- Fixes #250 

Signed-off-by: Steve Sloka <slokas@vmware.com>

**Release note**:
```
release-note
```
