### PR TITLE
Provide more clear output from sonobuoy e2e

### DIFF
--- a/cmd/sonobuoy/app/e2e.go
+++ b/cmd/sonobuoy/app/e2e.go
@@ -99,8 +99,11 @@ func e2es(cmd *cobra.Command, args []string) {
 
 	// If we are not doing a rerun, print and exit.
 	if !e2eflags.rerun {
-		fmt.Printf("%v tests\n", e2eflags.show)
-		fmt.Println(client.PrintableTestCases(testCases))
+		numTests := len(testCases)
+		fmt.Printf("%v tests: %v\n", e2eflags.show, numTests)
+		if numTests > 0 {
+			fmt.Println(client.PrintableTestCases(testCases))
+		}
 		return
 	}
 

--- a/pkg/client/e2e.go
+++ b/pkg/client/e2e.go
@@ -73,6 +73,10 @@ func Focus(testCases []reporters.JUnitTestCase) string {
 type PrintableTestCases []reporters.JUnitTestCase
 
 func (p PrintableTestCases) String() string {
+	if len(p) == 0 {
+		return ""
+	}
+
 	out := make([]string, len(p))
 	for i, tc := range p {
 		out[i] = tc.Name

--- a/pkg/client/e2e_test.go
+++ b/pkg/client/e2e_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestString(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		cases  PrintableTestCases
+		expect string
+	}{
+		{
+			desc:   "No tests should report empty string",
+			cases:  PrintableTestCases([]reporters.JUnitTestCase{}),
+			expect: "",
+		}, {
+			desc:   "Nil tests should report empty string",
+			cases:  PrintableTestCases(nil),
+			expect: "",
+		}, {
+			desc: "Should not end with extra new line",
+			cases: PrintableTestCases([]reporters.JUnitTestCase{
+				reporters.JUnitTestCase{Name: "a"},
+				reporters.JUnitTestCase{Name: "b"},
+			}),
+			expect: "a\nb",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := tc.cases.String()
+			if out != tc.expect {
+				t.Errorf("Expected %q but got %q", tc.expect, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
 - when no tests reported, we make that clear by showing
the number in addition to the list
 - when no tests reported, ensure we dont have an unnecessary
empty line

**Which issue(s) this PR fixes**
Fixes #380

**Release note**:
```
Clarifies the output from `sonobuoy e2e`
```
