### PR TITLE
Add wait flags to run and delete

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -189,6 +189,24 @@ func AddDeleteAllFlag(flag *bool, flags *pflag.FlagSet) {
 	)
 }
 
+// AddDeleteWaitFlag adds a boolean flag for waiting for the delete process to complete.
+func AddDeleteWaitFlag(flag *int, flags *pflag.FlagSet) {
+	flags.IntVar(
+		flag, "wait", 0,
+		"Wait for resources to be deleted before completing. 0 indicates do not wait. By providing --wait the default is to wait for 1 hour.",
+	)
+	flags.Lookup("wait").NoOptDefVal = "60"
+}
+
+// AddRunWaitFlag adds an int flag for waiting for the entire run to finish.
+func AddRunWaitFlag(flag *int, flags *pflag.FlagSet) {
+	flags.IntVar(
+		flag, "wait", 0,
+		"Wait for sonobuoy run to be completed (or fail). 0 indicates do not wait. By providing --wait the default is to wait for 1 day.",
+	)
+	flags.Lookup("wait").NoOptDefVal = "1440"
+}
+
 // AddImagePullPolicyFlag adds a boolean flag for deleting everything (including E2E tests).
 func AddImagePullPolicyFlag(policy *ImagePullPolicy, flags *pflag.FlagSet) {
 	*policy = ImagePullPolicy(v1.PullAlways) //default

--- a/cmd/sonobuoy/app/delete.go
+++ b/cmd/sonobuoy/app/delete.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"os"
+	"time"
 
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/errlog"
@@ -30,6 +31,7 @@ var deleteopts client.DeleteConfig
 var deleteFlags struct {
 	kubeconfig Kubeconfig
 	rbacMode   RBACMode
+	wait       int
 }
 
 func init() {
@@ -44,6 +46,7 @@ func init() {
 	AddNamespaceFlag(&deleteopts.Namespace, cmd.Flags())
 	AddRBACModeFlags(&deleteFlags.rbacMode, cmd.Flags(), DetectRBACMode)
 	AddDeleteAllFlag(&deleteopts.DeleteAll, cmd.Flags())
+	AddDeleteWaitFlag(&deleteFlags.wait, cmd.Flags())
 
 	RootCmd.AddCommand(cmd)
 }
@@ -73,6 +76,7 @@ func deleteSonobuoyRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	deleteopts.EnableRBAC = rbacEnabled
+	deleteopts.Wait = time.Duration(deleteFlags.wait) * time.Minute
 
 	if err := sbc.Delete(&deleteopts); err != nil {
 		errlog.LogError(errors.Wrap(err, "failed to delete sonobuoy resources"))

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ import (
 type runFlags struct {
 	genFlags
 	skipPreflight bool
+	wait          int
 }
 
 var runflags runFlags
@@ -41,6 +43,7 @@ func RunFlagSet(cfg *runFlags) *pflag.FlagSet {
 	// Default to detect since we need kubeconfig regardless
 	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode, ConformanceImageVersionAuto))
 	AddSkipPreflightFlag(&cfg.skipPreflight, runset)
+	AddRunWaitFlag(&cfg.wait, runset)
 	return runset
 }
 
@@ -51,6 +54,7 @@ func (r *runFlags) Config() (*client.RunConfig, error) {
 	}
 	return &client.RunConfig{
 		GenConfig: *gencfg,
+		Wait:      time.Duration(r.wait) * time.Minute,
 	}, nil
 }
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"io"
+	"time"
 
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
@@ -60,6 +61,7 @@ type E2EConfig struct {
 // RunConfig are the input options for running Sonobuoy.
 type RunConfig struct {
 	GenConfig
+	Wait time.Duration
 }
 
 // DeleteConfig are the input options for cleaning up a Sonobuoy run.
@@ -67,6 +69,7 @@ type DeleteConfig struct {
 	Namespace  string
 	EnableRBAC bool
 	DeleteAll  bool
+	Wait       time.Duration
 }
 
 // RetrieveConfig are the input options for retrieving a Sonobuoy run's results.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently running a sonobuoy run takes significant time and
the user is left to poll the status on their own. In a
CI environment this is especially true.

Deleting, likewise, takes some time since cleaning up
namespaces in k8s is not always fast.

This PR introduces wait options to run/delete and allows
customizable timeouts to the wait behavior.

**Which issue(s) this PR fixes**
Fixes #568
Fixes #437

**Special notes for your reviewer**:

**Release note**:
```
Adds --wait flag to run and delete commands.
```
