### PR TITLE
List files created by retrieve command

### DIFF
--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -81,7 +81,16 @@ func retrieveResults(cmd *cobra.Command, args []string) {
 
 	eg := &errgroup.Group{}
 	eg.Go(func() error { return <-ec })
-	eg.Go(func() error { return client.UntarAll(reader, outDir, prefix) })
+	eg.Go(func() error {
+		filesCreated, err := client.UntarAll(reader, outDir, prefix)
+		if err != nil {
+			return err
+		}
+		for _, name := range filesCreated {
+			fmt.Println(name)
+		}
+		return nil
+	})
 
 	err = eg.Wait()
 	if _, ok := err.(exec.CodeExitError); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
When the user calls sonobuoy retrieve they are given no output
and then left to figure out if they got any files and what their
name is.

As someone who runs this a lot I'd like to be able to know more
easily what files were created so that I can script around them
or more easily grep for the "new" file in a sea of older tarballs.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Which issue(s) this PR fixes**
Fixes #594

**Special notes for your reviewer**:
Nothing greatly testable here; in the error case it doesnt print the names. Otherwise it prints the list, one file per line.

**Release note**:
```
sonobuoy retrieve now prints the local files it creates to stdout
```
