### PR TITLE
Update to go1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-    - "1.10"
+    - "1.12"
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.10-alpine
+BUILD_IMAGE ?= golang:1.12.0-alpine3.9
 
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
@@ -74,17 +74,17 @@ local-test:
 
 # Unit tests
 test: sonobuoy vet
-	$(DOCKER_BUILD) '$(TEST)'
+	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(TEST)'
 
 # Integration tests
 int: sonobuoy
-	$(DOCKER_BUILD) '$(INT_TEST)'
+	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(INT_TEST)'
 
 lint:
 	$(DOCKER_BUILD) '$(LINT)'
 
 vet:
-	$(DOCKER_BUILD) '$(VET)'
+	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(VET)'
 
 pre:
 	go get github.com/estesp/manifest-tool

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ records the following results:
 
 ### CLI Prerequisites
 
-* Golang installed. We recommend [gimme][gimme], with golang version 1.10.4.
+* Golang installed. We recommend [gimme][gimme], with golang version 1.12.0.
 
 * Your $PATH configured:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates go with the new release of 1.12. Go 1.10 is no longer supported.

**Which issue(s) this PR fixes**
- Fixes #610

**Special notes for your reviewer**:
Not sure the exact reason CGO_ENABLED=0 needs set for `go vet` but I do know it was partially touched based on the release notes stating that `go tool vet` was now deprecated.

Also, I know #609 mentions building based on debian slim but I am assuming that it only matters for the actual images we are shipping, not this which is just for producing the artifacts. #609 will be addressed separately.