### PR TITLE
Add support for KUBE_TEST_REPO_LIST and custom registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,35 @@ To clean up Kubernetes objects created by Sonobuoy, run:
 sonobuoy delete
 ```
 
+### Custom registries and air-gapped testing
+
+In air-gapped deployments where there is no access to the public Docker registries
+Sonobuoy supports running end-to-end tests with custom registries. This enables
+you to test your air-gapped deployment once you've loaded the necessary images
+into a registry that is reachable by your cluster.
+
+Just provide the `--e2e-repo-config` parameter and pass it the path to a local
+yaml file pointing to the registries you'd like to use. This will instruct the
+Kubernetes end-to-end suite to use your registries instead of the default ones.
+
+```
+sonobuoy run --e2e-repo-config custom-repos.yaml
+```
+
+The registry list is a yaml document specifying a few different registry
+categories and their values:
+
+```
+dockerLibraryRegistry: docker.io/library
+e2eRegistry: gcr.io/kubernetes-e2e-test-images
+gcRegistry: k8s.gcr.io
+privateRegistry: gcr.io/k8s-authenticated-test
+sampleRegistry: gcr.io/google-samples
+```
+
+The keys in that file are specified in the Kubernetes test framework itself. You
+may provide a subset of those and the defaults will be used for the others.
+
 ### Run on Google Cloud Platform (GCP)
 
 Note that if you run Sonobuoy on a Google Kubernetes Engine (GKE) cluster, you

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -43,6 +43,7 @@ type genFlags struct {
 	sshUser                     string
 	kubeConformanceImageVersion ConformanceImageVersion
 	imagePullPolicy             ImagePullPolicy
+	e2eRepoList                 string
 
 	// These two fields are here since to properly squash settings down into nested
 	// configs we need to tell whether or not values are default values or the user

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -31,9 +31,10 @@ import (
 
 // templateValues are used for direct template substitution for manifest generation.
 type templateValues struct {
-	E2EFocus             string
-	E2ESkip              string
-	E2EParallel          string
+	E2EFocus    string
+	E2ESkip     string
+	E2EParallel string
+
 	SonobuoyConfig       string
 	SonobuoyImage        string
 	Version              string
@@ -43,6 +44,11 @@ type templateValues struct {
 	KubeConformanceImage string
 	SSHKey               string
 	SSHUser              string
+
+	// CustomRegistries should be a multiline yaml string which represents
+	// the file contents of KUBE_TEST_REPO_LIST, the overrides for k8s e2e
+	// registries.
+	CustomRegistries string
 }
 
 // GenerateManifest fills in a template with a Sonobuoy config
@@ -82,6 +88,9 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 		KubeConformanceImage: cfg.KubeConformanceImage,
 		SSHKey:               base64.StdEncoding.EncodeToString(sshKeyData),
 		SSHUser:              cfg.SSHUser,
+
+		// Often created from reading a file, this value could have trailing newline.
+		CustomRegistries: strings.TrimSpace(cfg.E2EConfig.CustomRegistries),
 	}
 
 	var buf bytes.Buffer

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -56,6 +56,11 @@ type E2EConfig struct {
 	Focus    string
 	Skip     string
 	Parallel string
+
+	// CustomRegistries is the contents of a yaml file which will be
+	// used as KUBE_TEST_REPO_LIST which overrides which registries
+	// e2e tests use.
+	CustomRegistries string
 }
 
 // RunConfig are the input options for running Sonobuoy.


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s 1.13 organized and allowed overrides for where to pull
e2e images from. The env var needed is KUBE_TEST_REPO_LIST.

To facilitate users providing this, the following changes
have been made:

 - the user can specify a file path on the command line with
the proper contents
 - the file is read
 - the contents are used to create a configmap of the values
 - the configmap is mounted as a volume for the kube-conformance
container
 - the env var KUBE_TEST_REPO_LIST is set to point to this file


**Which issue(s) this PR fixes**
Fixes #160

**Special notes for your reviewer**:
Personally to test this I just pulled from `docker.io/library` (the nginx:1.14-alpine which is used by the quick mode test), tagged it as `schnake/nginx:1.14-alpine`, pushed to the public dockerhub and ran the test again (setting the yaml/flag as necessary). You could test with any test/image this one was just fast. It has the downside of tearing down the container though so you just look through logs and such to see what it was based on.

Otherwise we need to set up another public docker registry, secured with TLS.

**Release note**:
```release-note 
Adds support for custom registries during e2e tests via --e2e-repo-config flag.
```
