### PR TITLE
Use upstream conformance image when >= v1.13

### DIFF
--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -22,6 +22,56 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 )
 
+// TestResolveConformanceImage tests the temporary logic of ensuring that given
+// a certain string version, the proper conformance image is used (upstream
+// vs Heptio).
+func TestResolveConformanceImage(t *testing.T) {
+	tcs := []struct {
+		name             string
+		requestedVersion string
+		expected         string
+	}{
+		{
+			name:             "Comparison is lexical",
+			requestedVersion: "foo",
+			expected:         "gcr.io/heptio-images/kube-conformance",
+		}, {
+			name:             "Prior to v1.13 uses heptio and major.minor",
+			requestedVersion: "v1.12.99",
+			expected:         "gcr.io/heptio-images/kube-conformance",
+		}, {
+			name:             "v1.13 and after uses upstream and major.minor.patch",
+			requestedVersion: "v1.13.0",
+			expected:         "gcr.io/google-containers/conformance",
+		}, {
+			name:             "v1.13 and after uses upstream and major.minor.patch",
+			requestedVersion: "v1.15.1",
+			expected:         "gcr.io/google-containers/conformance",
+		}, {
+			name:             "latest should use upstream image",
+			requestedVersion: "latest",
+			expected:         "gcr.io/google-containers/conformance",
+		}, {
+			name:             "explicit version before v1.13 should use heptio image and given version",
+			requestedVersion: "v1.12+.0.alpha+",
+			expected:         "gcr.io/heptio-images/kube-conformance",
+		}, {
+			name:             "explicit version after v1.13 should use upstream and use given version",
+			requestedVersion: "v1.13+.beta2",
+			expected:         "gcr.io/google-containers/conformance",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			out := resolveConformanceImage(tc.requestedVersion)
+			if out != tc.expected {
+				t.Errorf("Expected image %q but got %q", tc.expected, out)
+			}
+		})
+	}
+}
+
 func TestGetConfig(t *testing.T) {
 	defaultPluginSearchPath := config.New().PluginSearchPath
 

--- a/cmd/sonobuoy/app/imageversion_test.go
+++ b/cmd/sonobuoy/app/imageversion_test.go
@@ -135,7 +135,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			name:          "auto retrieves server version",
 			version:       "auto",
 			serverVersion: workingServerVersion,
-			expected:      "v1.13",
+			expected:      "v1.13.0",
 		},
 		{
 			name:          "auto returns error if upstream fails",
@@ -148,7 +148,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			version:       "auto",
 			serverVersion: betaServerVersion,
 			warning:       true,
-			expected:      "v1.13",
+			expected:      "v1.13.0",
 		},
 		{
 			name:          "gke server strips plus sign",
@@ -161,6 +161,12 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			version:       "v1.11.2",
 			serverVersion: workingServerVersion,
 			expected:      "v1.11.2",
+		},
+		{
+			name:          "set version ignores server version and can be anything",
+			version:       "foo",
+			serverVersion: workingServerVersion,
+			expected:      "foo",
 		},
 		{
 			name:          "set version doesn't call server so ignores errors",
@@ -214,6 +220,8 @@ func TestGetConformanceImageVersion(t *testing.T) {
 	}
 }
 
+// fakeServerVersionInterface is used as a test implementation as
+// discovery.ServerVersionInterface.
 type fakeServerVersionInterface struct {
 	err     error
 	version version.Info

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/heptio/sonobuoy/pkg/plugin"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -32,6 +32,9 @@ const (
 
 	// DefaultKubeConformanceImageURL is the URL of the docker image to run for the kube conformance tests.
 	DefaultKubeConformanceImageURL = "gcr.io/heptio-images/kube-conformance"
+	// UpstreamKubeConformanceImageURL is the URL of the docker image to run for
+	// the kube conformance tests which is maintained by upstream Kubernetes.
+	UpstreamKubeConformanceImageURL = "gcr.io/google-containers/conformance"
 	// DefaultKubeConformanceImageTag is the default tag of the conformance image
 	DefaultKubeConformanceImageTag = "latest"
 	// DefaultAggregationServerBindPort is the default port for the aggregation server to bind to.


### PR DESCRIPTION
Transition to using the upstream conformance image. They started
publishing it after v1.13.0 so for versions before that we still
need to support the heptio/kube-conformance image.

This PR adds the conditional logic for choosing the right image
as well as extends the version-getting logic so that for versions
at/after v1.13 we provide all 3 segments of the semver since
we now track exactly with each release.

Fixes #593

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
This changes Sonobuoy to use the upstream Kubernetes conformance image if: the version requested is >= v1.13, latest, or auto and the server reports a version >= v1.13.
```