### PR TITLE
Update README

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -1,0 +1,28 @@
+# Custom registries and air-gapped testing
+
+In air-gapped deployments where there is no access to the public Docker registries
+Sonobuoy supports running end-to-end tests with custom registries. This enables
+you to test your air-gapped deployment once you've loaded the necessary images
+into a registry that is reachable by your cluster.
+
+Just provide the `--e2e-repo-config` parameter and pass it the path to a local
+YAML file pointing to the registries you'd like to use. This will instruct the
+Kubernetes end-to-end suite to use your registries instead of the default ones.
+
+```
+sonobuoy run --e2e-repo-config custom-repos.yaml
+```
+
+The registry list is a YAML document specifying a few different registry
+categories and their values:
+
+```
+dockerLibraryRegistry: docker.io/library
+e2eRegistry: gcr.io/kubernetes-e2e-test-images
+gcRegistry: k8s.gcr.io
+privateRegistry: gcr.io/k8s-authenticated-test
+sampleRegistry: gcr.io/google-samples
+```
+
+The keys in that file are specified in the Kubernetes test framework itself. You
+may provide a subset of those and the defaults will be used for the others.

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -1,0 +1,19 @@
+# Customization
+
+Sonobuoy provides many flags to customize your run but sometimes you have a special use case that isn't supported yet.  For these cases, Sonobuoy provides `sonobuoy gen`.
+
+The command `sonobuoy gen` will print the YAML for your run to stdout instead of actually creating it. It accepts all of the relevant flags for customizing the run just like `sonobuoy run` would. You can then edit it yourself and apply it as if Sonobuoy had run it.
+
+Output the YAML Sonobuoy would create to a file:
+```
+sonobuoy gen --e2e-focus="sig-networking" --e2e-skip="Alpha" > sonobuoy.yaml
+```
+
+Then manually modify it as necessary. Maybe you need special options for plugins or want your own sidecar to be running with the images.
+
+Finally, create the resources yourself via kubectl.
+```
+kubectl apply -f sonobuoy.yaml
+```
+
+> Note: If you find that you need this flow to accomplish your work, talk to us about it in our [Slack][slack] channel or file an [issue][issue] in Github. Others may have the same need and we'd love to help support you.

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -1,5 +1,6 @@
 # Sonobuoy Snapshot Layout
 
+- [Retrieving results](#retrieving-results)
 - [Filename](#filename)
 - [Contents](#contents)
 	- [/hosts](#hosts)
@@ -11,7 +12,30 @@
 	- [/serverversion.json](#serverversionjson)
 - [File formats](#file-formats)
 
-This document describes the standard layout of a Sonobuoy results tarball, how it is formatted, and how data is named and laid out.
+This document describes retrieving the Sonobuoy results tarball, its layout, how it is formatted, and how data is named and laid out.
+
+## Retrieving results
+
+To view the output, copy the output directory from the aggregator Sonobuoy pod to
+your local machine (and save the name of the file to a variable for reference):
+```
+output=$(sonobuoy retrieve)
+```
+
+The results can be inspected without being extracted. It will list the number of tests failed and their names:
+```
+sonobuoy e2e $output
+```
+
+You can also extract the output locally so that you can view the other
+information Sonobuoy gathered as well:
+ - detailed plugin results
+ - pod logs
+ - query results about the contents/state of your cluster
+
+```
+mkdir ./results; tar xzf $output -C ./results
+```
 
 ## Filename
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the README in a number of ways:
 - Adds more details about quick mode which is often
used not but front and center in the README
 - Adds improved script lines which take advantate
of --wait options and capturing the filename from
retrieve
 - Adds information regarding `sonobuoy gen` which is the
best workaround whenever Sonobuoy lacks functionality users
need. Slack is usually full of questions where the answer is:
use `sonobuoy gen` and `kubectl apply`
 - Moves the link definitions to a central location at the
bottom of the file.
 - Removes prefix from code lines to improve copy/paste use
 - Clarifies installation can also be from binary which
doesnt require Go and that kubectl isn't required except in
some workflows

**Which issue(s) this PR fixes**
Fixes #614

**Special notes for your reviewer**:

**Release note**:
```
N/A
```
