### PR TITLE
Default to 'auto' for gen command

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -73,25 +73,18 @@ func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
 }
 
 // AddKubeConformanceImageVersion initialises an image version flag.
-func AddKubeConformanceImageVersion(imageVersion *ConformanceImageVersion, flags *pflag.FlagSet, defaultVersion ConformanceImageVersion) {
-	help := "Use Heptio's KubeConformance image, but override the version. "
-	switch defaultVersion {
-	case ConformanceImageVersionAuto:
-		help += "Default is 'auto', which will be set to your cluster's version."
-	case ConformanceImageVersionLatest:
-		help += "Default is 'latest', which will run the tests for the most recently released Sonobuoy conformance image."
-	default:
-		help += fmt.Sprintf("Default is '%s'", defaultVersion)
-	}
+func AddKubeConformanceImageVersion(imageVersion *ConformanceImageVersion, flags *pflag.FlagSet) {
+	help := "Use default Conformance image, but override the version. "
+	help += fmt.Sprintf("Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise.")
 
-	*imageVersion = defaultVersion // default
+	*imageVersion = ConformanceImageVersionAuto
 	flags.Var(imageVersion, "kube-conformance-image-version", help)
 }
 
 // AddKubeconfigFlag adds a kubeconfig flag to the provided command.
 func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	// The default is the empty string (look in the environment)
-	flags.Var(cfg, "kubeconfig", "Path to explict kubeconfig file.")
+	flags.Var(cfg, "kubeconfig", "Path to explicit kubeconfig file.")
 }
 
 // AddSonobuoyConfigFlag adds a SonobuoyConfig flag to the provided command.

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -54,7 +54,7 @@ type genFlags struct {
 
 var genflags genFlags
 
-func GenFlagSet(cfg *genFlags, rbac RBACMode, version ConformanceImageVersion) *pflag.FlagSet {
+func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	genset := pflag.NewFlagSet("generate", pflag.ExitOnError)
 	AddModeFlag(&cfg.mode, genset)
 	AddSonobuoyConfigFlag(&cfg.sonobuoyConfig, genset)
@@ -66,7 +66,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode, version ConformanceImageVersion) *
 	AddNamespaceFlag(&cfg.namespace, genset)
 	AddSonobuoyImage(&cfg.sonobuoyImage, genset)
 	AddKubeConformanceImage(&cfg.kubeConformanceImage, genset)
-	AddKubeConformanceImageVersion(&cfg.kubeConformanceImageVersion, genset, version)
+	AddKubeConformanceImageVersion(&cfg.kubeConformanceImageVersion, genset)
 	AddSSHKeyPathFlag(&cfg.sshKeyPath, genset)
 	AddSSHUserFlag(&cfg.sshUser, genset)
 
@@ -163,7 +163,7 @@ func NewCmdGen() *cobra.Command {
 		Run:   genManifest,
 		Args:  cobra.ExactArgs(0),
 	}
-	GenCommand.Flags().AddFlagSet(GenFlagSet(&genflags, EnabledRBACMode, ConformanceImageVersionLatest))
+	GenCommand.Flags().AddFlagSet(GenFlagSet(&genflags, EnabledRBACMode))
 	return GenCommand
 }
 

--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -208,7 +208,7 @@ func TestGetConfig(t *testing.T) {
 			// Simulate parsing of input via CLI. Making this optional to avoid complicating
 			// setup for other tests which just explicitly set the values.
 			if len(tc.cliInput) > 0 {
-				fs := GenFlagSet(tc.input, EnabledRBACMode, ConformanceImageVersionLatest)
+				fs := GenFlagSet(tc.input, EnabledRBACMode)
 				if err := fs.Parse(strings.Split(tc.cliInput, " ")); err != nil {
 					t.Fatalf("Failed to parse CLI input %q: %v", tc.cliInput, err)
 				}

--- a/cmd/sonobuoy/app/imageversion.go
+++ b/cmd/sonobuoy/app/imageversion.go
@@ -67,7 +67,7 @@ func (c *ConformanceImageVersion) Set(str string) error {
 
 // Get retrieves the preset version if there is one, or queries client if the ConformanceImageVersion is set to `auto`.
 // kubernetes.Interface.Discovery() provides ServerVersionInterface.
-// don't require the entire kubernetes.Interface to simplify the required test mocks
+// Don't require the entire kubernetes.Interface to simplify the required test mocks
 func (c *ConformanceImageVersion) Get(client discovery.ServerVersionInterface) (string, error) {
 	if *c == ConformanceImageVersionAuto {
 		if client == nil {

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -41,7 +41,7 @@ var runflags runFlags
 func RunFlagSet(cfg *runFlags) *pflag.FlagSet {
 	runset := pflag.NewFlagSet("run", pflag.ExitOnError)
 	// Default to detect since we need kubeconfig regardless
-	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode, ConformanceImageVersionAuto))
+	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode))
 	AddSkipPreflightFlag(&cfg.skipPreflight, runset)
 	AddRunWaitFlag(&cfg.wait, runset)
 	return runset


### PR DESCRIPTION
**What this PR does / why we need it**:
There exists a bifurcation in the kube-conformance logic
which is unintuitive and potentially damaging to the user
experience.

Currently, if they use sonobuoy gen the kube-conformance
version is defaulted to `latest` but if they use sonobuoy run
it is defaulted to `auto`. The problem is that one may work
on a cluster while the other will not: leaving users in a
situation where run will work but gen -> kubectl apply will
not without an indication why.

This change causes the two to be in sync. The downside is that
there are cases where you may run sonobuoy gen without a
current KUBECONFIG, so now sonobuoy gen will fail.

The error is descriptive and the workaround is to provide the
image version you want explicitly rather than falling back to
latest implicitly.

I think this is preferred behavior, since some users would have
already been broken with the existing logic.

**Which issue(s) this PR fixes**
Fixes: #619

**Special notes for your reviewer**:
I had thought the gen/run difference would have been because the logic was buried in a way which made it difficult to merge into one. However, gen already has the required logic and it was just a matter of defaults.

As the commit notes; it will cause _different_ users to fail:
 - running gen without access to a cluster will cause failure instead of defaulting to latest
 - you will not, however, generate a YAML which will fail because you are not compatible with `latest`

**Release note**:
```
sonobuoy gen will now fail if you can't reach a cluster. This is deliberate as an alternative to defaulting to latest which will cause older clusters to fail in a less clear way.
```
