### PR TITLE
Show list of images used for upstream Kubernetes E2E tests

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/heptio/sonobuoy/pkg/image"
+
 	"gopkg.in/yaml.v2"
 
 	ops "github.com/heptio/sonobuoy/pkg/client"
@@ -34,6 +36,7 @@ const (
 	namespaceFlag       = "namespace"
 	sonobuoyImageFlag   = "sonobuoy-image"
 	imagePullPolicyFlag = "image-pull-policy"
+	pluginFlag          = "plugin"
 )
 
 // AddNamespaceFlag initialises a namespace flag.
@@ -73,11 +76,11 @@ func AddKubeConformanceImage(image *string, flags *pflag.FlagSet) {
 }
 
 // AddKubeConformanceImageVersion initialises an image version flag.
-func AddKubeConformanceImageVersion(imageVersion *ConformanceImageVersion, flags *pflag.FlagSet) {
+func AddKubeConformanceImageVersion(imageVersion *image.ConformanceImageVersion, flags *pflag.FlagSet) {
 	help := "Use default Conformance image, but override the version. "
 	help += fmt.Sprintf("Default is 'auto', which will be set to your cluster's version if detected, erroring otherwise.")
 
-	*imageVersion = ConformanceImageVersionAuto
+	*imageVersion = image.ConformanceImageVersionAuto
 	flags.Var(imageVersion, "kube-conformance-image-version", help)
 }
 
@@ -85,6 +88,12 @@ func AddKubeConformanceImageVersion(imageVersion *ConformanceImageVersion, flags
 func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	// The default is the empty string (look in the environment)
 	flags.Var(cfg, "kubeconfig", "Path to explicit kubeconfig file.")
+}
+
+// AddPluginFlag describes which plugin's images to interact with
+func AddPluginFlag(cfg *string, flags *pflag.FlagSet) {
+	// The default is 'e2e' since it's the only plugin enabled at the moment
+	flags.StringVarP(cfg, pluginFlag, "p", "e2e", "Describe which plugin's images to interact (Valid plugins are 'e2e').")
 }
 
 // AddSonobuoyConfigFlag adds a SonobuoyConfig flag to the provided command.

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	imagepkg "github.com/heptio/sonobuoy/pkg/image"
+
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/errlog"
@@ -41,7 +43,7 @@ type genFlags struct {
 	kubeConformanceImage        string
 	sshKeyPath                  string
 	sshUser                     string
-	kubeConformanceImageVersion ConformanceImageVersion
+	kubeConformanceImageVersion imagepkg.ConformanceImageVersion
 	imagePullPolicy             ImagePullPolicy
 	e2eRepoList                 string
 
@@ -113,7 +115,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		// if discoveryClient is needed, ErrImageVersionNoClient will be returned and that error can be reported back up
 		imageVersion, err := g.kubeConformanceImageVersion.Get(discoveryClient)
 		if err != nil {
-			if errors.Cause(err) == ErrImageVersionNoClient {
+			if errors.Cause(err) == imagepkg.ErrImageVersionNoClient {
 				return nil, errors.Wrap(err, kubeError.Error())
 			}
 			return nil, err
@@ -147,7 +149,7 @@ func resolveConformanceImage(imageVersion string) string {
 	// image instead of our own heptio/kube-conformance one. They started
 	// publishing it for v1.13.
 	switch {
-	case imageVersion == ConformanceImageVersionLatest:
+	case imageVersion == imagepkg.ConformanceImageVersionLatest:
 		return config.UpstreamKubeConformanceImageURL
 	case imageVersion < "v1.13":
 		return config.DefaultKubeConformanceImageURL

--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/heptio/sonobuoy/pkg/image"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var imagesflags imagesFlags
+
+type imagesFlags struct {
+	e2eRegistryConfig string
+	plugin            string
+	kubeconfig        Kubeconfig
+
+	imagesflags *pflag.FlagSet
+}
+
+func ImagesFlagSet(cfg *imagesFlags) *pflag.FlagSet {
+	flagset := pflag.NewFlagSet("images", pflag.ExitOnError)
+	AddPluginFlag(&cfg.plugin, flagset)
+	AddKubeconfigFlag(&cfg.kubeconfig, flagset)
+	cfg.imagesflags = flagset
+	return flagset
+}
+
+func NewCmdImages() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Manage images used in a plugin. Supported plugins are: 'e2e'",
+		Run:   getImages,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().AddFlagSet(ImagesFlagSet(&imagesflags))
+	return cmd
+}
+
+func getImages(cmd *cobra.Command, args []string) {
+
+	switch imagesflags.plugin {
+	case "e2e":
+
+		cfg, err := imagesflags.kubeconfig.Get()
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
+			os.Exit(1)
+		}
+
+		sbc, err := getSonobuoyClient(cfg)
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
+			os.Exit(1)
+		}
+
+		version, err := sbc.Version()
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "couldn't get Sonobuoy client"))
+			os.Exit(1)
+		}
+
+		// Get list of images that match the version
+		registry, err := image.NewRegistryList("", version)
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "couldn't init Registry List"))
+			os.Exit(1)
+		}
+
+		images, err := registry.GetImageConfigs()
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "couldn't get images for version"))
+			os.Exit(1)
+		}
+
+		for _, v := range images {
+			fmt.Println(v.GetE2EImage())
+		}
+	default:
+		errlog.LogError(errors.Errorf("Unsupported plugin: %v", imagesflags.plugin))
+		os.Exit(1)
+	}
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"flag"
+
 	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +44,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdRetrieve())
 	cmds.AddCommand(NewCmdRun())
 	cmds.AddCommand(NewCmdGenPlugin())
+	cmds.AddCommand(NewCmdImages())
 
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	cmds.PersistentFlags().BoolVarP(&errlog.DebugOutput, "debug", "d", false, "Enable debug output (includes stack traces)")

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"os"
+
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/pkg/errors"
+)
+
+// Version gets the Kubernetes API version
+func (c *SonobuoyClient) Version() (string, error) {
+
+	// Init client
+	client, err := c.Client()
+	if err != nil {
+		errlog.LogError(err)
+		os.Exit(1)
+	}
+
+	// Get Version
+	version, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return "", errors.Wrap(err, "couldn't retrieve server version")
+	}
+
+	return version.GitVersion, nil
+}

--- a/pkg/image/imageversion.go
+++ b/pkg/image/imageversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package image
 
 import (
 	"fmt"

--- a/pkg/image/imageversion_test.go
+++ b/pkg/image/imageversion_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package image
 
 import (
 	"io/ioutil"

--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE: This is manually replicated from: https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go
+
+package image
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	version "github.com/hashicorp/go-version"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// RegistryList holds public and private image registries
+type RegistryList struct {
+	DockerLibraryRegistry string `yaml:"dockerLibraryRegistry"`
+	E2eRegistry           string `yaml:"e2eRegistry"`
+	EtcdRegistry          string `yaml:"etcdRegistry"`
+	GcRegistry            string `yaml:"gcRegistry"`
+	PrivateRegistry       string `yaml:"privateRegistry"`
+	SampleRegistry        string `yaml:"sampleRegistry"`
+
+	K8sVersion *version.Version
+	Images     map[int]Config
+}
+
+// Config holds an images registry, name, and version
+type Config struct {
+	registry string
+	name     string
+	version  string
+}
+
+// NewRegistryList returns a default registry or one that matches a config file passed
+func NewRegistryList(repoConfig, k8sVersion string) (*RegistryList, error) {
+	registry := &RegistryList{
+		DockerLibraryRegistry: "docker.io/library",
+		E2eRegistry:           "gcr.io/kubernetes-e2e-test-images",
+		EtcdRegistry:          "quay.io/coreos",
+		GcRegistry:            "k8s.gcr.io",
+		PrivateRegistry:       "gcr.io/k8s-authenticated-test",
+		SampleRegistry:        "gcr.io/google-samples",
+	}
+
+	// Load in a config file
+	if repoConfig != "" {
+
+		fileContent, err := ioutil.ReadFile(repoConfig)
+		if err != nil {
+			panic(fmt.Errorf("Error reading '%v' file contents: %v", repoConfig, err))
+		}
+
+		err = yaml.Unmarshal(fileContent, &registry)
+		if err != nil {
+			panic(fmt.Errorf("Error unmarshalling '%v' YAML file: %v", repoConfig, err))
+		}
+	}
+
+	// Init images for k8s version & repos configured
+	version, err := validateVersion(k8sVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	registry.K8sVersion = version
+
+	return registry, nil
+}
+
+// GetImageConfigs returns the map of imageConfigs
+func (r *RegistryList) GetImageConfigs() (map[string]Config, error) {
+	switch r.K8sVersion.Segments()[0] {
+	case 1:
+		switch r.K8sVersion.Segments()[1] {
+		case 13:
+			return r.v1_13(), nil
+		}
+	}
+	return map[string]Config{}, fmt.Errorf("No matching configuration for k8s version: %v", r.K8sVersion)
+}
+
+// GetE2EImage returns the fully qualified URI to an image (including version)
+func (i *Config) GetE2EImage() string {
+	return fmt.Sprintf("%s/%s:%s", i.registry, i.name, i.version)
+}

--- a/pkg/image/v1.13.go
+++ b/pkg/image/v1.13.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE: This is manually replicated from: https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go
+
+package image
+
+func (r *RegistryList) v1_13() map[string]Config {
+
+	e2eRegistry := r.E2eRegistry
+	dockerLibraryRegistry := r.DockerLibraryRegistry
+	sampleRegistry := r.SampleRegistry
+	etcdRegistry := r.EtcdRegistry
+	gcRegistry := r.GcRegistry
+
+	configs := map[string]Config{}
+	configs["CRDConversionWebhook"] = Config{e2eRegistry, "crd-conversion-webhook", "1.13rev2"}
+	configs["AdmissionWebhook"] = Config{e2eRegistry, "webhook", "1.14v1"}
+	configs["APIServer"] = Config{e2eRegistry, "sample-apiserver", "1.10"}
+	configs["AppArmorLoader"] = Config{e2eRegistry, "apparmor-loader", "1.0"}
+	configs["AuditProxy"] = Config{e2eRegistry, "audit-proxy", "1.0"}
+	configs["BusyBox"] = Config{dockerLibraryRegistry, "busybox", "1.29"}
+	configs["CheckMetadataConcealment"] = Config{e2eRegistry, "metadata-concealment", "1.2"}
+	configs["CudaVectorAdd"] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
+	configs["CudaVectorAdd2"] = Config{e2eRegistry, "cuda-vector-add", "2.0"}
+	configs["Dnsutils"] = Config{e2eRegistry, "dnsutils", "1.1"}
+	configs["EchoServer"] = Config{e2eRegistry, "echoserver", "2.2"}
+	configs["EntrypointTester"] = Config{e2eRegistry, "entrypoint-tester", "1.0"}
+	configs["Etcd"] = Config{etcdRegistry, "etcd", "v3.3.10"}
+	configs["Fakegitserver"] = Config{e2eRegistry, "fakegitserver", "1.0"}
+	configs["GBFrontend"] = Config{sampleRegistry, "gb-frontend", "v6"}
+	configs["GBRedisSlave"] = Config{sampleRegistry, "gb-redisslave", "v3"}
+	configs["Hostexec"] = Config{e2eRegistry, "hostexec", "1.1"}
+	configs["IpcUtils"] = Config{e2eRegistry, "ipc-utils", "1.0"}
+	configs["Iperf"] = Config{e2eRegistry, "iperf", "1.0"}
+	configs["JessieDnsutils"] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
+	configs["Kitten"] = Config{e2eRegistry, "kitten", "1.0"}
+	configs["Liveness"] = Config{e2eRegistry, "liveness", "1.0"}
+	configs["LogsGenerator"] = Config{e2eRegistry, "logs-generator", "1.0"}
+	configs["Mounttest"] = Config{e2eRegistry, "mounttest", "1.0"}
+	configs["MounttestUser"] = Config{e2eRegistry, "mounttest-user", "1.0"}
+	configs["Nautilus"] = Config{e2eRegistry, "nautilus", "1.0"}
+	configs["Net"] = Config{e2eRegistry, "net", "1.0"}
+	configs["Netexec"] = Config{e2eRegistry, "netexec", "1.1"}
+	configs["Nettest"] = Config{e2eRegistry, "nettest", "1.0"}
+	configs["Nginx"] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
+	configs["NginxNew"] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
+	configs["Nonewprivs"] = Config{e2eRegistry, "nonewprivs", "1.0"}
+	configs["NoSnatTest"] = Config{e2eRegistry, "no-snat-test", "1.0"}
+	configs["NoSnatTestProxy"] = Config{e2eRegistry, "no-snat-test-proxy", "1.0"}
+	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
+	configs["Pause"] = Config{gcRegistry, "pause", "3.1"}
+	configs["Porter"] = Config{e2eRegistry, "porter", "1.0"}
+	configs["PortForwardTester"] = Config{e2eRegistry, "port-forward-tester", "1.0"}
+	configs["Redis"] = Config{e2eRegistry, "redis", "1.0"}
+	configs["ResourceConsumer"] = Config{e2eRegistry, "resource-consumer", "1.5"}
+	configs["ResourceController"] = Config{e2eRegistry, "resource-consumer/controller", "1.0"}
+	configs["ServeHostname"] = Config{e2eRegistry, "serve-hostname", "1.1"}
+	configs["TestWebserver"] = Config{e2eRegistry, "test-webserver", "1.0"}
+	configs["VolumeNFSServer"] = Config{e2eRegistry, "volume/nfs", "1.0"}
+	configs["VolumeISCSIServer"] = Config{e2eRegistry, "volume/iscsi", "1.0"}
+	configs["VolumeGlusterServer"] = Config{e2eRegistry, "volume/gluster", "1.0"}
+	configs["VolumeRBDServer"] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
+	return configs
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to see what images are used in upstream e2e tests by adding a new command: `images e2e`.

**Which issue(s) this PR fixes**
- Fixes #604

**Release note**:
```
release-note: Adds a new command `images e2e` which shows all upstream images used for E2E plugin tests. 

```
Signed-off-by: Steve Sloka <slokas@vmware.com>

