### PR TITLE
Add missing registry entry for airgap example

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -20,6 +20,7 @@ categories and their values:
 dockerLibraryRegistry: docker.io/library
 e2eRegistry: gcr.io/kubernetes-e2e-test-images
 gcRegistry: k8s.gcr.io
+etcdRegistry: quay.io/coreos
 privateRegistry: gcr.io/k8s-authenticated-test
 sampleRegistry: gcr.io/google-samples
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
The etcd registry was missing from the example so if users would use it as a base, the etcd image would not get updated properly. This just updates to make the examples whole. 

Signed-off-by: Steve Sloka <slokas@vmware.com>