### PR TITLE
Replace alpine with debian-slim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.12.0-alpine3.9
+BUILD_IMAGE ?= golang:1.12.1-stretch
+AMD_IMAGE ?= debian:stretch-slim
+ARM_IMAGE ?= arm64v8/ubuntu:16.04
 
 TESTARGS ?= $(VERBOSE_FLAG) -timeout 60s
 TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
@@ -101,13 +103,13 @@ build_container:
 container: sonobuoy
 	for arch in $(LINUX_ARCH); do \
 		if [ $$arch = amd64 ]; then \
-			sed -e 's|BASEIMAGE|alpine:3.7|g' \
-			-e 's|CMD1|RUN apk add --no-cache ca-certificates bash|g' \
+			sed -e 's|BASEIMAGE|$(AMD_IMAGE)|g' \
+			-e 's|CMD1||g' \
 			-e 's|BINARY|build/linux/amd64/sonobuoy|g' Dockerfile > Dockerfile-$$arch; \
 			$(MAKE) build_container DOCKERFILE=Dockerfile-$$arch; \
 			$(MAKE) build_container DOCKERFILE="Dockerfile-$$arch" TARGET="sonobuoy-$$arch"; \
 	elif [ $$arch = arm64 ]; then \
-			sed -e 's|BASEIMAGE|arm64v8/ubuntu:16.04|g' \
+			sed -e 's|BASEIMAGE|$(ARM_IMAGE)|g' \
 			-e 's|CMD1||g' \
 			-e 's|BINARY|build/linux/arm64/sonobuoy|g' Dockerfile > Dockerfile-$$arch; \
 			$(MAKE) build_container DOCKERFILE="Dockerfile-$$arch" TARGET="sonobuoy-$$arch"; \


### PR DESCRIPTION
Updates the images we use when building Sonobuoy.
For the build image this also updates go from
1.12.0 to 1.12.1.

Due to the fact that golang doesnt offer a
stretch-slim image, the 1.12.1 stretch image
is used.

Stretch slim seems to come with what it needs
so the dockerfile CMD1 can just be removed. For
ease of future changes I left the CMD1 in place and,
just like on arm64, we just remove the line rather
than replace it.

Fixes #609

Signed-off-by: John Schnake <jschnake@vmware.com>
