### PR TITLE
Use default image for worker

### DIFF
--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/plugin"
@@ -89,8 +90,8 @@ func TestGetConfig(t *testing.T) {
 			},
 			expected: &config.Config{
 				Namespace:       "heptio-sonobuoy",
-				WorkerImage:     "gcr.io/heptio-images/sonobuoy:latest",
-				ImagePullPolicy: "Always", // default
+				WorkerImage:     "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version,
+				ImagePullPolicy: "IfNotPresent", // default
 				PluginSelections: []plugin.Selection{
 					plugin.Selection{Name: "e2e"},
 					plugin.Selection{Name: "systemd-logs"},
@@ -113,8 +114,8 @@ func TestGetConfig(t *testing.T) {
 			},
 			expected: &config.Config{
 				Namespace:       "heptio-sonobuoy",
-				WorkerImage:     "gcr.io/heptio-images/sonobuoy:latest",
-				ImagePullPolicy: "Always", // default
+				WorkerImage:     "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version,
+				ImagePullPolicy: "IfNotPresent", // default
 				PluginSelections: []plugin.Selection{
 					plugin.Selection{Name: "e2e"},
 				},
@@ -141,8 +142,8 @@ func TestGetConfig(t *testing.T) {
 			},
 			expected: &config.Config{
 				Namespace:       "heptio-sonobuoy",
-				WorkerImage:     "gcr.io/heptio-images/sonobuoy:latest",
-				ImagePullPolicy: "Always", // default
+				WorkerImage:     "gcr.io/heptio-images/sonobuoy:" + buildinfo.Version,
+				ImagePullPolicy: "IfNotPresent", // default
 				PluginSelections: []plugin.Selection{
 					plugin.Selection{
 						Name: "systemd-logs",
@@ -161,11 +162,11 @@ func TestGetConfig(t *testing.T) {
 					Config: config.Config{Namespace: "configNS"},
 				},
 			},
-			cliInput: "--namespace=flagNS --sonobuoy-image=flagImage --image-pull-policy=IfNotPresent",
+			cliInput: "--namespace=flagNS --sonobuoy-image=flagImage --image-pull-policy=Always",
 			expected: &config.Config{
 				Namespace:       "flagNS",
 				WorkerImage:     "flagImage",
-				ImagePullPolicy: "IfNotPresent",
+				ImagePullPolicy: "Always",
 				PluginSelections: []plugin.Selection{
 					plugin.Selection{Name: "e2e"},
 					plugin.Selection{Name: "systemd-logs"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,8 @@ const (
 	MasterContainerName = "kube-sonobuoy"
 	// MasterResultsPath is the location in the main container of the master pod where results will be archived.
 	MasterResultsPath = "/tmp/sonobuoy"
+	// DefaultSonobuoyPullPolicy is the default pull policy used in the Sonobuoy config.
+	DefaultSonobuoyPullPolicy = "IfNotPresent"
 )
 
 var (
@@ -296,9 +298,8 @@ func New() *Config {
 		"~/sonobuoy/plugins.d",
 	}
 
-	// TODO (timothysc) reference the other consts
-	cfg.WorkerImage = "gcr.io/heptio-images/sonobuoy:latest"
-	cfg.ImagePullPolicy = "Always"
+	cfg.WorkerImage = DefaultImage
+	cfg.ImagePullPolicy = DefaultSonobuoyPullPolicy
 
 	return &cfg
 }


### PR DESCRIPTION
The worker's default image was using a hardcoded
value and not referencing the const that was
defined for that purpose leading to the
aggregator and worker using different images.

* Notes for reviewer
A seemingly minor problem, I worry about what some of the edge cases might be if we have different defaults there. It could lead to some awkward behavior if we have a few point releases.

I _know_ we need to also add more tests but this is a tiny bug with an obvious cause. We need to spike eventually on improving testing of gen input/output.

Fixes: #643
Signed-off-by: John Schnake <jschnake@vmware.com>