### PR TITLE
Add a short version option for scripting

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -272,3 +272,12 @@ func AddSSHUserFlag(user *string, flags *pflag.FlagSet) {
 		fmt.Sprintf("SSH user for ssh-key."),
 	)
 }
+
+// AddShortFlag adds a boolean flag to just print the Sonobuoy version and
+// nothing else. Useful in scripts.
+func AddShortFlag(flag *bool, flags *pflag.FlagSet) {
+	flags.BoolVar(
+		flag, "short", false,
+		"If true, prints just the sonobuoy version",
+	)
+}

--- a/cmd/sonobuoy/app/version.go
+++ b/cmd/sonobuoy/app/version.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
 	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ import (
 
 type versionFlags struct {
 	kubecfg Kubeconfig
+	short   bool
 }
 
 var versionflags versionFlags
@@ -39,11 +41,16 @@ func NewCmdVersion() *cobra.Command {
 	}
 
 	AddKubeconfigFlag(&versionflags.kubecfg, cmd.Flags())
+	AddShortFlag(&versionflags.short, cmd.Flags())
 
 	return cmd
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
+	if versionflags.short {
+		fmt.Println(buildinfo.Version)
+		return
+	}
 
 	fmt.Println(fmt.Sprintf("Sonobuoy Version: %s", buildinfo.Version))
 	fmt.Println(fmt.Sprintf("MinimumKubeVersion: %s", buildinfo.MinimumKubeVersion))

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -14,10 +14,11 @@ function goreleaser() {
 
 if [ ! -z "$TRAVIS_TAG" ]; then
 
-    if [ "$(./sonobuoy version)" != "$TRAVIS_TAG" ]; then
+    if [ "$(./sonobuoy version --short)" != "$TRAVIS_TAG" ]; then
         echo "sonobuoy version does not match tagged version!" >&2
-        echo "sonobuoy version is $(./sonobuoy version)" >&2
+        echo "sonobuoy short version is $(./sonobuoy version --short)" >&2
         echo "tag is $TRAVIS_TAG" >&2
+        echo "sonobuoy full version info is $(./sonobuoy version)" >&2
         exit 1
     fi
 


### PR DESCRIPTION
Our release scripts hinged on checking a version
which recent changes complicated slightly. We
need this to have a sanity check we release
the right versions.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Adds a new --short flag to the version command to just see Sonobuoy's version.
```
