### PR TITLE
Skip goreleaser validation

### DIFF
--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -22,5 +22,5 @@ if [ ! -z "$TRAVIS_TAG" ]; then
         exit 1
     fi
 
-    goreleaser
+    goreleaser --skip-validate
 fi


### PR DESCRIPTION
Testing that we've added leaves a few artifacts around
which mess up the porcelain state goreleaser wants.

For the time being we're just going to remove the
validation.

Signed-off-by: John Schnake <jschnake@vmware.com>