### PR TITLE
Add additional documentation about testing in airgap

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -5,6 +5,8 @@ Sonobuoy supports running end-to-end tests with custom registries. This enables
 you to test your air-gapped deployment once you've loaded the necessary images
 into a registry that is reachable by your cluster.
 
+## Test images
+
 Just provide the `--e2e-repo-config` parameter and pass it the path to a local
 YAML file pointing to the registries you'd like to use. This will instruct the
 Kubernetes end-to-end suite to use your registries instead of the default ones.
@@ -27,3 +29,32 @@ sampleRegistry: gcr.io/google-samples
 
 The keys in that file are specified in the Kubernetes test framework itself. You
 may provide a subset of those and the defaults will be used for the others.
+
+## Other required images
+
+The list of custom registries is consumed by the Kubernetes end-to-end tests, but outside of that there are 2 images you will need to be able to access:
+ - the sonobuoy image
+ - the conformance image
+
+To get those images into your cluster you need to pull/tag/push those images yourself:
+
+```
+PRIVATE_REG=<private registry>
+SONO_VERSION=<version of Sonobuoy you are targeting; e.g. v0.14.0>
+CLUSTER_VERSION=<version of k8s you are targeting; e.g. v1.14.0>
+
+docker pull gcr.io/google-containers/conformance:$CLUSTER_VERSION
+docker pull gcr.io/heptio-images/sonobuoy:$SONO_VERSION
+
+docker tag gcr.io/google-containers/conformance:$CLUSTER_VERSION $PRIVATE_REG/conformance:$CLUSTER_VERSION
+docker tag gcr.io/heptio-images/sonobuoy:$SONO_VERSION $PRIVATE_REG/sonobuoy:$SONO_VERSION
+
+docker push $PRIVATE_REG/conformance:$CLUSTER_VERSION
+docker push $PRIVATE_REG/sonobuoy:$SONO_VERSION
+```
+
+If you want to run the systemd_logs plugin you'll need to pull/tag/push it as well. In addition, you'll have to manually specify the image you want to use via `sonobuoy gen` -> `kubectl apply` since that image is not overridable on the CLI. The default value is: `gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest`
+
+If you do not wish to run it in your air-gapped cluster, just remove it from the list of [plugins][plugins] to be run (again, using `sonobuoy gen` -> `kubectl apply`).
+
+[plugins]: plugins.md#choosing-which-plugins-to-run

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -87,6 +87,24 @@ made available in the Sonobuoy results tarball in its original form.
 If you need additional mounts besides the default `results` mount that Sonobuoy
 always provides, you can define them in the `extra-volumes` field.
 
+#### Choosing which plugins to run
+
+All of the plugin definition files get mounted as files on the aggregator pod which runs them.
+
+The aggregator loads all the plugins it finds, but a separate list controls which plugins actually get run. There is a separate `config.json` which gets mounted on the aggregator which sets the configuration options for the aggregator. It has a field `Plugins` which is an array of plugin names. The default value includes both the e2e and systemd-logs plugin:
+
+```
+"Plugins":[{"name":"e2e"},{"name":"systemd-logs"}]
+```
+
+If you want to prevent one of those plugins from  being run, simply remove that item from the list. Likewise, if you'd like to run your own custom plugin, you need to add it to this list (in addition to adding its definition file to the plugin configmap):
+
+```
+"Plugins":[{"name":"custom-plugin"},{"name":"systemd-logs"}]
+```
+
+In either case, you use the sonobuoy [gen][gen] flow to edit the YAML and start the run with `kubectl`.
+
 ## Available Plugins
 
 The default Sonobuoy plugins are available in the `examples/plugins.d` directory in this repository.
@@ -100,6 +118,7 @@ Here's the current list:
 
 
 
+[gen]: gen.md
 [systemd]: /examples/plugins.d/systemd_logs.yaml
 [systemd-repo]: https://github.com/heptio/sonobuoy-plugin-systemd-logs
 [e2e]: /examples/plugins.d/heptio-e2e.yaml
@@ -107,4 +126,3 @@ Here's the current list:
 [guide]: conformance-testing.md#integration-with-sonobuoy 
 [bulkhead]: https://github.com/bgeesaman/sonobuoy-plugin-bulkhead/blob/master/examples/benchmark.yml
 [bench]: https://github.com/bgeesaman/sonobuoy-plugin-bulkhead
-


### PR DESCRIPTION
In addition to the test images the users need
the conformance and sonobuoy images. Created a section
showing this and also an example script for how to pull,
tag, and push the images.

Signed-off-by: John Schnake <jschnake@vmware.com>