### PR TITLE
Fix CRD query

### DIFF
--- a/cmd/sonobuoy/app/master.go
+++ b/cmd/sonobuoy/app/master.go
@@ -25,8 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"k8s.io/client-go/kubernetes"
 )
 
 var noExit bool
@@ -63,14 +61,8 @@ func runMaster(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	clientset, err := kubernetes.NewForConfig(kcfg)
-	if err != nil {
-		errlog.LogError(err)
-		os.Exit(1)
-	}
-
 	// Run Discovery (gather API data, run plugins)
-	errcount := discovery.Run(clientset, cfg)
+	errcount := discovery.Run(kcfg, cfg)
 
 	if noExit {
 		logrus.Info("no-exit was specified, sonobuoy is now blocking")


### PR DESCRIPTION
The CRD query did not have a properly formed
rest client leading to the wrong URLs being
used to query for CRDs. This resulted in an
error every Sonobuoy run on the aggregator.

This change fixes the issue in a backwards
compatible way by introducing a wrapper function
which properly handles the crdClient. The legacy
method is kept for 2 k8s release cycles just
in case someone is integrating against it. The
legacy method acts as if they had just passed
nil, or no crdClient, which will just err as
it did before.

Fixes #640

Signed-off-by: John Schnake <jschnake@vmware.com>

** Special note for reviewer **
No test added here since it is just a matter of integrating correctly with the k8s API.

To manually test this you can do the following (assuming you have a cluster up):

```
sonobuoy run --mode quick --wait
```

You can either just tail the logs or retrieve the results and look in the aggregator logs. You will see an error about failing to query CRDs.

If you do that again but with an image based on this fix:

```
sonobuoy run --mode quick --wait --sonobuoy-image=--sonobuoy-image=schnake/sonobuoy:v0.14.0-4-g7775d40-dirty
```

You will see the error goes away. If you add a CRD to your cluster you will also see it in the `resources/cluster/customresourcedefinitions` file. For an example CRD, just use `kubectl apply -f crd.yaml`

where `crd.yaml` is:
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: crontabs.stable.example.com
spec:
  group: stable.example.com
  version: v1
  scope: Namespaced
  names:
    plural: crontabs
    singular: crontab
    kind: CronTab
    shortNames:
    - ct
```

**Release note**:
```
Fixed a bug which caused CRDs to be improperly queried.
```
