### PR TITLE
Add validation to focus/skip regexp flags

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -19,6 +19,7 @@ package app
 import (
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"strings"
 
 	"github.com/heptio/sonobuoy/pkg/image"
@@ -160,6 +161,9 @@ func GetE2EConfig(mode ops.Mode, flags *pflag.FlagSet) (*ops.E2EConfig, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't retrieve focus flag")
 		}
+		if _, err := regexp.Compile(focus); err != nil {
+			return nil, errors.Wrap(err, "focus flag fails regexp validation")
+		}
 		cfg.Focus = focus
 	}
 
@@ -167,6 +171,9 @@ func GetE2EConfig(mode ops.Mode, flags *pflag.FlagSet) (*ops.E2EConfig, error) {
 		skip, err := flags.GetString(e2eSkipFlag)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't retrieve skip flag")
+		}
+		if _, err := regexp.Compile(skip); err != nil {
+			return nil, errors.Wrap(err, "skip flag fails regexp validation")
 		}
 		cfg.Skip = skip
 	}

--- a/cmd/sonobuoy/app/args_test.go
+++ b/cmd/sonobuoy/app/args_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	ops "github.com/heptio/sonobuoy/pkg/client"
+)
+
+func TestGetE2EConfig(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		mode      ops.Mode
+		flagArgs  []string
+		expect    *ops.E2EConfig
+		expectErr bool
+	}{
+		{
+			desc:     "Default",
+			mode:     "Conformance",
+			flagArgs: []string{},
+			expect: &ops.E2EConfig{
+				Focus:    `\[Conformance\]`,
+				Skip:     `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]`,
+				Parallel: "1",
+			},
+		}, {
+			desc:     "Flags settable",
+			mode:     "Conformance",
+			flagArgs: []string{"--e2e-focus=foo", "--e2e-skip=bar", "--e2e-parallel=2"},
+			expect: &ops.E2EConfig{
+				Focus:    `foo`,
+				Skip:     `bar`,
+				Parallel: "2",
+			},
+		}, {
+			desc:      "Focus regexp validated settable",
+			mode:      "Conformance",
+			flagArgs:  []string{"--e2e-focus=*"},
+			expectErr: true,
+		}, {
+			desc:      "Skip regexp validated settable",
+			mode:      "Conformance",
+			flagArgs:  []string{"--e2e-skip=*"},
+			expectErr: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ExitOnError)
+			AddE2EConfigFlags(fs)
+			fs.Parse(tC.flagArgs)
+			cfg, err := GetE2EConfig(tC.mode, fs)
+			switch {
+			case err != nil && !tC.expectErr:
+				t.Fatalf("Expected no error but got %v", err)
+			case err == nil && tC.expectErr:
+				t.Fatalf("Expected error but got none")
+			}
+
+			switch {
+			case cfg == nil && tC.expect != nil:
+				t.Fatalf("Expected value %+v but got nil", tC.expect)
+			case cfg != nil && tC.expect == nil:
+				t.Fatalf("Expected nil value but got %+v", cfg)
+			case cfg == nil && tC.expect == nil:
+				return
+			case *tC.expect != *cfg:
+				t.Errorf("Expected config %+v but got %+v", tC.expect, cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When creating a run and using the focus/skip
flags it can be common to accidently provide
an invalid regexp such as improperly escaping
certain characters or using `*` instead of
`.*` This change ensures that we are validing
and failing early to create a better user
experience.

Currently, if the user does this the sonobuoy
run will get created and the e2e plugin will
fail but you have to retrieve the output and
inspect the logs manually to see the panic
from the framework.

Fixes #615

**Release note**:
```
Added additional client-side validation of --e2e-focus and --e2e-skip flags in order to fail earlier for the user rather than having to see the plugin fail and manually find the problem in the logs.
```
