### PR TITLE
Use heptio kube-conformance image for any cluster < v1.14.1

### DIFF
--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -139,19 +139,19 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 	}, nil
 }
 
-// resolveConformanceImage maps versions before 1.13 to Heptio's image and otherwise
+// resolveConformanceImage maps versions before 1.14.0 to Heptio's image and otherwise
 // to the upstream cnoformance image. Latest is always mapped to the upstream
-// regardless. The comparison is just lexical, e.g. "foo" < "v1.13" and "zip" >
-// "v1.13". These are a-typical and not given more support at this time.
+// regardless. The comparison is just lexical, e.g. "foo" <= "v1.14.0" and "zip" >
+// "v1.14.0". These are a-typical and not given more support at this time.
 func resolveConformanceImage(imageVersion string) string {
 	// TODO(johnschnake): This logic should be temporary and is only
 	// required as we phase in the use of the upstream k8s kube-conformance
 	// image instead of our own heptio/kube-conformance one. They started
-	// publishing it for v1.13.
+	// publishing it for v1.14.1. (https://github.com/kubernetes/kubernetes/pull/76101)
 	switch {
 	case imageVersion == imagepkg.ConformanceImageVersionLatest:
 		return config.UpstreamKubeConformanceImageURL
-	case imageVersion < "v1.13":
+	case imageVersion < "v1.14.1":
 		return config.DefaultKubeConformanceImageURL
 	default:
 		return config.UpstreamKubeConformanceImageURL

--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -37,15 +37,19 @@ func TestResolveConformanceImage(t *testing.T) {
 			requestedVersion: "foo",
 			expected:         "gcr.io/heptio-images/kube-conformance",
 		}, {
-			name:             "Prior to v1.13 uses heptio and major.minor",
-			requestedVersion: "v1.12.99",
+			name:             "Prior to v1.14.0 uses heptio and major.minor",
+			requestedVersion: "v1.13.99",
 			expected:         "gcr.io/heptio-images/kube-conformance",
 		}, {
-			name:             "v1.13 and after uses upstream and major.minor.patch",
-			requestedVersion: "v1.13.0",
+			name:             "v1.14.0 uses heptio and major.minor",
+			requestedVersion: "v1.14.0",
+			expected:         "gcr.io/heptio-images/kube-conformance",
+		}, {
+			name:             "v1.14.1 and after uses upstream and major.minor.patch",
+			requestedVersion: "v1.14.1",
 			expected:         "gcr.io/google-containers/conformance",
 		}, {
-			name:             "v1.13 and after uses upstream and major.minor.patch",
+			name:             "v1.14.0 and after uses upstream and major.minor.patch",
 			requestedVersion: "v1.15.1",
 			expected:         "gcr.io/google-containers/conformance",
 		}, {
@@ -53,12 +57,12 @@ func TestResolveConformanceImage(t *testing.T) {
 			requestedVersion: "latest",
 			expected:         "gcr.io/google-containers/conformance",
 		}, {
-			name:             "explicit version before v1.13 should use heptio image and given version",
+			name:             "explicit version before v1.14.0 should use heptio image and given version",
 			requestedVersion: "v1.12+.0.alpha+",
 			expected:         "gcr.io/heptio-images/kube-conformance",
 		}, {
-			name:             "explicit version after v1.13 should use upstream and use given version",
-			requestedVersion: "v1.13+.beta2",
+			name:             "explicit version after v1.14.0 should use upstream and use given version",
+			requestedVersion: "v1.14.1",
 			expected:         "gcr.io/google-containers/conformance",
 		},
 	}

--- a/pkg/image/imageversion.go
+++ b/pkg/image/imageversion.go
@@ -89,10 +89,10 @@ func (c *ConformanceImageVersion) Get(client discovery.ServerVersionInterface) (
 		}
 
 		// Temporary logic in place to truncate auto-resolved versions while we
-		// transition to upstream. If < 1.13 return 2 segments due to lag behind
+		// transition to upstream. If < 1.14 return 2 segments due to lag behind
 		// releases. Otherwise return 3. Use the segments instead of .major and
 		// .minor because GKE's .minor is `10+` instead of `10`.
-		if segments[0] == 1 && segments[1] < 13 {
+		if segments[0] == 1 && segments[1] < 14 {
 			return fmt.Sprintf("v%d.%d", segments[0], segments[1]), nil
 		}
 

--- a/pkg/image/imageversion_test.go
+++ b/pkg/image/imageversion_test.go
@@ -98,16 +98,16 @@ func TestGetConformanceImageVersion(t *testing.T) {
 	workingServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
 			Major:      "1",
-			Minor:      "13",
-			GitVersion: "v1.13.0",
+			Minor:      "14",
+			GitVersion: "v1.14.1",
 		},
 	}
 
 	betaServerVersion := &fakeServerVersionInterface{
 		version: version.Info{
 			Major:      "1",
-			Minor:      "13",
-			GitVersion: "v1.13.0-beta.2.78+e0b33dbc2bde88",
+			Minor:      "14",
+			GitVersion: "v1.14.1-beta.2.78+e0b33dbc2bde88",
 		},
 	}
 
@@ -135,7 +135,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			name:          "auto retrieves server version",
 			version:       "auto",
 			serverVersion: workingServerVersion,
-			expected:      "v1.13.0",
+			expected:      "v1.14.1",
 		},
 		{
 			name:          "auto returns error if upstream fails",
@@ -148,7 +148,7 @@ func TestGetConformanceImageVersion(t *testing.T) {
 			version:       "auto",
 			serverVersion: betaServerVersion,
 			warning:       true,
-			expected:      "v1.13.0",
+			expected:      "v1.14.1",
 		},
 		{
 			name:          "gke server strips plus sign",


### PR DESCRIPTION
**What this PR does / why we need it**:
Any cluster earlier than v1.14.1 that has failing e2e tests would crash and not give feedback to the user. The heptio kube-conformance image is used by default for these clusters. Starting with any cluster v1.14.1 the upstream conformance image will be used by default. 

**Which issue(s) this PR fixes**
- Fixes #655 

**Release note**:
```
release-note: Any cluster earlier than v1.14.1 that has failing e2e tests would crash and not give feedback to the user. The heptio kube-conformance image is used by default for these clusters. Starting with any cluster v1.14.1 the upstream conformance image will be used by default. 
```

Signed-off-by: Steve Sloka <slokas@vmware.com>
