### PR TITLE
Add `gen plugin` command to generate boilerplate for plugins

### DIFF
--- a/cmd/sonobuoy/app/envvars.go
+++ b/cmd/sonobuoy/app/envvars.go
@@ -1,0 +1,43 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+type EnvVars map[string]string
+
+func (i *EnvVars) String() string { return fmt.Sprint(map[string]string(*i)) }
+func (i *EnvVars) Type() string   { return "envvar" }
+
+func (i *EnvVars) Set(str string) error {
+	eq := strings.Index(str, "=")
+	if eq < 0 {
+		delete(map[string]string(*i), str)
+		return nil
+	}
+	keyval := strings.SplitN(str, "=", 2)
+	map[string]string(*i)[keyval[0]] = keyval[1]
+	return nil
+}
+
+// Map just casts the EnvVars to its underlying map type.
+func (i *EnvVars) Map() map[string]string {
+	return map[string]string(*i)
+}

--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -1,0 +1,146 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	v1 "k8s.io/api/core/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	defaultPluginName    = "plugin"
+	defaultPluginDriver  = "Job"
+	defaultMountPath     = "/tmp/results"
+	defaultMountName     = "results"
+	defaultMountReadOnly = false
+)
+
+// GenPluginDefConfig are the input options for running
+type GenPluginDefConfig struct {
+	def manifest.Manifest
+
+	// env holds the values that will be parsed into the manifest env vars.
+	env EnvVars
+
+	// driver holds the values that will be parsed into the plugin driver.
+	// Allows validation during flag parsing by having a custom type.
+	driver pluginDriver
+}
+
+// NewCmdGenPluginDef ...
+func NewCmdGenPluginDef() *cobra.Command {
+	genPluginOpts := GenPluginDefConfig{
+		def: defaultManifest(),
+		env: map[string]string{},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Generates the manifest Sonobuoy uses to define a plugin",
+		Run:   genPluginDefWrapper(&genPluginOpts),
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.Flags().StringVarP(
+		&genPluginOpts.def.SonobuoyConfig.PluginName, "name", "n", "",
+		"Plugin name",
+	)
+	cmd.MarkFlagRequired("name")
+
+	cmd.Flags().VarP(
+		&genPluginOpts.driver, "type", "t",
+		"Plugin Driver (job or daemonset)",
+	)
+
+	cmd.Flags().StringVarP(
+		&genPluginOpts.def.Spec.Image, "image", "i", "",
+		"Plugin image",
+	)
+	cmd.MarkFlagRequired("image")
+
+	cmd.Flags().StringArrayVarP(
+		&genPluginOpts.def.Spec.Command, "cmd", "c", []string{"./run.sh"},
+		"Command to run when starting the plugin's container",
+	)
+
+	cmd.Flags().VarP(
+		&genPluginOpts.env, "env", "e",
+		"Env var values to set on the image (e.g. --env FOO=bar)",
+	)
+
+	return cmd
+}
+
+// defaultManifest returns the basic manifest the user's options will be placed
+// on top of.
+func defaultManifest() manifest.Manifest {
+	m := manifest.Manifest{}
+	m.Spec.Name = defaultPluginName
+	m.SonobuoyConfig.Driver = defaultPluginDriver
+	m.Spec.VolumeMounts = []v1.VolumeMount{
+		v1.VolumeMount{
+			MountPath: defaultMountPath,
+			Name:      defaultMountName,
+			ReadOnly:  defaultMountReadOnly,
+		},
+	}
+	return m
+}
+
+// genPluginDefWrapper returns a closure around a given *GenPluginDefConfig that
+// will adhere to the method signature needed by cobra. It prints the result of
+// the action or logs an error and exits with non-zero status.
+func genPluginDefWrapper(cfg *GenPluginDefConfig) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		s, err := genPluginDef(cfg)
+		if err != nil {
+			errlog.LogError(err)
+			os.Exit(1)
+		}
+		fmt.Println(string(s))
+	}
+}
+
+// genPluginDef returns the YAML for the plugin which Sonobuoy would expect as
+// a configMap in order to run/gen a typical run.
+func genPluginDef(cfg *GenPluginDefConfig) ([]byte, error) {
+	// Result type just duplicates the name in most cases.
+	cfg.def.SonobuoyConfig.ResultType = cfg.def.SonobuoyConfig.PluginName
+
+	// Copy the validated value to the actual field.
+	cfg.def.SonobuoyConfig.Driver = cfg.driver.String()
+
+	// Add env vars to the container spec.
+	cfg.def.Spec.Env = []v1.EnvVar{}
+	for k, v := range cfg.env.Map() {
+		cfg.def.Spec.Env = append(cfg.def.Spec.Env, v1.EnvVar{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	yaml, err := kuberuntime.Encode(manifest.Encoder, &cfg.def)
+	return yaml, errors.Wrap(err, "serializing as YAML")
+}

--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+
+	 Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"testing"
+
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
+	v1 "k8s.io/api/core/v1"
+)
+
+var update = flag.Bool("update", false, "update .golden files")
+
+func TestPluginGenDef(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		cfg        GenPluginDefConfig
+		expectFile string
+		expectErr  string
+	}{
+		{
+			desc: "Container fields",
+			cfg: GenPluginDefConfig{
+				def: manifest.Manifest{
+					Spec: manifest.Container{
+						Container: v1.Container{
+							Name:    "n",
+							Image:   "img",
+							Command: []string{"/bin/sh", "-c", "./run.sh"},
+						},
+					},
+				},
+			},
+			expectFile: "testdata/pluginDef-container.golden",
+		}, {
+			desc: "Env vars",
+			cfg: GenPluginDefConfig{
+				def: manifest.Manifest{},
+				env: map[string]string{"FOO": "bar", "FIZZ": "buzz"},
+			},
+			expectFile: "testdata/pluginDef-env.golden",
+		}, {
+			desc: "Sonobuoy config",
+			cfg: GenPluginDefConfig{
+				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{
+						Driver:     "overridden by validated value",
+						PluginName: "n",
+					},
+				},
+				driver: "Job",
+			},
+			expectFile: "testdata/pluginDef-sonoconfig.golden",
+		}, {
+			// The serialization is really handled by go-yaml/yaml so this
+			// test is mainly just for doc/sanity check. The rules for YAML
+			// quoting are complex and I'm glad its not our responsibility.
+			desc: "Strings with special chars should be quoted",
+			cfg: GenPluginDefConfig{
+				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{
+						Driver:     "overridden by validated value",
+						PluginName: "n",
+					},
+					Spec: manifest.Container{
+						Container: v1.Container{
+							Name:    "n - foo",
+							Image:   "img:v1",
+							Command: []string{"/bin/sh", "- c", "./run.sh"},
+						},
+					},
+				},
+				env: map[string]string{"FOO": "- bar", "FIZZ": "buzz"},
+			},
+			expectFile: "testdata/pluginDef-quotes.golden",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			manifest, err := genPluginDef(&tC.cfg)
+			if err != nil {
+				if len(tC.expectErr) == 0 {
+					t.Fatalf("Expected nil error but got %v", err)
+				}
+				if err.Error() != tC.expectErr {
+					t.Fatalf("Expected error %q but got %q", err, tC.expectErr)
+				}
+			}
+
+			if *update {
+				ioutil.WriteFile(tC.expectFile, manifest, 0666)
+			} else {
+				fileData, err := ioutil.ReadFile(tC.expectFile)
+				if err != nil {
+					t.Fatalf("Failed to read golden file %v: %v", tC.expectFile, err)
+				}
+				if !bytes.Equal(fileData, manifest) {
+					t.Errorf("Expected manifest to equal goldenfile: %v but instead got:\n\n%v", tC.expectFile, string(manifest))
+				}
+			}
+		})
+	}
+}

--- a/cmd/sonobuoy/app/plugindriver.go
+++ b/cmd/sonobuoy/app/plugindriver.go
@@ -1,0 +1,42 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+type pluginDriver string
+
+var driverMap = map[string]pluginDriver{
+	string("job"):       pluginDriver("Job"),
+	string("daemonset"): pluginDriver("DaemonSet"),
+}
+
+func (d *pluginDriver) String() string { return string(*d) }
+func (d *pluginDriver) Type() string   { return "pluginDriver" }
+
+func (d *pluginDriver) Set(str string) error {
+	lcase := strings.ToLower(str)
+	driver, ok := driverMap[lcase]
+	if !ok {
+		return fmt.Errorf("unknown plugin driver %q", str)
+	}
+	*d = driver
+	return nil
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -35,7 +35,11 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdMaster())
 	cmds.AddCommand(NewCmdDelete())
 	cmds.AddCommand(NewCmdE2E())
-	cmds.AddCommand(NewCmdGen())
+
+	gen := NewCmdGen()
+	gen.AddCommand(NewCmdGenPluginDef())
+	cmds.AddCommand(gen)
+
 	cmds.AddCommand(NewCmdLogs())
 	cmds.AddCommand(NewCmdGenPlugin())
 	cmds.AddCommand(NewCmdVersion())

--- a/cmd/sonobuoy/app/testdata/pluginDef-container.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-container.golden
@@ -1,0 +1,12 @@
+sonobuoy-config:
+  driver: ""
+  plugin-name: ""
+  result-type: ""
+spec:
+  command:
+  - /bin/sh
+  - -c
+  - ./run.sh
+  image: img
+  name: "n"
+  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-env.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-env.golden
@@ -1,0 +1,12 @@
+sonobuoy-config:
+  driver: ""
+  plugin-name: ""
+  result-type: ""
+spec:
+  env:
+  - name: FOO
+    value: bar
+  - name: FIZZ
+    value: buzz
+  name: ""
+  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
@@ -1,0 +1,17 @@
+sonobuoy-config:
+  driver: ""
+  plugin-name: "n"
+  result-type: "n"
+spec:
+  command:
+  - /bin/sh
+  - '- c'
+  - ./run.sh
+  env:
+  - name: FOO
+    value: '- bar'
+  - name: FIZZ
+    value: buzz
+  image: img:v1
+  name: n - foo
+  resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-sonoconfig.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-sonoconfig.golden
@@ -1,0 +1,7 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: "n"
+  result-type: "n"
+spec:
+  name: ""
+  resources: {}

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/daemonset"
@@ -124,10 +125,10 @@ func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolic
 		Spec:         def.Spec,
 	}
 
-	switch def.SonobuoyConfig.Driver {
-	case "Job":
+	switch strings.ToLower(def.SonobuoyConfig.Driver) {
+	case "job":
 		return job.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy), nil
-	case "DaemonSet":
+	case "daemonset":
 		return daemonset.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy), nil
 	default:
 		return nil, fmt.Errorf("unknown driver %q for plugin %v",

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -44,7 +44,7 @@ func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 type Manifest struct {
 	SonobuoyConfig SonobuoyConfig `json:"sonobuoy-config"`
 	Spec           Container      `json:"spec"`
-	ExtraVolumes   []Volume       `json:"extra-volumes"`
+	ExtraVolumes   []Volume       `json:"extra-volumes,omitempty"`
 	objectKind
 }
 


### PR DESCRIPTION
When creating a plugin there are two main steps:
 - generating the plugin manifest
 - putting that manifest into the `sonobuoy gen` YAML to run it

This addresses the first point. Using this command we can generate
the boilerplate YAML for most standard plugins. It allows
customizing the plugin type, name, image, command, and env vars.

Fixes #665

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Added `gen plugin` command to generate plugin manifest for custom plugins.
```
