### PR TITLE
Change logic in template to use a list of plugin manifests

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -26,7 +26,18 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
+	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	"github.com/heptio/sonobuoy/pkg/templates"
+
+	corev1 "k8s.io/api/core/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	e2ePluginName    = "e2e"
+	systemdLogsName  = "systemd-logs"
+	pluginResultsDir = "/tmp/results"
 )
 
 // templateValues are used for direct template substitution for manifest generation.
@@ -34,6 +45,8 @@ type templateValues struct {
 	E2EFocus    string
 	E2ESkip     string
 	E2EParallel string
+
+	Plugins []string
 
 	SonobuoyConfig       string
 	SonobuoyImage        string
@@ -67,6 +80,23 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 		}
 	}
 
+	plugins := []*manifest.Manifest{}
+	if includes(cfg.Config.PluginSelections, e2ePluginName) {
+		plugins = append(plugins, e2eManifest(cfg))
+	}
+	if includes(cfg.Config.PluginSelections, systemdLogsName) {
+		plugins = append(plugins, systemdLogsManifest(cfg))
+	}
+
+	pluginYAML := []string{}
+	for _, v := range plugins {
+		yaml, err := kuberuntime.Encode(manifest.Encoder, v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "serializing plugin %v as YAML", v.SonobuoyConfig.PluginName)
+		}
+		pluginYAML = append(pluginYAML, strings.TrimSpace(string(yaml)))
+	}
+
 	// Template values that are regexps (`E2EFocus` and `E2ESkip`) are
 	// embedded in YAML files using single quotes to remove the need to
 	// escape characters e.g. `\` as they would be if using double quotes.
@@ -89,6 +119,8 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 		SSHKey:               base64.StdEncoding.EncodeToString(sshKeyData),
 		SSHUser:              cfg.SSHUser,
 
+		Plugins: pluginYAML,
+
 		// Often created from reading a file, this value could have trailing newline.
 		CustomRegistries: strings.TrimSpace(cfg.E2EConfig.CustomRegistries),
 	}
@@ -100,4 +132,145 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func includes(set []plugin.Selection, s string) bool {
+	for _, v := range set {
+		if s == v.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func systemdLogsManifest(cfg *GenConfig) *manifest.Manifest {
+	trueVal := true
+	return &manifest.Manifest{
+		SonobuoyConfig: manifest.SonobuoyConfig{
+			PluginName: "systemd-logs",
+			Driver:     "DaemonSet",
+			ResultType: "systemd-logs",
+		},
+		Spec: manifest.Container{
+			Container: corev1.Container{
+				Name:            "systemd-logs",
+				Image:           "gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest",
+				Command:         []string{"/bin/sh", "-c", "/get_systemd_logs.sh && sleep 3600"},
+				ImagePullPolicy: corev1.PullPolicy(cfg.ImagePullPolicy),
+				Env: []corev1.EnvVar{
+					corev1.EnvVar{Name: "CHROOT_DIR", Value: "/node"},
+					corev1.EnvVar{Name: "RESULTS_DIR", Value: pluginResultsDir},
+					corev1.EnvVar{Name: "NODE_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+						},
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged: &trueVal,
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					corev1.VolumeMount{
+						ReadOnly:  false,
+						Name:      "results",
+						MountPath: pluginResultsDir,
+					}, corev1.VolumeMount{
+						ReadOnly:  false,
+						Name:      "root",
+						MountPath: "/node",
+					},
+				},
+			},
+		},
+	}
+}
+
+func e2eManifest(cfg *GenConfig) *manifest.Manifest {
+	m := &manifest.Manifest{
+		SonobuoyConfig: manifest.SonobuoyConfig{
+			PluginName: "e2e",
+			Driver:     "Job",
+			ResultType: "e2e",
+		},
+		Spec: manifest.Container{
+			Container: corev1.Container{
+				Name:            "e2e",
+				Image:           cfg.KubeConformanceImage,
+				Command:         []string{"/run_e2e.sh"},
+				ImagePullPolicy: corev1.PullPolicy(cfg.ImagePullPolicy),
+				Env: []corev1.EnvVar{
+					corev1.EnvVar{Name: "E2E_FOCUS", Value: cfg.E2EConfig.Focus},
+					corev1.EnvVar{Name: "E2E_SKIP", Value: cfg.E2EConfig.Skip},
+					corev1.EnvVar{Name: "E2E_PARALLEL", Value: cfg.E2EConfig.Parallel},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					corev1.VolumeMount{
+						ReadOnly:  false,
+						Name:      "results",
+						MountPath: pluginResultsDir,
+					},
+				},
+			},
+		},
+	}
+
+	// Add volume mount, volume, and env var for custom registries.
+	if len(cfg.E2EConfig.CustomRegistries) > 0 {
+		m.ExtraVolumes = append(m.ExtraVolumes, manifest.Volume{
+			Volume: corev1.Volume{
+				Name: "repolist-vol",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "repolist-cm"},
+					},
+				},
+			},
+		})
+		m.Spec.Env = append(m.Spec.Env, corev1.EnvVar{
+			Name: "KUBE_TEST_REPO_LIST", Value: "/tmp/sonobuoy/repo-list.yaml",
+		})
+		m.Spec.VolumeMounts = append(m.Spec.VolumeMounts,
+			corev1.VolumeMount{
+				ReadOnly:  false,
+				Name:      "repolist-vol",
+				MountPath: "/tmp/sonobuoy",
+			},
+		)
+	}
+
+	// Add volume mount, volume, and 3 env vars (for different possible platforms) for SSH capabilities.
+	if len(cfg.SSHKeyPath) > 0 {
+		defMode := int32(256)
+		m.ExtraVolumes = append(m.ExtraVolumes, manifest.Volume{
+			Volume: corev1.Volume{
+				Name: "sshkey-vol",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  "ssh-key",
+						DefaultMode: &defMode,
+					},
+				},
+			},
+		})
+		m.Spec.Env = append(m.Spec.Env,
+			corev1.EnvVar{Name: "LOCAL_SSH_KEY", Value: "id_rsa"},
+			corev1.EnvVar{Name: "AWS_SSH_KEY", Value: "/root/.ssh/id_rsa"},
+			corev1.EnvVar{Name: "KUBE_SSH_KEY", Value: "id_rsa"},
+		)
+		m.Spec.VolumeMounts = append(m.Spec.VolumeMounts,
+			corev1.VolumeMount{
+				ReadOnly:  false,
+				Name:      "sshkey-vol",
+				MountPath: "/root/.ssh",
+			},
+		)
+	}
+
+	if len(cfg.SSHUser) > 0 {
+		m.Spec.Env = append(m.Spec.Env,
+			corev1.EnvVar{Name: "KUBE_SSH_USER", Value: cfg.SSHUser},
+		)
+	}
+
+	return m
 }

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -1,0 +1,85 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"v0.14.1","ResultsDir":"/tmp/sonobuoy","Resources":["CertificateSigningRequests","ClusterRoleBindings","ClusterRoles","ComponentStatuses","CustomResourceDefinitions","Nodes","PersistentVolumes","PodSecurityPolicies","ServerGroups","ServerVersion","StorageClasses","ConfigMaps","ControllerRevisions","CronJobs","DaemonSets","Deployments","Endpoints","Ingresses","Jobs","LimitRanges","NetworkPolicies","PersistentVolumeClaims","PodDisruptionBudgets","PodTemplates","Pods","ReplicaSets","ReplicationControllers","ResourceQuotas","RoleBindings","Roles","ServiceAccounts","Services","StatefulSets"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":null,"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"heptio-sonobuoy","LoadedPlugins":null,"WorkerImage":"gcr.io/heptio-images/sonobuoy:v0.14.1","ImagePullPolicy":"IfNotPresent"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -1,0 +1,110 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"v0.14.1","ResultsDir":"/tmp/sonobuoy","Resources":["CertificateSigningRequests","ClusterRoleBindings","ClusterRoles","ComponentStatuses","CustomResourceDefinitions","Nodes","PersistentVolumes","PodSecurityPolicies","ServerGroups","ServerVersion","StorageClasses","ConfigMaps","ControllerRevisions","CronJobs","DaemonSets","Deployments","Endpoints","Ingresses","Jobs","LimitRanges","NetworkPolicies","PersistentVolumeClaims","PodDisruptionBudgets","PodTemplates","Pods","ReplicaSets","ReplicationControllers","ResourceQuotas","RoleBindings","Roles","ServiceAccounts","Services","StatefulSets"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":[{"name":"e2e"}],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"heptio-sonobuoy","LoadedPlugins":null,"WorkerImage":"gcr.io/heptio-images/sonobuoy:v0.14.1","ImagePullPolicy":"IfNotPresent"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-type: e2e
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -25,7 +25,7 @@ data:
 apiVersion: v1
 data:
   config.json: |
-    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","LoadedPlugins":null,"WorkerImage":"","ImagePullPolicy":""}
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":[{"name":"e2e"}],"PluginSearchPath":null,"Namespace":"","LoadedPlugins":null,"WorkerImage":"","ImagePullPolicy":""}
 kind: ConfigMap
 metadata:
   labels:
@@ -35,72 +35,38 @@ metadata:
 ---
 apiVersion: v1
 data:
-  e2e.yaml: |
+  plugin-0.yaml: |
+    extra-volumes:
+    - name: sshkey-vol
+      secret:
+        defaultMode: 256
+        secretName: ssh-key
     sonobuoy-config:
       driver: Job
       plugin-name: e2e
       result-type: e2e
     spec:
+      command:
+      - /run_e2e.sh
       env:
       - name: E2E_FOCUS
-        value: ''
       - name: E2E_SKIP
-        value: ''
       - name: E2E_PARALLEL
-        value: ''
       - name: LOCAL_SSH_KEY
-        value: 'id_rsa'
+        value: id_rsa
       - name: AWS_SSH_KEY
-        value: '/root/.ssh/id_rsa'
+        value: /root/.ssh/id_rsa
       - name: KUBE_SSH_KEY
-        value: 'id_rsa'
+        value: id_rsa
       - name: KUBE_SSH_USER
         value: ssh-user
-      command: ["/run_e2e.sh"]
-      image: 
-      imagePullPolicy: 
       name: e2e
+      resources: {}
       volumeMounts:
       - mountPath: /tmp/results
         name: results
-        readOnly: false
       - mountPath: /root/.ssh
         name: sshkey-vol
-      tolerations:
-        - operator: "Exists"
-    extra-volumes:
-    - name: sshkey-vol
-      secret:
-        secretName: ssh-key
-        defaultMode: 256
-  systemd-logs.yaml: |
-    sonobuoy-config:
-      driver: DaemonSet
-      plugin-name: systemd-logs
-      result-type: systemd_logs
-    spec:
-      command: ["/bin/sh", "-c", "/get_systemd_logs.sh && sleep 3600"]
-      env:
-      - name: NODE_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-      - name: RESULTS_DIR
-        value: /tmp/results
-      - name: CHROOT_DIR
-        value: /node
-      image: gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest
-      imagePullPolicy: 
-      name: sonobuoy-systemd-logs-config
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /tmp/results
-        name: results
-        readOnly: false
-      - mountPath: /node
-        name: root
-        readOnly: false
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -1,0 +1,122 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"","Version":"v0.14.1","ResultsDir":"/tmp/sonobuoy","Resources":["CertificateSigningRequests","ClusterRoleBindings","ClusterRoles","ComponentStatuses","CustomResourceDefinitions","Nodes","PersistentVolumes","PodSecurityPolicies","ServerGroups","ServerVersion","StorageClasses","ConfigMaps","ControllerRevisions","CronJobs","DaemonSets","Deployments","Endpoints","Ingresses","Jobs","LimitRanges","NetworkPolicies","PersistentVolumeClaims","PodDisruptionBudgets","PodTemplates","Pods","ReplicaSets","ReplicationControllers","ResourceQuotas","RoleBindings","Roles","ServiceAccounts","Services","StatefulSets"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":[{"name":"systemd-logs"}],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"heptio-sonobuoy","LoadedPlugins":null,"WorkerImage":"gcr.io/heptio-images/sonobuoy:v0.14.1","ImagePullPolicy":"IfNotPresent"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-type: systemd-logs
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh && sleep 3600
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      image: gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+      - mountPath: /node
+        name: root
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -17,7 +17,7 @@ limitations under the License.
 package manifest
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,7 +44,7 @@ func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 type Manifest struct {
 	SonobuoyConfig SonobuoyConfig `json:"sonobuoy-config"`
 	Spec           Container      `json:"spec"`
-	ExtraVolumes   []Volume       `json:"extra-volumes"`
+	ExtraVolumes   []Volume       `json:"extra-volumes,omitempty"`
 	objectKind
 }
 
@@ -62,7 +62,7 @@ func (m *Manifest) GetObjectKind() schema.ObjectKind { return m }
 
 // Container is a thin wrapper around coreV1.Container that supplies DeepCopyObject and GetObjectKind
 type Container struct {
-	v1.Container
+	corev1.Container
 	objectKind
 }
 
@@ -82,7 +82,7 @@ func (c *Container) GetObjectKind() schema.ObjectKind { return c }
 
 // Volume is a thin wrapper around coreV1.Volume that supplies DeepCopyObject and GetObjectKind
 type Volume struct {
-	v1.Volume
+	corev1.Volume
 	objectKind
 }
 


### PR DESCRIPTION
Currently, the template for the initial YAML (via sonobuoy gen)
has it hardcoded that both the e2e and systemd-logs plugin are
configured. This is 1) misleading to users who might see this and
think both are going to be run and 2) brittle.

With upcoming changes wanting to make the plugin list more
variable, it makes sense to put this change first: go ahead and
track a plugin list and adjust the template to iterate over the
plugins, inserting their YAML each time.

This makes the YAML more clear, flexible, and in some cases shorter.

Fixes #672

Signed-off-by: John Schnake <jschnake@vmware.com>

**Special notes for your reviewer**:

**Release note**:
```
`sonobuoy gen` output will now reflect only the set of plugins you are selecting to run instead of always generating the e2e and systemd-logs configurations.
```
