### PR TITLE
Centralize the process of going from kubeconfig to sonobuoy client

### DIFF
--- a/cmd/sonobuoy/app/common.go
+++ b/cmd/sonobuoy/app/common.go
@@ -19,3 +19,11 @@ func getSonobuoyClient(cfg *rest.Config) (*client.SonobuoyClient, error) {
 	}
 	return client.NewSonobuoyClient(cfg, skc)
 }
+
+func getSonobuoyClientFromKubecfg(kubecfg Kubeconfig) (*client.SonobuoyClient, error) {
+	cfg, err := kubecfg.Get()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get rest config")
+	}
+	return getSonobuoyClient(cfg)
+}

--- a/cmd/sonobuoy/app/delete.go
+++ b/cmd/sonobuoy/app/delete.go
@@ -52,13 +52,7 @@ func NewCmdDelete() *cobra.Command {
 }
 
 func deleteSonobuoyRun(cmd *cobra.Command, args []string) {
-	cfg, err := deleteFlags.kubeconfig.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
-		os.Exit(1)
-	}
-
-	sbc, err := getSonobuoyClient(cfg)
+	sbc, err := getSonobuoyClientFromKubecfg(deleteFlags.kubeconfig)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)

--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -116,13 +116,7 @@ func listImages(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		cfg, err := imagesflags.kubeconfig.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-			os.Exit(1)
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(imagesflags.kubeconfig)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			os.Exit(1)
@@ -160,13 +154,7 @@ func pullImages(cmd *cobra.Command, args []string) {
 	switch imagesflags.plugin {
 	case "e2e":
 
-		cfg, err := imagesflags.kubeconfig.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-			os.Exit(1)
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(imagesflags.kubeconfig)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			os.Exit(1)
@@ -203,13 +191,7 @@ func downloadImages(cmd *cobra.Command, args []string) {
 	switch imagesflags.plugin {
 	case "e2e":
 
-		cfg, err := imagesflags.kubeconfig.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-			os.Exit(1)
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(imagesflags.kubeconfig)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			os.Exit(1)
@@ -268,13 +250,7 @@ func pushImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		cfg, err := imagesflags.kubeconfig.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-			os.Exit(1)
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(imagesflags.kubeconfig)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			os.Exit(1)
@@ -317,14 +293,7 @@ func pushImages(cmd *cobra.Command, args []string) {
 func deleteImages(cmd *cobra.Command, args []string) {
 	switch imagesflags.plugin {
 	case "e2e":
-
-		cfg, err := imagesflags.kubeconfig.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
-			os.Exit(1)
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(imagesflags.kubeconfig)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			os.Exit(1)

--- a/cmd/sonobuoy/app/logs.go
+++ b/cmd/sonobuoy/app/logs.go
@@ -54,12 +54,7 @@ func NewCmdLogs() *cobra.Command {
 }
 
 func getLogs(cmd *cobra.Command, args []string) {
-	cfg, err := logsKubecfg.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "failed to get rest config"))
-		os.Exit(1)
-	}
-	sbc, err := getSonobuoyClient(cfg)
+	sbc, err := getSonobuoyClientFromKubecfg(logsKubecfg)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)

--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -61,12 +61,7 @@ func retrieveResults(cmd *cobra.Command, args []string) {
 		outDir = args[0]
 	}
 
-	cfg, err := rcvFlags.kubecfg.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "failed to get kubernetes client"))
-		os.Exit(1)
-	}
-	sbc, err := getSonobuoyClient(cfg)
+	sbc, err := getSonobuoyClientFromKubecfg(rcvFlags.kubecfg)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)

--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -71,20 +71,15 @@ func NewCmdRun() *cobra.Command {
 }
 
 func submitSonobuoyRun(cmd *cobra.Command, args []string) {
-	cfg, err := runflags.kubecfg.Get()
+	sbc, err := getSonobuoyClientFromKubecfg(runflags.kubecfg)
 	if err != nil {
-		errlog.LogError(errors.Wrap(err, "couldn't get REST client"))
+		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)
 	}
 
 	runCfg, err := runflags.Config()
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not retrieve E2E config"))
-		os.Exit(1)
-	}
-	sbc, err := getSonobuoyClient(cfg)
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)
 	}
 

--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -58,12 +58,7 @@ func NewCmdStatus() *cobra.Command {
 // TODO (timothysc) summarize and aggregate daemonset-plugins by status done (24) running (24)
 // also --show-all
 func getStatus(cmd *cobra.Command, args []string) {
-	cfg, err := statusFlags.kubecfg.Get()
-	if err != nil {
-		errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
-		os.Exit(1)
-	}
-	sbc, err := getSonobuoyClient(cfg)
+	sbc, err := getSonobuoyClientFromKubecfg(statusFlags.kubecfg)
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 		os.Exit(1)

--- a/cmd/sonobuoy/app/version.go
+++ b/cmd/sonobuoy/app/version.go
@@ -70,13 +70,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 func getK8Sversion() (string, bool) {
 
 	if versionflags.kubecfg.String() != "" {
-		cfg, err := versionflags.kubecfg.Get()
-		if err != nil {
-			errlog.LogError(errors.Wrap(err, "couldn't get kubernetes config"))
-			return "", true
-		}
-
-		sbc, err := getSonobuoyClient(cfg)
+		sbc, err := getSonobuoyClientFromKubecfg(versionflags.kubecfg)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
 			return "", true


### PR DESCRIPTION
This logic is repeated throughout nearly every command; this
tries to further centralize it.

The goal is to DRY up the codebase slightly making way for
further refactors to increase testability and test coverage
of the entire project.

Related to #651

Signed-off-by: John Schnake <jschnake@vmware.com>

**Special notes for your reviewer**:
Small change but I just wanted to keep it very focused for an easy review. More refactor/testability changes will be coming.