### PR TITLE
Add context flag whenever kubeconfig flag is added

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -85,10 +85,11 @@ func AddKubeConformanceImageVersion(imageVersion *image.ConformanceImageVersion,
 	flags.Var(imageVersion, "kube-conformance-image-version", help)
 }
 
-// AddKubeconfigFlag adds a kubeconfig flag to the provided command.
+// AddKubeconfigFlag adds a kubeconfig and context flags to the provided command.
 func AddKubeconfigFlag(cfg *Kubeconfig, flags *pflag.FlagSet) {
 	// The default is the empty string (look in the environment)
 	flags.Var(cfg, "kubeconfig", "Path to explicit kubeconfig file.")
+	flags.StringVar(&cfg.Context, "context", "", "Context in the kubeconfig to use.")
 }
 
 // AddPluginFlag describes which plugin's images to interact with

--- a/cmd/sonobuoy/app/kubeconfig.go
+++ b/cmd/sonobuoy/app/kubeconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
 	// Add auth providers
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -27,6 +28,7 @@ import (
 // Kubeconfig represents an explict or implict kubeconfig
 type Kubeconfig struct {
 	*clientcmd.ClientConfigLoadingRules
+	Context string
 }
 
 // Make sure Kubeconfig implements Value properly
@@ -55,12 +57,15 @@ func (c *Kubeconfig) Set(str string) error {
 
 // Get returns a rest Config, possibly based on a provided config
 func (c *Kubeconfig) Get() (*rest.Config, error) {
-
 	if c.ClientConfigLoadingRules == nil {
 		c.ClientConfigLoadingRules = clientcmd.NewDefaultClientConfigLoadingRules()
 	}
 
 	configOverrides := &clientcmd.ConfigOverrides{}
+	if len(c.Context) > 0 {
+		configOverrides.CurrentContext = c.Context
+	}
+
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(c, configOverrides)
 	return kubeConfig.ClientConfig()
 }


### PR DESCRIPTION
Some users may have multiple clusters in their config;
adding support for context is very minimal and helps
simplify their Sonobuoy integration.

Fixes #421

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Added a `--context` flag support for passing a KUBECONFIG context whenever a `--kubeconifg` flag is supported.
```
