### PR TITLE
Fix flaky unit test

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -52,7 +52,7 @@ func TestPluginGenDef(t *testing.T) {
 			desc: "Env vars",
 			cfg: GenPluginDefConfig{
 				def: manifest.Manifest{},
-				env: map[string]string{"FOO": "bar", "FIZZ": "buzz"},
+				env: map[string]string{"FOO": "bar"},
 			},
 			expectFile: "testdata/pluginDef-env.golden",
 		}, {
@@ -86,7 +86,7 @@ func TestPluginGenDef(t *testing.T) {
 						},
 					},
 				},
-				env: map[string]string{"FOO": "- bar", "FIZZ": "buzz"},
+				env: map[string]string{"FOO": "- bar"},
 			},
 			expectFile: "testdata/pluginDef-quotes.golden",
 		},

--- a/cmd/sonobuoy/app/testdata/pluginDef-env.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-env.golden
@@ -6,7 +6,5 @@ spec:
   env:
   - name: FOO
     value: bar
-  - name: FIZZ
-    value: buzz
   name: ""
   resources: {}

--- a/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-quotes.golden
@@ -10,8 +10,6 @@ spec:
   env:
   - name: FOO
     value: '- bar'
-  - name: FIZZ
-    value: buzz
   image: img:v1
   name: n - foo
   resources: {}


### PR DESCRIPTION
The ordering of YAML lists is not well defined and so this passed
tests locally and in CI by chance. Even trying to repeat the
flakiness failed at first because I was hitting the testing cache.

Removing the 2nd end var does little to limit the value of the test
and we also have functional tests (e2e integration tests) which
will hit this flow.

Signed-off-by: John Schnake <jschnake@vmware.com>
