### PR TITLE
Add sonobuoy gen config file and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ sonobuoy logs
  * [plugins][plugins]
  * Testing of [air gapped clusters][airgap].
  * [Customization][gen] of YAML prior to running.
+ * The [Sonobuoy config file][sonobuoyconfig] file and how to edit it.
 
 ## Troubleshooting
 
@@ -151,6 +152,7 @@ See [the list of releases][releases] to find out about feature changes.
 [releases]: https://github.com/heptio/sonobuoy/releases
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
 [snapshot]: docs/snapshot.md
+[sonobuoyconfig]: docs/sonobuoy-config.md
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master
 [travis]: https://travis-ci.org/heptio/sonobuoy/#
 [wait]: docs/wait.md

--- a/cmd/sonobuoy/app/gen_config.go
+++ b/cmd/sonobuoy/app/gen_config.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/heptio/sonobuoy/pkg/errlog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdGenConfig creates the `config` command which will print out
+// the default sonobuoy config in a json format.
+func NewCmdGenConfig() *cobra.Command {
+	var GenCommand = &cobra.Command{
+		Use:   "config",
+		Short: "Generates a sonobuoy config for input to sonobuoy gen or run.",
+		Run:   genConfigCobra,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	return GenCommand
+}
+
+// genConfigCobra is the function that executes the functional logic
+// but wraps it in the function signature/flow expected for cobra.
+func genConfigCobra(cmd *cobra.Command, args []string) {
+	s, err := genConfig()
+	if err != nil {
+		errlog.LogError(err)
+		os.Exit(1)
+	}
+	fmt.Println(string(s))
+}
+
+// genConfig is the actual functional logic of the command.
+func genConfig() ([]byte, error) {
+	// Using genflags.getConfig() instead of config.New() because
+	// it will include any defaults we have on the command line such
+	// as default plugin selection. We didn't want to wire this into
+	// the `config` package, but it will be a default value the CLI
+	// users expect.
+	c := genflags.getConfig()
+	b, err := json.Marshal(c)
+	return b, errors.Wrap(err, "unable to marshal configuration")
+}

--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -38,6 +38,7 @@ func NewSonobuoyCommand() *cobra.Command {
 
 	gen := NewCmdGen()
 	gen.AddCommand(NewCmdGenPluginDef())
+	gen.AddCommand(NewCmdGenConfig())
 	cmds.AddCommand(gen)
 
 	cmds.AddCommand(NewCmdLogs())

--- a/docs/sonobuoy-config.md
+++ b/docs/sonobuoy-config.md
@@ -1,0 +1,60 @@
+# Sonobuoy Config
+
+The commands "run" and "gen" both accept a parameter for a Sonobuoy config file which allows you to customize multiple aspects of the run.
+
+We've provided a command to generate the JSON file necessary so that it is easier to edit for your runs. Run the command:
+
+```
+sonobuoy gen config
+```
+
+and you will see the default configuration. Below is a description of each of the values.
+
+## General options
+
+Description
+ - A string which provides consumers a way to add extra context to a configuration that may be in memory or saved to disk. Unused by Sonobuoy itself.
+
+UUID
+ - A unique identifier used to identify the run of this configuration. Used in a few places including the name of the results file.
+
+Namespace
+ - The namespace in which to run Sonobuoy.
+
+WorkerImage
+ - The image for the Sonobuoy worker container which runs as a sidecar along the plugins. Responsible for reporting results back to the Sonobuoy aggregator.
+
+ImagePullPolicy
+ - The image pull policy to set on the Sonobuoy worker sidecars as well as each of the plugins.
+
+ResultsDir
+ - The location on the Sonobuoy aggregator where the results are placed.
+
+Version
+ - The version of Sonobuoy which created the configuration file.
+
+
+## Plugin options
+
+Plugins
+ - An array of plugin selection objects of the plugins you want to run. When running custom plugins (or avoiding running a particular plugin) this value needs modified.
+
+PluginSearchPath
+ - The aggregator pod looks for plugin configurations in these locations. You shouldn't need to edit this unless you are doing development work on the aggregator itself.
+
+## Query options
+
+Resources
+ - A list of resources which Sonobuoy will query for in every namespace in which it runs queries. In the namespace in which Sonobuoy is running, PodLogs, Events, and HorizontalPodAutoscalers are also added.
+
+Filters
+ - Namespace
+   - A regexp which specifies which namespaces to run queries against.
+ - LabelSelector
+   - A Kubernetes [label selector][labelselector] which will be added to every query run.
+
+Limits
+ - Options for limiting the size of the pod logs (in bytes) or the how far back in time to gather logs (in seconds). These will be passed onto Kubernetes [PodLogOptions][podlogopts]
+
+[labelselector]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[podlogopts]: https://godoc.org/k8s.io/api/core/v1#PodLogOptions


### PR DESCRIPTION
The Sonobuoy config file is a little mysterious to most
users since the values are only really defined in code
and not well documented.

This change adds a command to output the default config
so that users might tweak the values they need more
easily.

In addition, I updated the documentation to make it more
clear for everyone what the configuration file is and
how each of the fields are used.

Fixes #661

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
Added "sonobuoy gen config" command to see the default config that is passed to the server and added documentation about each field. This helps any user utilize the customizability that already exists.
```
