### PR TITLE
Add test that will run through command creation

### DIFF
--- a/cmd/sonobuoy/app/root_test.go
+++ b/cmd/sonobuoy/app/root_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+
+	 Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import "testing"
+
+// TestCommands exists to ensure that some test goes through
+// the code paths of generating all the commands. This helps with
+// getting a better sense of code coverage and provides a place to
+// add more tests to later.
+func TestCommands(t *testing.T) {
+	c := NewSonobuoyCommand()
+	if c == nil {
+		t.Fatal("Expected non-nil command; got nil")
+	}
+}


### PR DESCRIPTION
The CLI code has very low code coverage which indicates
that it has lots of areas potentially containing bugs.

However, a large chunk of the code in the CLI is just
boilerplate that sets up cobra commands and doesn't
execute much actual logic.

The point of this test is to have a code flow go through
those so that code coverage better reflects actual,
substantive code.

Relates to #651

Signed-off-by: John Schnake <jschnake@vmware.com>

**Release note**:
```
N/A
```
