### PR TITLE
Run all loaded plugins by default

### DIFF
--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -73,7 +73,11 @@ func LoadAllPlugins(namespace, sonobuoyImage, imagePullPolicy string, searchPath
 		pluginDefinitions = append(pluginDefinitions, pluginDefinition)
 	}
 
-	pluginDefinitions = filterPluginDef(pluginDefinitions, selections)
+	// The zero value for the slice, nil, indicates that all plugins should be run.
+	// If the user wants to run 0 plugins, they should explicitly pass an empty array.
+	if selections != nil {
+		pluginDefinitions = filterPluginDef(pluginDefinitions, selections)
+	}
 
 	plugins := []plugin.Interface{}
 	for _, def := range pluginDefinitions {

--- a/pkg/plugin/loader/loader_test.go
+++ b/pkg/plugin/loader/loader_test.go
@@ -211,6 +211,16 @@ func TestLoadAllPlugins(t *testing.T) {
 				plugin.Selection{Name: "test-daemon-set-plugin"},
 			},
 			expectedPluginNames: []string{"test-job-plugin", "test-daemon-set-plugin"},
+		}, {
+			testname:            "nil selections defaults to run all",
+			searchPath:          []string{path.Join("testdata", "onlyvalid")},
+			selections:          nil,
+			expectedPluginNames: []string{"test-job-plugin", "test-daemon-set-plugin"},
+		}, {
+			testname:            "empty (non-nil) selection runs none",
+			searchPath:          []string{path.Join("testdata", "plugin.d")},
+			selections:          []plugin.Selection{},
+			expectedPluginNames: []string{},
 		},
 	}
 

--- a/pkg/plugin/loader/testdata/onlyvalid/daemonset.yaml
+++ b/pkg/plugin/loader/testdata/onlyvalid/daemonset.yaml
@@ -1,0 +1,12 @@
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: test-daemon-set-plugin
+  result-type: test-daemon-set-plugin
+spec:
+  image: gcr.io/heptio-images/heptio-e2e:master
+  imagePullPolicy: Always
+  name: heptio-e2e
+  volumeMounts:
+    - mountPath: /tmp/results
+      name: results
+      readOnly: false

--- a/pkg/plugin/loader/testdata/onlyvalid/job.yml
+++ b/pkg/plugin/loader/testdata/onlyvalid/job.yml
@@ -1,0 +1,12 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: test-job-plugin
+  result-type: test-job-plugin
+spec:
+  image: gcr.io/heptio-images/heptio-e2e:master
+  imagePullPolicy: Always
+  name: heptio-e2e
+  volumeMounts:
+    - mountPath: /tmp/results
+      name: results
+      readOnly: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The aggregator has a plugin filtering mechanism that
seems to actually complicate things for most users. Beyond
adding their plugin to the config map, they also have to
adjust the plugin selection.

This seems to have originated due to a desire for
flexibility (before knowing we needed it or not) and also
ease of testing.

This change just introduces special handling for the nil
selection (not empty, completely nil). In that case, all
plugins are run which are loaded.

**Which issue(s) this PR fixes**
ref #405

**Special notes for your reviewer**:
I copied some plugin manifests in the testing directory because otherwise, you get an error when you try and run the invalid manifest.

**Release note**:
```
The aggregator pod will now run all plugins found in the search paths unless given a non-nil value for `Plugins` in the config.json settings.
```

Signed-off-by: John Schnake <jschnake@vmware.com>