### PR TITLE
Properly set default for plugin job driver

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -52,8 +52,9 @@ type GenPluginDefConfig struct {
 // NewCmdGenPluginDef ...
 func NewCmdGenPluginDef() *cobra.Command {
 	genPluginOpts := GenPluginDefConfig{
-		def: defaultManifest(),
-		env: map[string]string{},
+		def:    defaultManifest(),
+		env:    map[string]string{},
+		driver: defaultPluginDriver,
 	}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
The value was being set in the config, but for the flag
logic to work properly, this also needed set.
