### PR TITLE
Add example for command runner plugin

### DIFF
--- a/examples/plugins/cmd-runner/Dockerfile
+++ b/examples/plugins/cmd-runner/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch-slim
+
+# Install kubectl
+# Note: Latest version may be found on:
+# https://aur.archlinux.org/packages/kubectl-bin/
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+
+ENV HOME=/config
+
+# Basic check it works.
+RUN apt-get update && \
+    apt-get -y install net-tools && \
+    apt-get -y install curl && \
+    chmod +x /usr/local/bin/kubectl && \
+    kubectl version --client
+
+COPY ./run.sh ./run.sh 
+
+ENTRYPOINT ["./run.sh"]

--- a/examples/plugins/cmd-runner/README.md
+++ b/examples/plugins/cmd-runner/README.md
@@ -1,0 +1,35 @@
+# Command Runner
+
+This example creates an Sonobuoy plugin which runs each of its arguments (via /bin/sh) and saves the output in a results file (the output for the Nth command is output to a file called "outN").
+
+Kubectl is added to the image so that it can grab information from/about the cluster.
+
+All of the results files are added into a tar file and then the 'done' file is written, telling the Sonobuoy worker where to find the output.
+
+## Example
+
+```
+$ docker build . -t user/easy-sonobuoy-cmds:v0.1
+$ docker push user/easy-sonobuoy-cmds:v0.1
+
+$ sonobuoy gen plugin \
+--name=hello-world \
+--image user/easy-sonobuoy-cmds:v0.1 \
+--arg="echo hello world" \
+--arg="kubectl cluster-info" > hello-world.yaml
+
+$ sonobuoy run --plugin hello-world.yaml
+```
+
+You can obtain all the Sonobuoy results locally by running:
+```
+outfile=$(sonobuoy retrieve) && \
+mkdir results && tar -xf $outfile -C results
+```
+
+Print our specific results with:
+```
+cat results/plugins/hello-world/results/out*
+```
+
+

--- a/examples/plugins/cmd-runner/run.sh
+++ b/examples/plugins/cmd-runner/run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -x
+
+# This is the entrypoint for the image and meant to wrap the
+# logic of gathering/reporting results to the Sonobuoy worker.
+
+results_dir="${RESULTS_DIR:-/tmp/results}"
+
+# saveResults prepares the results for handoff to the Sonobuoy worker.
+# See: https://github.com/heptio/sonobuoy/blob/master/docs/plugins.md
+saveResults() {
+    cd ${results_dir}
+
+    # Sonobuoy worker expects a tar file.
+	tar czf results.tar.gz *
+
+	# Signal to the worker that we are done and where to find the results.
+	printf ${results_dir}/results.tar.gz > ${results_dir}/done
+}
+
+# Ensure that we tell the Sonobuoy worker we are done regardless of results.
+trap saveResults EXIT
+
+# Each command is expected to be given as an arg. If no args, error out
+# but print one result file for clarity in the results.
+if [ "$#" -eq "0" ]; then
+	echo "No arguments; expects each argument to be a shell command." > ${results_dir}/out
+	exit 1
+fi
+
+# Iterate through each argument. Grab each by location and shift
+# to preserve spacing (using "$@" will lose that information).
+i=0
+while [ "$1" != "" ]; do
+	# Run each arg as a command and save the output in the results directory.
+    /bin/sh -c "$1" > ${results_dir}/out${i}
+    i=$((i + 1))
+
+    # Shift all the parameters down by one
+    shift
+done


### PR DESCRIPTION
With the new plugin generation/runner capabilities we needed
a new example to show users what they can do/how to do it.

This example just takes all the arguments it is given and
runs them with /bin/sh, saves the output, tars it up, and
tells the Sonobuoy worker where to find the results.

This example includes:
 - the code for the plugin (a single bash script)
 - the Dockerfile to build the script
 - a README.md to explain what it does and how to use it

**Release note**:
```
NONE
```
