### PR TITLE
Fix servergroups query

### DIFF
--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -343,11 +343,11 @@ func queryServerGroups(kubeClient kubernetes.Interface, recorder *QueryRecorder,
 		logrus.Info("servergroups not specified in non-nil Resources. Skipping servergroups query.")
 		return nil
 	}
-	objqry := func() (interface{}, error) { return kubeClient.Discovery().ServerVersion() }
+	objqry := func() (interface{}, error) { return kubeClient.Discovery().ServerGroups() }
 	query := func() (time.Duration, error) {
-		return timedObjectQuery(cfg.OutputDir(), "serverversion.json", objqry)
+		return timedObjectQuery(cfg.OutputDir(), "servergroups.json", objqry)
 	}
-	timedQuery(recorder, "serverversion", "", query)
+	timedQuery(recorder, "servergroups", "", query)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the dynamic query PR that merged recently there was a
copy/paste error which caused servergroups to get lost.

This fixes the issue and returns this functionality to its
original state.

Signed-off-by: John Schnake <jschnake@vmware.com>

**Special notes for your reviewer**:
To confirm this you can just run the master locally:
```
./sonobuoy master
```

**Release note**:
```
NONE
```

Marking as none since it was never broken in a release.
