### PR TITLE
Add coverage profile to gitignore to ensure clean state after tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Dockerfile-arm64
 
 # kubectl which is downloaded for testing in CI
 kubectl
+
+# coverage profile
+coverage.txt


### PR DESCRIPTION
Goreleaser fails again because the coverage.txt file makes it think
changes have been made.

Ignores this file.

Signed-off-by: John Schnake <jschnake@vmware.com>