### PR TITLE
remove redundant fields from GenConfig

### DIFF
--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -136,11 +136,9 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 	return &client.GenConfig{
 		E2EConfig:            e2ecfg,
 		Config:               g.resolveConfig(),
-		Image:                g.sonobuoyImage,
-		Namespace:            g.namespace,
 		EnableRBAC:           rbacEnabled,
-		ImagePullPolicy:      g.imagePullPolicy.String(),
 		KubeConformanceImage: image,
+		ImagePullPolicy:      g.imagePullPolicy.String(),
 		SSHKeyPath:           g.sshKeyPath,
 		SSHUser:              g.sshUser,
 		DynamicPlugins:       g.plugins.DynamicPlugins,

--- a/pkg/client/defaults.go
+++ b/pkg/client/defaults.go
@@ -28,8 +28,6 @@ func NewGenConfig() *GenConfig {
 	return &GenConfig{
 		E2EConfig:  &defaultE2E,
 		Config:     config.New(),
-		Image:      config.DefaultImage,
-		Namespace:  config.DefaultNamespace,
 		EnableRBAC: true,
 	}
 }

--- a/pkg/client/example_interfaces_test.go
+++ b/pkg/client/example_interfaces_test.go
@@ -51,8 +51,6 @@ func Example() {
 				Skip:  "",
 			},
 			Config:          config.New(),
-			Image:           config.DefaultImage,
-			Namespace:       config.DefaultNamespace,
 			EnableRBAC:      true,
 			ImagePullPolicy: "Always",
 		},

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -63,15 +63,15 @@ type templateValues struct {
 
 // GenerateManifest fills in a template with a Sonobuoy config
 func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
-	marshalledConfig, err := json.Marshal(cfg.Config)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't marshall selector")
-	}
-
 	// Allow nil cfg.Config but avoid dereference errors.
 	conf := &config.Config{}
 	if cfg.Config != nil {
 		conf = cfg.Config
+	}
+
+	marshalledConfig, err := json.Marshal(conf)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't marshall selector")
 	}
 
 	sshKeyData := []byte{}
@@ -130,10 +130,10 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 
 	tmplVals := &templateValues{
 		SonobuoyConfig:   string(marshalledConfig),
-		SonobuoyImage:    cfg.Image,
-		Namespace:        cfg.Namespace,
+		SonobuoyImage:    conf.WorkerImage,
+		Namespace:        conf.Namespace,
 		EnableRBAC:       cfg.EnableRBAC,
-		ImagePullPolicy:  cfg.ImagePullPolicy,
+		ImagePullPolicy:  conf.ImagePullPolicy,
 		ImagePullSecrets: conf.ImagePullSecrets,
 		SSHKey:           base64.StdEncoding.EncodeToString(sshKeyData),
 		SSHUser:          cfg.SSHUser,

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -28,6 +28,14 @@ func TestGenerateManifest(t *testing.T) {
 		expected *config.Config
 	}{
 		{
+			name: "nil config",
+			inputcm: &client.GenConfig{
+				E2EConfig: &client.E2EConfig{},
+				Config:    nil,
+			},
+			expected: &config.Config{},
+		},
+		{
 			name: "Defaults in yield a default manifest.",
 			inputcm: &client.GenConfig{
 				E2EConfig: &client.E2EConfig{},

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -43,8 +43,6 @@ type LogConfig struct {
 type GenConfig struct {
 	E2EConfig            *E2EConfig
 	Config               *config.Config
-	Image                string
-	Namespace            string
 	EnableRBAC           bool
 	ImagePullPolicy      string
 	KubeConformanceImage string

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -92,7 +92,7 @@ func (c *SonobuoyClient) Run(cfg *RunConfig) error {
 		seenStatus := false
 		runCondition := func() (bool, error) {
 			// Get the heptio pod and check if its status is completed or terminated.
-			status, err := c.GetStatus(cfg.Namespace)
+			status, err := c.GetStatus(cfg.Config.Namespace)
 			switch {
 			case err != nil && seenStatus:
 				return false, errors.Wrap(err, "failed to get status")

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -77,7 +77,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -87,7 +87,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -99,8 +99,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -128,7 +128,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -77,7 +77,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -87,7 +87,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -99,8 +99,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -128,7 +128,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -48,7 +48,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -58,7 +58,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -70,8 +70,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -99,7 +99,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 data:
   config.json: |
-    null
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 data:
   config.json: |
-    null
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 data:
   config.json: |
-    null
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 data:
   config.json: |
-    null
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/client/testdata/no-plugins-via-selection.golden
+++ b/pkg/client/testdata/no-plugins-via-selection.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 ---
 apiVersion: v1
@@ -33,7 +33,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -45,8 +45,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -74,7 +74,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -47,7 +47,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -57,7 +57,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -69,8 +69,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -98,7 +98,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: 
+  name: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,7 +11,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-serviceaccount
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -22,7 +22,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-config-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 data:
@@ -60,7 +60,7 @@ metadata:
   labels:
     component: sonobuoy
   name: sonobuoy-plugins-cm
-  namespace: 
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod
@@ -70,7 +70,7 @@ metadata:
     run: sonobuoy-master
     tier: analysis
   name: sonobuoy
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   containers:
   - command:
@@ -82,8 +82,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: 
-    imagePullPolicy: 
+    image: gcr.io/heptio-images/sonobuoy:v0.14.2
+    imagePullPolicy: IfNotPresent
     name: kube-sonobuoy
     volumeMounts:
     - mountPath: /etc/sonobuoy
@@ -111,7 +111,7 @@ metadata:
     component: sonobuoy
     run: sonobuoy-master
   name: sonobuoy-master
-  namespace: 
+  namespace: heptio-sonobuoy
 spec:
   ports:
   - port: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the redundant fields from GenConfig struct and uses the fields in Config to generate manifest.

**Which issue(s) this PR fixes**
- Fixes #691 

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
