### PR TITLE
Set any plugin env vars from the CLI

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -296,6 +296,12 @@ func AddPluginSetFlag(p *pluginList, flags *pflag.FlagSet) {
 	flags.VarP(p, "plugin", "p", "Which plugins to run. Can either point to a local file or be one of the known plugins (e2e or systemd-logs). Can be specified multiple times to run multiple plugins.")
 }
 
+// AddPluginEnvFlag adds the flag for gen/run which keeps track of which plugins
+// to run and loads them from local files if necessary.
+func AddPluginEnvFlag(p *PluginEnvVars, flags *pflag.FlagSet) {
+	flags.Var(p, "plugin-env", "Set env vars on plugins. Values can be given multiple times and are in the form plugin.env=value")
+}
+
 // AddShortFlag adds a boolean flag to just print the Sonobuoy version and
 // nothing else. Useful in scripts.
 func AddShortFlag(flag *bool, flags *pflag.FlagSet) {

--- a/cmd/sonobuoy/app/envvars_plugin.go
+++ b/cmd/sonobuoy/app/envvars_plugin.go
@@ -1,0 +1,59 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PluginEnvVars is a map of plugin (by name) mapped to a k-v map of env var name/values.
+type PluginEnvVars map[string]map[string]string
+
+func (i *PluginEnvVars) String() string { return fmt.Sprint((map[string]map[string]string)(*i)) }
+func (i *PluginEnvVars) Type() string   { return "pluginenvvar" }
+
+// Set parses the value from the CLI and places it into the internal map. Expected
+// form is pluginName.envName=envValue. If no equals is found or it is the last character
+// ("x.y" or "x.y=") then the env var will be saved internally as the empty string with
+// the meaning that it will be removed from the plugins env vars.
+func (i *PluginEnvVars) Set(str string) error {
+	parts := strings.SplitN(str, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected form plugin.env=val but got %v parts when splitting by '.'", len(parts))
+	}
+	pluginName := parts[0]
+	mapI := (map[string]map[string]string)(*i)
+
+	if mapI == nil {
+		mapI = map[string]map[string]string{}
+	}
+	if mapI[pluginName] == nil {
+		mapI[pluginName] = map[string]string{}
+	}
+
+	envParts := strings.SplitN(parts[1], "=", 2)
+	switch len(envParts) {
+	case 1:
+		mapI[pluginName][envParts[0]] = ""
+	default:
+		mapI[pluginName][envParts[0]] = envParts[1]
+	}
+
+	*i = mapI
+	return nil
+}

--- a/cmd/sonobuoy/app/envvars_plugin_test.go
+++ b/cmd/sonobuoy/app/envvars_plugin_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+
+	 Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestPluginEnvSet(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		init      PluginEnvVars
+		input     string
+		expect    PluginEnvVars
+		expectErr string
+	}{
+		{
+			desc:  "Set value",
+			init:  PluginEnvVars(map[string]map[string]string{}),
+			input: "name.env=val",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+		}, {
+			desc: "Set value again same plugin",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env2=val2",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val", "env2": "val2"},
+			}),
+		}, {
+			desc: "Set value again different plugin",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name2.env2=val2",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name":  map[string]string{"env": "val"},
+				"name2": map[string]string{"env2": "val2"},
+			}),
+		}, {
+			desc: "Override value already in map",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env=val2",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val2"},
+			}),
+		}, {
+			desc: "Empty string if no equals",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env2",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val", "env2": ""},
+			}),
+		}, {
+			desc: "Empty string if equals but no value",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env2=",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val", "env2": ""},
+			}),
+		}, {
+			desc: "Splits on first period",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env.with.dot=val2",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val", "env.with.dot": "val2"},
+			}),
+		}, {
+			desc: "Splits on first equals and period",
+			init: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+			input: "name.env.with.dot=val=with=equals",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val", "env.with.dot": "val=with=equals"},
+			}),
+		}, {
+			desc:  "Starting with nil map",
+			init:  PluginEnvVars(nil),
+			input: "name.env=val",
+			expect: PluginEnvVars(map[string]map[string]string{
+				"name": map[string]string{"env": "val"},
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.init.Set(tc.input)
+			switch {
+			case err != nil && len(tc.expectErr) == 0:
+				t.Fatalf("Expected nil error but got %q", err)
+			case err != nil && len(tc.expectErr) > 0:
+				if fmt.Sprint(err) != tc.expectErr {
+					t.Errorf("Expected error \n\t%q\nbut got\n\t%q", tc.expectErr, err)
+				}
+				return
+			case err == nil && len(tc.expectErr) > 0:
+				t.Fatalf("Expected error %q but got nil", tc.expectErr)
+			default:
+				// No error
+			}
+
+			if diff := pretty.Compare(tc.expect, tc.init); diff != "" {
+				t.Fatalf("\n\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -52,6 +52,11 @@ type genFlags struct {
 	// flag support.
 	plugins pluginList
 
+	// pluginEnvs is a set of overrides for plugin env vars. Provided out of band
+	// from the list of plugins because the e2e/systemd plugins are dynamically
+	// generated at the current time and so we can't manipulate those objects.
+	pluginEnvs PluginEnvVars
+
 	// These two fields are here since to properly squash settings down into nested
 	// configs we need to tell whether or not values are default values or the user
 	// provided them on the command line/config file.
@@ -79,6 +84,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	AddSSHUserFlag(&cfg.sshUser, genset)
 
 	AddPluginSetFlag(&cfg.plugins, genset)
+	AddPluginEnvFlag(&cfg.pluginEnvs, genset)
 	cfg.genflags = genset
 	return genset
 }
@@ -143,6 +149,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		SSHUser:              g.sshUser,
 		DynamicPlugins:       g.plugins.DynamicPlugins,
 		StaticPlugins:        g.plugins.StaticPlugins,
+		PluginEnvOverrides:   g.pluginEnvs,
 	}, nil
 }
 

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -296,6 +296,26 @@ func TestGenerateManifestGolden(t *testing.T) {
 				},
 			},
 			goldenFile: filepath.Join("testdata", "imagePullSecrets.golden"),
+		}, {
+			name: "Env overrides",
+			inputcm: &client.GenConfig{
+				E2EConfig:      &client.E2EConfig{},
+				DynamicPlugins: []string{"e2e"},
+				PluginEnvOverrides: map[string]map[string]string{
+					"e2e": map[string]string{"E2E_SKIP": "override", "E2E_DRYRUN": "true"},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "envoverrides.golden"),
+		}, {
+			name: "Env overrides must match plugin names",
+			inputcm: &client.GenConfig{
+				E2EConfig:      &client.E2EConfig{},
+				DynamicPlugins: []string{"e2e"},
+				PluginEnvOverrides: map[string]map[string]string{
+					"e2e2": map[string]string{"E2E_SKIP": "override", "E2E_DRYRUN": "true"},
+				},
+			},
+			expectErr: "failed to override env vars for plugin e2e2, no plugin with that name found; have plugins: [e2e]",
 		},
 	}
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -57,6 +57,13 @@ type GenConfig struct {
 	// explicitly and will be written without further consideration of other
 	// GenConfig settings.
 	StaticPlugins []*manifest.Manifest
+
+	// PluginEnvOverrides are mappings between plugin name and k-v pairs to be
+	// set as env vars on the given plugin. If a plugin has overrides set, it
+	// will completely override all other env vars set on the plugin. Provided
+	// out of band from the plugins because of how the dynamic plugins are not
+	// yet able to be manipulated in this way.
+	PluginEnvOverrides map[string]map[string]string
 }
 
 // E2EConfig is the configuration of the E2E tests.

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -1,0 +1,113 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-type: e2e
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_DRYRUN
+        value: "true"
+      - name: E2E_FOCUS
+      - name: E2E_PARALLEL
+      - name: E2E_SKIP
+        value: override
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a new flag and backing type in order to gather and
set env vars on any plugin from the command line which
makes it easier to iterate on plugins/tests.

This PR does the following:
 - adds new flag --plugin-env and backing type
 - adds new field on GenConfig in order to pass this to
pkg/client/gen/GenerateManifest(...) in order to apply
the changes after the dynamic plugins have been generated.
 - adds logic to sort the env var to ensure a stable order
for testing/use

On the command line the values are of the form:
--plugin-env pluginName.env=val

**Which issue(s) this PR fixes**
Fixes #639

**Release note**:
```
Added new flag --plugin-env allowing users to specify env var values on any plugin from the command line.
```
