### PR TITLE
Use go modules when getting KinD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 
 before_install:
   # Download and install Kind and kubectl
-  - go get sigs.k8s.io/kind
+  - GO111MODULE=on go get sigs.k8s.io/kind
   - kind create cluster --config kind-config.yaml
   - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
   - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently moved to modules and removed the vendor directory. In
order to get `go get` to work we need to ensure we are using
the modules as intended.

**Which issue(s) this PR fixes**
Fixes #713

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
