### PR TITLE
Ensure conformance image version is prefixed with 'v'

### DIFF
--- a/pkg/image/imageversion.go
+++ b/pkg/image/imageversion.go
@@ -59,7 +59,10 @@ func (c *ConformanceImageVersion) Set(str string) error {
 		if err != nil {
 			return err
 		}
-		*c = ConformanceImageVersion(version.String())
+
+		// It is important to set the string with the `v` prefix in order
+		// to be consistent with server version reporting and image tagging norms.
+		*c = ConformanceImageVersion(fmt.Sprintf("v%v", version.String()))
 	}
 
 	return nil

--- a/pkg/image/imageversion_test.go
+++ b/pkg/image/imageversion_test.go
@@ -33,16 +33,19 @@ func TestSetConformanceImageVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
+		expect  string
 		error   bool
 	}{
 		{
 			name:    "version detect",
 			version: "auto",
+			expect:  "auto",
 			error:   false,
 		},
 		{
 			name:    "use latest",
 			version: "latest",
+			expect:  "latest",
 			error:   false,
 		},
 		{
@@ -53,12 +56,25 @@ func TestSetConformanceImageVersion(t *testing.T) {
 		{
 			name:    "stable version",
 			version: "v1.13.0",
+			expect:  "v1.13.0",
 			error:   false,
 		},
 		{
 			name:    "version without v",
 			version: "1.13.0",
 			error:   true,
+		},
+		{
+			name:    "version without patch",
+			version: "v1.13",
+			expect:  "v1.13.0",
+			error:   false,
+		},
+		{
+			name:    "version without minor/patch",
+			version: "v1",
+			expect:  "v1.0.0",
+			error:   false,
 		},
 		{
 			name:    "empty string",
@@ -68,6 +84,7 @@ func TestSetConformanceImageVersion(t *testing.T) {
 		{
 			name:    "version with addendum",
 			version: "v1.13.0-beta.2.78+e0b33dbc2bde88",
+			expect:  "v1.13.0-beta.2.78+e0b33dbc2bde88",
 			error:   false,
 		},
 		{
@@ -77,14 +94,17 @@ func TestSetConformanceImageVersion(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			var v ConformanceImageVersion
-			err := v.Set(test.version)
-			if test.error && err == nil {
-				t.Error("expected error, got nil")
-			} else if !test.error && err != nil {
-				t.Errorf("expected no error, got %v", err)
+			err := v.Set(tc.version)
+			if tc.error && err == nil {
+				t.Fatal("expected error, got nil")
+			} else if !tc.error && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if v.String() != tc.expect {
+				t.Errorf("Expected %q but got %q", tc.expect, v.String())
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using flags to set the kube-conformance-image-version
the `Set` method ends up stripping the `v` prefix which it
requires the user to provide.

This causes a problem because the rest of the codebase assumes
the version will start with that prefix due to the fact that that
is how images are tagged (for Sonobuoy, Heptio kube-conformance,
and for upstream conformance images).

This change just adds the prefix back after validating the version
and updates the tests to actually check for the version that
gets persisted.

**Which issue(s) this PR fixes**
Fixes #716

**Special notes for your reviewer**:
A simple test:
```
$ ./sonobuoy gen --kube-conformance-image-version=v1.14.0|grep conform
$ ./sonobuoy gen --kube-conformance-image-version=v1.14.1|grep conform
```
Both of those should result in images with the tag prefixed with `v`. In addition, the first should be a heptio image, the latter a google image.

As it stands now, the `v` prefix is missing and both try to use the Heptio registry due to the missing prefix affecting the comparison.


**Release note**:
```
Fixes handling of the --kube-conformance-image-version flag so that the resulting conformance image tag is prefixed with 'v' as expected.
```
