### PR TITLE
Properly report error when a plugin fails to run

### DIFF
--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -64,7 +64,7 @@ func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy,
 // a Job only launches one pod, only one result type is expected.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return []plugin.ExpectedResult{
-		plugin.ExpectedResult{ResultType: p.GetResultType()},
+		{ResultType: p.GetResultType()},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the logic of the aggregator short circuits when a
plugin fails to `Run` without error. It exits abruptly and does
not launch other plugins or report the failure on the plugin
status.

This commit changes the following behavior:
 - ensures we can create all the auth certs needed before launching
any plugins, ensuring we don't fail to generate some certs after
other plugins are already running.
 - when a plugin fails to Run without error, we send a failing
result so that the aggregator properly reports the status of
the plugin as an error and the results tarball shows the error
as expected.

**Which issue(s) this PR fixes**
Fixes #559

**Special notes for your reviewer**:
No good test for the entire logic here, I can attach some screenshots of when I modified the code to force an error though.

**Release note**:
```
The aggregator server will now report a plugin as failed if it can't properly be started and will continue starting other plugins.
```
