### PR TITLE
Add ability to specify custom annotations

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin.go
+++ b/cmd/sonobuoy/app/gen_plugin.go
@@ -40,9 +40,10 @@ const (
 
 // GenPluginConfig are the input options for running
 type GenPluginConfig struct {
-	Paths            []string
-	PluginName       string
-	ImagePullSecrets string
+	Paths             []string
+	PluginName        string
+	ImagePullSecrets  string
+	CustomAnnotations map[string]string
 }
 
 var genPluginOpts GenPluginConfig
@@ -86,6 +87,7 @@ func generatePluginManifest(cfg GenPluginConfig) ([]byte, error) {
 		config.DefaultImage,
 		"Always",
 		cfg.ImagePullSecrets,
+		cfg.CustomAnnotations,
 		cfg.Paths,
 		[]plugin.Selection{{Name: cfg.PluginName}},
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,9 +155,10 @@ type Config struct {
 	///////////////////////////////////////////////
 	// Sonobuoy configuration
 	///////////////////////////////////////////////
-	WorkerImage      string `json:"WorkerImage" mapstructure:"WorkerImage"`
-	ImagePullPolicy  string `json:"ImagePullPolicy" mapstructure:"ImagePullPolicy"`
-	ImagePullSecrets string `json:"ImagePullSecrets" mapstructure:"ImagePullSecrets"`
+	WorkerImage       string            `json:"WorkerImage" mapstructure:"WorkerImage"`
+	ImagePullPolicy   string            `json:"ImagePullPolicy" mapstructure:"ImagePullPolicy"`
+	ImagePullSecrets  string            `json:"ImagePullSecrets" mapstructure:"ImagePullSecrets"`
+	CustomAnnotations map[string]string `json:"CustomAnnotations,omitempty" mapstructure:"CustomAnnotations"`
 }
 
 // LimitConfig is a configuration on the limits of sizes of various responses.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -123,6 +123,7 @@ func loadAllPlugins(cfg *Config) error {
 		cfg.WorkerImage,
 		cfg.ImagePullPolicy,
 		cfg.ImagePullSecrets,
+		cfg.CustomAnnotations,
 		cfg.PluginSearchPath,
 		cfg.PluginSelections,
 	)

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -33,13 +33,14 @@ import (
 
 // Base is the struct that stores state for plugin drivers and contains helper methods.
 type Base struct {
-	Definition       plugin.Definition
-	SessionID        string
-	Namespace        string
-	SonobuoyImage    string
-	CleanedUp        bool
-	ImagePullPolicy  string
-	ImagePullSecrets string
+	Definition        plugin.Definition
+	SessionID         string
+	Namespace         string
+	SonobuoyImage     string
+	CleanedUp         bool
+	ImagePullPolicy   string
+	ImagePullSecrets  string
+	CustomAnnotations map[string]string
 }
 
 // TemplateData is all the fields available to plugin driver templates.
@@ -51,6 +52,7 @@ type TemplateData struct {
 	SonobuoyImage     string
 	ImagePullPolicy   string
 	ImagePullSecrets  string
+	CustomAnnotations map[string]string
 	ProducerContainer string
 	MasterAddress     string
 	CACert            string
@@ -105,6 +107,7 @@ func (b *Base) GetTemplateData(masterAddress string, cert *tls.Certificate) (*Te
 		SonobuoyImage:     b.SonobuoyImage,
 		ImagePullPolicy:   b.ImagePullPolicy,
 		ImagePullSecrets:  b.ImagePullSecrets,
+		CustomAnnotations: b.CustomAnnotations,
 		ProducerContainer: string(container),
 		MasterAddress:     masterAddress,
 		CACert:            cacert,

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -47,16 +47,17 @@ var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
 // and sonobuoy master address.
-func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string) *Plugin {
+func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
 	return &Plugin{
 		driver.Base{
-			Definition:       dfn,
-			SessionID:        utils.GetSessionID(),
-			Namespace:        namespace,
-			SonobuoyImage:    sonobuoyImage,
-			ImagePullPolicy:  imagePullPolicy,
-			ImagePullSecrets: imagePullSecrets,
-			CleanedUp:        false,
+			Definition:        dfn,
+			SessionID:         utils.GetSessionID(),
+			Namespace:         namespace,
+			SonobuoyImage:     sonobuoyImage,
+			ImagePullPolicy:   imagePullPolicy,
+			ImagePullSecrets:  imagePullSecrets,
+			CustomAnnotations: customAnnotations,
+			CleanedUp:         false,
 		},
 	}
 }

--- a/pkg/plugin/driver/daemonset/daemonset_test.go
+++ b/pkg/plugin/driver/daemonset/daemonset_test.go
@@ -68,7 +68,7 @@ func TestFillTemplate(t *testing.T) {
 				},
 			},
 		},
-	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret")
+	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
 
 	auth, err := ca.NewAuthority()
 	if err != nil {
@@ -155,5 +155,14 @@ func TestFillTemplate(t *testing.T) {
 		if pullSecrets[0].Name != "image-pull-secret" {
 			t.Errorf("Expected imagePullSecrets with name %v but got %v", "image-pull-secret", pullSecrets)
 		}
+	}
+
+	if daemonSet.Annotations["key1"] != "val1" ||
+		daemonSet.Annotations["key2"] != "val2" {
+		t.Errorf("Expected annotations key1:val1 and key2:val2 to be set, but got %v", daemonSet.Annotations)
+	}
+	if daemonSet.Spec.Template.Annotations["key1"] != "val1" ||
+		daemonSet.Spec.Template.Annotations["key2"] != "val2" {
+		t.Errorf("Expected annotations key1:val1 and key2:val2 to be set, but got %v", daemonSet.Spec.Template.Annotations)
 	}
 }

--- a/pkg/plugin/driver/daemonset/template.go
+++ b/pkg/plugin/driver/daemonset/template.go
@@ -29,6 +29,9 @@ metadata:
     sonobuoy-driver: DaemonSet
     sonobuoy-plugin: {{.PluginName}}
     sonobuoy-result-type: {{.ResultType}}
+    {{- if .CustomAnnotations }}{{- range $k, $v := .CustomAnnotations }}
+    {{ indent 4 $k}}: {{$v}}
+    {{- end }}{{- end }}
   labels:
     component: sonobuoy
     sonobuoy-run: '{{.SessionID}}'
@@ -45,6 +48,10 @@ spec:
         component: sonobuoy
         sonobuoy-run: '{{.SessionID}}'
         tier: analysis
+      {{- if .CustomAnnotations }}
+      annotations:{{- range $k, $v := .CustomAnnotations }}
+        {{ indent 8 $k}}: {{$v}}
+      {{- end }}{{- end }}
     spec:
       containers:
       - {{.ProducerContainer | indent 8}}

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -46,16 +46,17 @@ var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
 // and sonobuoy master address.
-func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string) *Plugin {
+func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
 	return &Plugin{
 		driver.Base{
-			Definition:       dfn,
-			SessionID:        utils.GetSessionID(),
-			Namespace:        namespace,
-			SonobuoyImage:    sonobuoyImage,
-			ImagePullPolicy:  imagePullPolicy,
-			ImagePullSecrets: imagePullSecrets,
-			CleanedUp:        false, // be explicit
+			Definition:        dfn,
+			SessionID:         utils.GetSessionID(),
+			Namespace:         namespace,
+			SonobuoyImage:     sonobuoyImage,
+			ImagePullPolicy:   imagePullPolicy,
+			ImagePullSecrets:  imagePullSecrets,
+			CustomAnnotations: customAnnotations,
+			CleanedUp:         false, // be explicit
 		},
 	}
 }

--- a/pkg/plugin/driver/job/job_test.go
+++ b/pkg/plugin/driver/job/job_test.go
@@ -67,7 +67,7 @@ func TestFillTemplate(t *testing.T) {
 				},
 			},
 		},
-	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret")
+	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
 
 	auth, err := ca.NewAuthority()
 	if err != nil {
@@ -152,6 +152,11 @@ func TestFillTemplate(t *testing.T) {
 		if pod.Spec.ImagePullSecrets[0].Name != "image-pull-secret" {
 			t.Errorf("Expected imagePullSecrets with name %v but got %v", "image-pull-secret", pod.Spec.ImagePullSecrets)
 		}
+	}
+
+	if pod.Annotations["key1"] != "val1" ||
+		pod.Annotations["key2"] != "val2" {
+		t.Errorf("Expected annotations key1:val1 and key2:val2 to be set, but got %v", pod.Annotations)
 	}
 
 }

--- a/pkg/plugin/driver/job/template.go
+++ b/pkg/plugin/driver/job/template.go
@@ -29,6 +29,9 @@ metadata:
     sonobuoy-driver: Job
     sonobuoy-plugin: {{.PluginName}}
     sonobuoy-result-type: {{.ResultType}}
+    {{- if .CustomAnnotations }}{{- range $k, $v := .CustomAnnotations }}
+    {{ indent 4 $k}}: {{$v}}
+    {{- end }}{{- end }}
   labels:
     component: sonobuoy
     sonobuoy-run: '{{.SessionID}}'

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -37,7 +37,7 @@ import (
 // directory, taking a user's plugin selections, and a sonobuoy phone home
 // address (host:port) and returning all of the active, configured plugins for
 // this sonobuoy run.
-func LoadAllPlugins(namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, searchPath []string, selections []plugin.Selection) (ret []plugin.Interface, err error) {
+func LoadAllPlugins(namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string, searchPath []string, selections []plugin.Selection) (ret []plugin.Interface, err error) {
 	pluginDefinitionFiles := make(map[string]struct{})
 	for _, dir := range searchPath {
 		wd, _ := os.Getwd()
@@ -83,7 +83,7 @@ func LoadAllPlugins(namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets 
 
 	plugins := []plugin.Interface{}
 	for _, def := range pluginDefinitions {
-		loadedPlugin, err := loadPlugin(def, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets)
+		loadedPlugin, err := loadPlugin(def, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets, customAnnotations)
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load plugin %v", def.SonobuoyConfig.PluginName)
 		}
@@ -123,7 +123,7 @@ func loadDefinition(bytes []byte) (*manifest.Manifest, error) {
 	return &def, errors.Wrap(err, "couldn't decode yaml for plugin definition")
 }
 
-func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string) (plugin.Interface, error) {
+func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) (plugin.Interface, error) {
 	pluginDef := plugin.Definition{
 		Name:         def.SonobuoyConfig.PluginName,
 		ResultType:   def.SonobuoyConfig.ResultType,
@@ -133,9 +133,9 @@ func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolic
 
 	switch strings.ToLower(def.SonobuoyConfig.Driver) {
 	case "job":
-		return job.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets), nil
+		return job.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets, customAnnotations), nil
 	case "daemonset":
-		return daemonset.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets), nil
+		return daemonset.NewPlugin(pluginDef, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets, customAnnotations), nil
 	default:
 		return nil, fmt.Errorf("unknown driver %q for plugin %v",
 			def.SonobuoyConfig.Driver, def.SonobuoyConfig.PluginName)

--- a/pkg/plugin/loader/loader_test.go
+++ b/pkg/plugin/loader/loader_test.go
@@ -115,7 +115,7 @@ func TestLoadJobPlugin(t *testing.T) {
 		},
 	}
 
-	pluginIface, err := loadPlugin(jobDef, namespace, image, "Always", "image-pull-secrets")
+	pluginIface, err := loadPlugin(jobDef, namespace, image, "Always", "image-pull-secrets", nil)
 	if err != nil {
 		t.Fatalf("unexpected error loading plugin: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestLoadDaemonSet(t *testing.T) {
 		},
 	}
 
-	pluginIface, err := loadPlugin(daemonDef, namespace, image, "Always", "image-pull-secrets")
+	pluginIface, err := loadPlugin(daemonDef, namespace, image, "Always", "image-pull-secrets", nil)
 	if err != nil {
 		t.Fatalf("unexpected error loading plugin: %v", err)
 	}
@@ -205,6 +205,7 @@ func TestLoadAllPlugins(t *testing.T) {
 		sonobuoyImage       string
 		imagePullPolicy     string
 		imagePullSecrets    string
+		customAnnotations   map[string]string
 		searchPath          []string
 		selections          []plugin.Selection
 		expectedPluginNames []string
@@ -213,8 +214,8 @@ func TestLoadAllPlugins(t *testing.T) {
 			testname:   "ensure duplicate paths do not result in duplicate loaded plugins.",
 			searchPath: []string{path.Join("testdata", "plugin.d"), path.Join("testdata", "plugin.d")},
 			selections: []plugin.Selection{
-				plugin.Selection{Name: "test-job-plugin"},
-				plugin.Selection{Name: "test-daemon-set-plugin"},
+				{Name: "test-job-plugin"},
+				{Name: "test-daemon-set-plugin"},
 			},
 			expectedPluginNames: []string{"test-job-plugin", "test-daemon-set-plugin"},
 		}, {
@@ -232,7 +233,7 @@ func TestLoadAllPlugins(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.testname, func(t *testing.T) {
-			plugins, err := LoadAllPlugins(tc.namespace, tc.sonobuoyImage, tc.imagePullPolicy, tc.imagePullSecrets, tc.searchPath, tc.selections)
+			plugins, err := LoadAllPlugins(tc.namespace, tc.sonobuoyImage, tc.imagePullPolicy, tc.imagePullSecrets, tc.customAnnotations, tc.searchPath, tc.selections)
 			if err != nil {
 				t.Fatalf("error loading all plugins: %v", err)
 			}

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -114,6 +114,11 @@ metadata:
     tier: analysis
   name: sonobuoy
   namespace: {{.Namespace}}
+{{- if .CustomAnnotations }}
+  annotations:{{- range $k, $v := .CustomAnnotations }}
+    {{ indent 4 $k}}: {{$v}}
+{{- end }}
+{{- end }}
 spec:
   containers:
   - command:


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases it may be necessary to add custom annotations
to the sonobuoy pods (aggregator and plugins). Most notably,
this helps facilitate kiam permissions.

This change adds the fields to the necessary types so that it
can be passed around appropriatly and fill in the different
templates where it should be used.

**Which issue(s) this PR fixes**
Fixes #567

**Special notes for your reviewer**:
To review the changes, you mainly just need to look at the modifications to the tests/templates I made.

They are not exactly the most idiomatic tests; they hard-code a single test case and then check each part of the result manually. I'd like to improve those sorts of tests but this PR is not the place for it; instead, I just opted to focus on the feature and leave the refactoring for another day (to be clear, I just extended existing tests).

It would be nice to have a way to _really_ generate the plugin yaml from the command line in a realistic way. There is currently a command that does that for dev purposes like this, but it hardcodes some things you may want to test and it doesn't follow the same path as `sonobuoy master` which really loads the plugins/configs. I may work on trying to get those in line so that testing things like this is not so difficult.

**Release note**:
```
Added a "CustomAnnotations" field to the configuration options so that you can annotate all the Sonobuoy pods/plugins with custom values. The values are added to any set Sonobuoy would already be using, and it is left to the user to ensure they do not collide.
```
