### PR TITLE
Don't create resource directories if not querying for resources

### DIFF
--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -137,6 +137,11 @@ func QueryResources(
 	ns *string,
 	cfg *config.Config) error {
 
+	// Early exit; avoid forming query or creating output directories.
+	if len(resources) == 0 {
+		return nil
+	}
+
 	if ns != nil {
 		logrus.Infof("Running ns query (%v)", *ns)
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ordering issue in the logic caused the paths to be created even
if the queries were noops. This adds an empty-check before
creating the directories at all.

**Which issue(s) this PR fixes**
Related to #721

**Special notes for your reviewer**:

**Release note**:
```
Fixed an issue which caused some query directories to be created even if queries were not run on the namespaces corresponding to those directories.
```
