### PR TITLE
Use a struct for GetStatus to be consistent

### DIFF
--- a/cmd/sonobuoy/app/status.go
+++ b/cmd/sonobuoy/app/status.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/heptio/sonobuoy/pkg/client"
 	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
@@ -64,7 +65,9 @@ func getStatus(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	status, err := sbc.GetStatus(statusFlags.namespace)
+	status, err := sbc.GetStatus(&client.StatusConfig{
+		Namespace: statusFlags.namespace,
+	})
 	if err != nil {
 		errlog.LogError(errors.Wrap(err, "error attempting to run sonobuoy"))
 		os.Exit(1)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -98,6 +98,12 @@ type RetrieveConfig struct {
 	Namespace string
 }
 
+// StatusConfig is the input options for retrieving a Sonobuoy run's results.
+type StatusConfig struct {
+	// Namespace is the namespace the sonobuoy aggregator is running in.
+	Namespace string
+}
+
 // PreflightConfig are the options passed to PreflightChecks.
 type PreflightConfig struct {
 	Namespace string
@@ -155,7 +161,7 @@ type Interface interface {
 	// RetrieveResults copies results from a sonobuoy run into a Reader in tar format.
 	RetrieveResults(cfg *RetrieveConfig) (io.Reader, <-chan error)
 	// GetStatus determines the status of the sonobuoy run in order to assist the user.
-	GetStatus(namespace string) (*aggregation.Status, error)
+	GetStatus(cfg *StatusConfig) (*aggregation.Status, error)
 	// LogReader returns a reader that contains a merged stream of sonobuoy logs.
 	LogReader(cfg *LogConfig) (*Reader, error)
 	// Delete removes a sonobuoy run, namespace, and all associated resources.

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -92,7 +92,7 @@ func (c *SonobuoyClient) Run(cfg *RunConfig) error {
 		seenStatus := false
 		runCondition := func() (bool, error) {
 			// Get the heptio pod and check if its status is completed or terminated.
-			status, err := c.GetStatus(cfg.Config.Namespace)
+			status, err := c.GetStatus(&StatusConfig{cfg.Config.Namespace})
 			switch {
 			case err != nil && seenStatus:
 				return false, errors.Wrap(err, "failed to get status")

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -20,11 +20,11 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
 
-func (c *SonobuoyClient) GetStatus(namespace string) (*aggregation.Status, error) {
+func (c *SonobuoyClient) GetStatus(cfg *StatusConfig) (*aggregation.Status, error) {
 	client, err := c.Client()
 	if err != nil {
 		return nil, err
 	}
 
-	return aggregation.GetStatus(client, namespace)
+	return aggregation.GetStatus(client, cfg.Namespace)
 }


### PR DESCRIPTION


**What this PR does / why we need it**:
Increases consistency of our method signatures for the interface.

**Which issue(s) this PR fixes**
Fixes #337

**Special notes for your reviewer**:

**Release note**:
```
The GetStatus method on the pkg/Interface (and SonobuoyClient type) will now take a struct which wraps the namespaces to increase in consistency and future extensibility.
```
