### PR TITLE
Add checks for if a container has terminated

### DIFF
--- a/pkg/plugin/aggregation/aggregator_test.go
+++ b/pkg/plugin/aggregation/aggregator_test.go
@@ -18,6 +18,7 @@ package aggregation
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -327,7 +328,7 @@ func TestAggregation_errors(t *testing.T) {
 
 	withAggregator(t, expected, func(agg *Aggregator, srv *authtest.Server) {
 		resultsCh := make(chan *plugin.Result)
-		go agg.IngestResults(resultsCh)
+		go agg.IngestResults(context.TODO(), resultsCh)
 
 		// Send an error
 		resultsCh <- pluginutils.MakeErrorResult("e2e", map[string]interface{}{"error": "foo"}, "")

--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -1,0 +1,192 @@
+package aggregation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/heptio/sonobuoy/pkg/plugin/driver"
+	"github.com/heptio/sonobuoy/pkg/plugin/driver/job"
+	sonotime "github.com/heptio/sonobuoy/pkg/time/timetest"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestRunAndMonitorPlugin(t *testing.T) {
+	// Dead simple plugin works for this test. No need to test daemonset/job specific logic so
+	// a job plugin is much simpler to test against.
+	testPlugin := &job.Plugin{
+		Base: driver.Base{
+			Definition: plugin.Definition{
+				Name:       "myPlugin",
+				ResultType: "myPlugin",
+			},
+			Namespace: "testNS",
+		},
+	}
+	testPluginExpectedResults := []plugin.ExpectedResult{
+		{ResultType: "myPlugin"},
+	}
+	healthyPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"sonobuoy-run": ""}},
+	}
+	failingPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"sonobuoy-run": ""}},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Reason: "Unschedulable"},
+			},
+		},
+	}
+	testCert, err := getTestCert()
+	if err != nil {
+		t.Fatalf("Could not generate test cert: %v", err)
+	}
+
+	sonotime.UseShortAfter()
+	defer sonotime.ResetAfter()
+
+	testCases := []struct {
+		desc string
+
+		expectNumResults   int
+		expectStillRunning bool
+		forceResults       bool
+		cancelContext      bool
+
+		plugin           plugin.Interface
+		expectedResults  []plugin.ExpectedResult
+		podList          *corev1.PodList
+		podCreationError error
+	}{
+		{
+			desc:            "Continue monitoring if no results/errors",
+			plugin:          testPlugin,
+			expectedResults: testPluginExpectedResults,
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{healthyPod},
+			},
+			expectStillRunning: true,
+		}, {
+			desc:            "Error launching plugin causes exit and plugin result",
+			plugin:          testPlugin,
+			expectedResults: testPluginExpectedResults,
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{healthyPod},
+			},
+			podCreationError: errors.New("createPod error"),
+			expectNumResults: 1,
+		}, {
+			desc:            "Failing plugin causes exit and plugin result",
+			plugin:          testPlugin,
+			expectedResults: testPluginExpectedResults,
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{failingPod},
+			},
+			expectNumResults: 1,
+		}, {
+			desc:            "Plugin obtaining results in exits",
+			plugin:          testPlugin,
+			expectedResults: testPluginExpectedResults,
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{healthyPod},
+			},
+			forceResults:     true,
+			expectNumResults: 1,
+		}, {
+			desc:            "Context cancellation results in exit",
+			plugin:          testPlugin,
+			expectedResults: testPluginExpectedResults,
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{healthyPod},
+			},
+			cancelContext:    true,
+			expectNumResults: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a := NewAggregator(".", tc.expectedResults)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			fclient := fake.NewSimpleClientset()
+			fclient.PrependReactor("list", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tc.podList, nil
+			})
+			fclient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, tc.podCreationError
+			})
+
+			doneCh, timeoutCh := make(chan (struct{}), 1), make(chan (struct{}), 1)
+			if tc.cancelContext {
+				cancel()
+			} else {
+				// Max timeout for test to unblock.
+				go func() {
+					time.Sleep(2 * time.Second)
+					timeoutCh <- struct{}{}
+					cancel()
+				}()
+			}
+
+			go func() {
+				a.RunAndMonitorPlugin(ctx, tc.plugin, fclient, nil, "testname", testCert)
+				doneCh <- struct{}{}
+			}()
+
+			if tc.forceResults {
+				a.resultsMutex.Lock()
+				a.Results["myPlugin"] = &plugin.Result{}
+				a.resultsMutex.Unlock()
+			}
+
+			// Wait for completion/timeout and see which happens first.
+			wasStillRunning := false
+			select {
+			case <-doneCh:
+				t.Log("runAndMonitor is done")
+			case <-timeoutCh:
+				t.Log("runAndMonitor timed out")
+				wasStillRunning = true
+			}
+
+			if len(a.Results) != tc.expectNumResults {
+				t.Errorf("Expected %v results but found %v: %+v", tc.expectNumResults, len(a.Results), a.Results)
+			}
+			if wasStillRunning != tc.expectStillRunning {
+				t.Errorf("Expected wasStillMonitoring %v but found %v", tc.expectStillRunning, wasStillRunning)
+			}
+		})
+	}
+}
+
+func getTestCert() (*tls.Certificate, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't generate private key")
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &privKey.PublicKey, privKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create certificate")
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  privKey,
+	}, nil
+}

--- a/pkg/plugin/driver/utils/utils_test.go
+++ b/pkg/plugin/driver/utils/utils_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodFailing(t *testing.T) {
+	// fromGoodPod is a helper function to simplify the specification of test cases.
+	fromGoodPod := func(f func(*corev1.Pod) *corev1.Pod) *corev1.Pod {
+		goodPod := &v1.Pod{}
+		return f(goodPod)
+	}
+
+	testCases := []struct {
+		desc          string
+		pod           *v1.Pod
+		expectFailing bool
+		expectMsg     string
+	}{
+		{
+			desc: "OK pod not failing",
+			pod:  fromGoodPod(func(p *corev1.Pod) *corev1.Pod { return p }),
+		}, {
+			desc:          "Terminated container reported failing if old enough",
+			expectFailing: true,
+			expectMsg:     "Container container1 is terminated state (exit code 1) due to reason: myReason: myMsg",
+			pod: fromGoodPod(func(p *corev1.Pod) *corev1.Pod {
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{
+						Name: "container1",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:     "myReason",
+								Message:    "myMsg",
+								ExitCode:   1,
+								FinishedAt: metav1.Time{Time: time.Now().Add(-3 * terminatedContainerWindow)},
+							},
+						}},
+				}
+				return p
+			}),
+		}, {
+			desc:          "Terminated container not reported failing if too recent",
+			expectFailing: false,
+			expectMsg:     "",
+			pod: fromGoodPod(func(p *corev1.Pod) *corev1.Pod {
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:     "reason",
+							Message:    "msg",
+							ExitCode:   1,
+							FinishedAt: metav1.Time{Time: time.Now()},
+						},
+					}},
+				}
+				return p
+			}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			failing, msg := IsPodFailing(tc.pod)
+			if failing != tc.expectFailing {
+				t.Errorf("Expected %v but got %v", tc.expectFailing, failing)
+			}
+			if msg != tc.expectMsg {
+				t.Errorf("Expected %v but got %v", tc.expectMsg, msg)
+			}
+		})
+	}
+}

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
 	"crypto/tls"
 	"io"
 	"path"
@@ -37,8 +38,9 @@ type Interface interface {
 	// Monitor continually checks for problems in the resources created by a
 	// plugin (either because it won't schedule, or the image won't
 	// download, too many failed executions, etc) and sends the errors as
-	// Result objects through the provided channel.
-	Monitor(kubeClient kubernetes.Interface, availableNodes []v1.Node, resultsCh chan<- *Result)
+	// Result objects through the provided channel. It should return once the context
+	// is cancelled.
+	Monitor(ctx context.Context, kubeClient kubernetes.Interface, availableNodes []v1.Node, resultsCh chan<- *Result)
 	// ExpectedResults is an array of Result objects that a plugin should
 	// expect to submit.
 	ExpectedResults(nodes []v1.Node) []ExpectedResult

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,0 +1,10 @@
+package time
+
+import (
+	"time"
+)
+
+// After is a function variable for swapping during tests, allowing
+// variable behavior, tracking of calls, etc depending on what the test
+// needs.
+var After = time.After

--- a/pkg/time/timetest/helpers.go
+++ b/pkg/time/timetest/helpers.go
@@ -1,0 +1,31 @@
+package timetest
+
+import (
+	sonotime "github.com/heptio/sonobuoy/pkg/time"
+	"time"
+)
+
+var (
+	// shortDuration is used in tests when we want to sleep, but not for long
+	// for the sake of testing time.
+	shortDuration = 250 * time.Millisecond
+)
+
+// UseShortAfter updates the After method to expedite sleep times for tests. Callers
+// should call ResetAfter() when they are done with their test.
+func UseShortAfter() {
+	sonotime.After = func(time.Duration) <-chan time.Time { return time.After(shortDuration) }
+}
+
+// UseNoAfter updates the After method to be a noop for tests. Callers
+// should call ResetAfter() when they are done with their test.
+func UseNoAfter() {
+	sonotime.After = func(time.Duration) <-chan time.Time { return time.After(0) }
+}
+
+// ResetAfter is just a test helper to simplify setting the After variable
+// for a specific test and then running this cleanup method when done to
+// return it to its normal state.
+func ResetAfter() {
+	sonotime.After = time.After
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, a plugin's main container may terminate without
reporting results. If this is the case, the sonobuoy worker
hangs forever (until the aggregator times out) because it thinks
the plugin is still running.

This change modifies the logic of the aggregator/plugin monitoring
logic in order to not only check for restarts/failure to schedule,
but also for if containers terminate without submitting results.

To ensure that we do not race with the normal plugin terminate and
result reporting, we wait 1 minute after the pod terminates to submit
the error result. In the normal flow, this would give plenty of time
for the plugin to send its results the server in which case this error
result would be tossed out.

**Which issue(s) this PR fixes**
Fixes #667

**Special notes for your reviewer**:
I added a test to cover the new functionality I added, but I did not add tests for the existing functionality. Those tests can be added later.

**Release note**:
```
Fixed a bug where Sonobuoy wouldn't realize a plugin container failed and would wait until the timeout to report it. Sonobuoy will now recognize that as an error and report it automatically.
```
