### PR TITLE
Fix excerpt separator being shown in blog posts

### DIFF
--- a/site/_posts/2019-05-13-Sonobuoy-101.md
+++ b/site/_posts/2019-05-13-Sonobuoy-101.md
@@ -1,7 +1,7 @@
 ---
 title: Sonobuoy 101
 # image: https://placehold.it/200x200
-excerpt_separator: <!--more-->
+excerpt: Given that there are many ways to create Kubernetes clusters and many environments used to host them, those tasked with maintaining a cluster are often left wondering whether it is ‘correct’.
 author_name: Sonobuoy Team
 author_url: https://www.google.com
 # author_avatar: https://placehold.it/64x64
@@ -9,7 +9,7 @@ categories: [kubernetes]
 # Tag should match author to drive author pages
 tags: ['Sonobuoy Team']
 ---
-Given that there are many ways to create Kubernetes clusters and many environments used to host them, those tasked with maintaining a cluster are often left wondering whether it is ‘correct’.<!--more--> Is it properly configured? Does it work as it should?
+Given that there are many ways to create Kubernetes clusters and many environments used to host them, those tasked with maintaining a cluster are often left wondering whether it is ‘correct’. Is it properly configured? Does it work as it should?
 
 Sonobuoy is a diagnostic tool that aims to address these questions. Sonobuoy makes it easier to understand the state of a Kubernetes cluster by running a set of Kubernetes conformance tests in an accessible and non-destructive manner. Its diagnostics provide a customizable, extendable, and cluster-agnostic way to generate clear, informative reports about your cluster, regardless of your deployment details.
 

--- a/site/_posts/2019-05-15-Certifying-Kubernetes-with-Sonobuoy.md
+++ b/site/_posts/2019-05-15-Certifying-Kubernetes-with-Sonobuoy.md
@@ -1,19 +1,19 @@
 ---
 title: Certifying Kubernetes with Sonobuoy
 image: /img/image1.png
-excerpt_separator: <!--more-->
+excerpt: There are many ways to create Kubernetes clusters and many environments that can host them. As a result, platform operators find it difficult to determine whether a cluster is properly configured and whether it is working as it should.
 author_name: Sonobuoy Team
 # author_avatar: https://placehold.it/64x64
 categories: [kubernetes]
 # Tag should match author to drive author pages
 tags: ['Sonobuoy Team']
 ---
-There are many ways to create Kubernetes clusters and many environments that can host them. As a result, platform operators find it difficult to determine whether a cluster is properly configured and whether it is working as it should.<!--more-->
+There are many ways to create Kubernetes clusters and many environments that can host them. As a result, platform operators find it difficult to determine whether a cluster is properly configured and whether it is working as it should.
 
 **Sonobuoy is an open-source diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of upstream Kubernetes tests in an accessible and non-destructive manner.** It is a customizable, extensible, and cluster-agnostic way to generate clear, informative reports about your cluster — regardless of your deployment details. Sonobuoy is the underlying technology powering the [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance), which was created by the Cloud Native Computing Foundation (CNCF) and is used by every [Certified Kubernetes Service Provider](https://www.cncf.io/certification/kcsp/).
 
 ![Certified Kubernetes](/img/image3.png "Certified Kubernetes")
- 
+
 Sonobuoy has three components:
 * A command-line utility that you use to trigger conformance tests, check status, view activity logs, and retrieve and analyze test results
 * An aggregator that runs in a Kubernetes pod to start plugins and aggregate their test results
@@ -22,7 +22,7 @@ Sonobuoy has three components:
 ![Sonobuoy Run](/img/image1.png "Sonobuoy Run")
 
 With a single Sonobuoy command, you can run the same tests that are used to qualify an upstream Kubernetes release. This ability provides strong levels of assurance that your cluster is configured correctly, and you can use the tool to debug configuration problems.
- 
+
 ## Native Extensibility Through Plugins
 Sonobuoy provides several plugins out of the box, including a systemd log collector and the upstream end-to-end Kubernetes conformance test suite. Sonobuoy is the community standard tool for executing conformance tests on a Kubernetes cluster; however, its architecture is designed to accomplish much more.
 
@@ -33,14 +33,14 @@ The open plugin architecture equips you, as a platform operator, with the means 
 Other plugins from the community exist, such as [Bulkhead](https://github.com/bgeesaman/sonobuoy-plugin-bulkhead). Bulkhead assesses the compliance of a cluster’s control plane and worker nodes with the security guidelines for Kubernetes established in the [CIS Benchmarks](https://www.cisecurity.org/benchmark/kubernetes/). These benchmarks are executed using kube-bench, a tool that implements the CIS Benchmarks based upon the version of Kubernetes that is deployed.
 
 The Sonobuoy team is community driven and would love to hear of any plugins that you have created or ideas on what you would like to see developed. Please open an [issue](https://github.com/heptio/sonobuoy/issues/new/choose) or find us on the Kubernetes Slack [#sonobuoy](https://kubernetes.slack.com/messages/C6L3G051C)!
- 
+
 ## Future Plans
 One of the recurring requests from the community has been the need to [run Sonobuoy in an air-gapped environment](https://github.com/heptio/sonobuoy/issues/160), meaning that the cluster is physically isolated from the Internet. This is important for medical and financial services industries with stringent security requirements. For months, the upstream Kubernetes community has been working to make this possible and we are committed to ensuring that capability is implemented. This will empower anyone to verify and debug their clusters, regardless of Internet connectivity.
 
 Another high-priority item is improving the developer experience and user documentation for creating and running custom plugins. The existing API that plugins have to meet is small but we know there are still some pain points in developing and using your own plugins. Expect documentation improvements, more examples, and improved integration with the CLI for custom plugins. By streamlining the plugin process, we hope to empower the community to create their own plugins and solve even more problems.
 
 Check out the planned features for the next release (version 0.14) by looking at our [Github milestone](https://github.com/heptio/sonobuoy/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3Av0.14+).  Sonobuoy is built by the community so make your voice heard! By creating or commenting on Github issues and communicating in Slack you can help influence future priorities. Issues labeled with [help wanted](https://github.com/heptio/sonobuoy/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3A%22help+wanted%22) or [good first issue](https://github.com/heptio/sonobuoy/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are a great place to start engaging with the project.
- 
+
 ## Join the Sonobuoy Community!
 * Get updates on Twitter ([@projectsonobuoy](https://twitter.com/projectsonobuoy))
 * Chat with us on Slack ([#sonobuoy​](https://kubernetes.slack.com/messages/sonobuoy) on Kubernetes)


### PR DESCRIPTION
Remove the excerpt separator `<!--more-->`, as it is being show in the blog posts:

![image](https://user-images.githubusercontent.com/1690215/59518395-8db07800-8e93-11e9-80c2-8f73b79bc516.png)

Signed-off-by: jonasrosland <jrosland@vmware.com>

**What this PR does / why we need it**:
Fixes the issue mentioned here: https://github.com/heptio/velero/issues/1575
