### PR TITLE
Fix build and cleanup test to ensure clean state for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ Dockerfile-arm64
 *.tar.gz
 *.tar
 
-# kubectl which is downloaded for testing in CI
-kubectl
+# kind is downloaded for testing in CI
+kind
 
 # coverage profile
 coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ script:
   - ./travis-ci.sh 
 
 before_install:
-  # Download and install Kind and kubectl
-  - GO111MODULE=on go get sigs.k8s.io/kind
-  - kind create cluster --config kind-config.yaml
-  - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-
+  # Download and install Kind
+  - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 --output kind && chmod +x kind
+  - ./kind create cluster --config kind-config.yaml
+  - export KUBECONFIG="$(./kind get kubeconfig-path --name="kind")"
 
 before_deploy:
   # Install gcloud cli here so it gets cached

--- a/Makefile
+++ b/Makefile
@@ -181,4 +181,6 @@ clean:
 	done
 
 deploy_kind:
-	kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true
+	# FIXME: This assumes kind is in cwd; intended to work with our other CI scripts and
+	# is a bit wonky for general use.
+	./kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true

--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -7,7 +7,9 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -118,7 +120,12 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			a := NewAggregator(".", tc.expectedResults)
+			tmpDir, err := ioutil.TempDir("", "sonobuoy-test")
+			if err != nil {
+				t.Fatalf("Failed to make temp directory: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+			a := NewAggregator(tmpDir, tc.expectedResults)
 			ctx, cancel := context.WithCancel(context.Background())
 
 			fclient := fake.NewSimpleClientset()


### PR DESCRIPTION
A few files were left around preventing goreleaser from working.
The following changes were made:
 - kubectl removed from deps since we didnt use it any more
 - kind binary was downloaded instead of using go get. This way
we dont end up with creating go.mod and go.sum files and we also
pin the version and prevent changes if they update/break
 - Updated a test to use and cleanup a tmp directory