### PR TITLE
Set GitSHA when using goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     - linux
   goarch:
     - amd64
-  ldflags: -s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v{{.Version}}
+  ldflags: -s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version=v{{.Version}} -X github.com/heptio/sonobuoy/pkg/buildinfo.GitSHA={{.FullCommit}}
 archive:
   format: tar.gz
   files:


### PR DESCRIPTION
**What this PR does / why we need it**:
The makefile sets this flag but goreleaser was not configured
to do so.

**Which issue(s) this PR fixes**
Fixes #748

**Special notes for your reviewer**:
If you download/install https://github.com/goreleaser/goreleaser you can run the following goreleaser command to test it out (for darwin; you can specify the linux path if you need that version):

```
goreleaser --skip-publish --skip-validate --rm-dist && ./dist/darwin_amd64/sonobuoy version
```

**Release note**:
```
Fixed a bug which caused releases to not list the GitSHA they were built from.
```
