### PR TITLE
Ensure dep has been run in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,9 @@ Dockerfile-arm64
 *.tar.gz
 *.tar
 
-# kind is downloaded for testing in CI
+# kind/dep are downloaded for testing in CI
 kind
+dep
 
 # coverage profile
 coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 --output kind && chmod +x kind
   - ./kind create cluster --config kind-config.yaml
   - export KUBECONFIG="$(./kind get kubeconfig-path --name="kind")"
+  - curl -L https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 --output dep && chmod +x dep
 
 before_deploy:
   # Install gcloud cli here so it gets cached

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -3,6 +3,15 @@
 # Don't fail silently when a step doesn't succeed
 set -e
 
+# Early detect/fail if deps not correct.
+./dep ensure
+git_status=$(git status -s)
+if [ -n "$git_status" ]; then
+    echo $git_status
+    echo "dep ensure modified the git status; did you need add/remove a dependency?"
+    exit 1
+fi
+
 make container deploy_kind
 
 echo "|---- Creating new Sonobuoy run/waiting for results..."


### PR DESCRIPTION
**What this PR does / why we need it**:
If someone fails to add a dep then the build will fail but
if they remove one and dont run it then it can lead to
deps hanging around unnecessarily and a future dev/PR getting
a surprising diff.

**Which issue(s) this PR fixes**
Fixes #244

**Special notes for your reviewer**:
dep _says_ that the command is supposed to exit non-zero if it would write something but that is just not true if you try it out/look at the code. Just checking that something gets written to stdout which seems (by looking into the code) to the only way to tell.

I am trying not to hinge on an exact wording like `Would have written` just in case that gets tweaked at some point. We are also pinning the version here though so it should be fine.

**Release note**:
```
NONE
```
