### PR TITLE
Add "native" Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ LINT = golint $(GOLINT_FLAGS) $(TEST_PKGS)
 
 WORKDIR ?= /sonobuoy
 DOCKER_BUILD ?= $(DOCKER) run --rm -v $(DIR):$(BUILDMNT) -w $(BUILDMNT) $(BUILD_IMAGE) /bin/sh -c
+GO_BUILD ?= CGO_ENABLED=0 $(GO_SYSTEM_FLAGS) go build -o $(BINARY) $(VERBOSE_FLAG) -ldflags="-s -w -X $(GOTARGET)/pkg/buildinfo.Version=$(GIT_VERSION) -X $(GOTARGET)/pkg/buildinfo.GitSHA=$(GIT_REF_LONG)" $(GOTARGET)
 
 .PHONY: all container push clean test local-test local generate plugins int
 
@@ -127,7 +128,7 @@ container: sonobuoy
 	done
 
 build_sonobuoy:
-	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(GO_SYSTEM_FLAGS) go build -o $(BINARY) $(VERBOSE_FLAG) -ldflags="-s -w -X $(GOTARGET)/pkg/buildinfo.Version=$(GIT_VERSION) -X $(GOTARGET)/pkg/buildinfo.GitSHA=$(GIT_REF_LONG)" $(GOTARGET)'
+	$(DOCKER_BUILD) '$(GO_BUILD)'
 
 sonobuoy:
 	for arch in $(LINUX_ARCH); do \
@@ -184,3 +185,6 @@ deploy_kind:
 	# FIXME: This assumes kind is in cwd; intended to work with our other CI scripts and
 	# is a bit wonky for general use.
 	./kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true
+
+native:
+	$(GO_BUILD)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new target which can be used in the Sonobuoy Formula for
Homebrew. Homebrew formulae typically build from source. We are
currently using Docker when building and this is not available when
building for Homebrew. To ensure that we use the same build parameters
for our own builds and builds on Homebrew, we are providing a new make
target (`native`) which which runs `go build` on the host machine. This
build command is shared across the `native` target and our other build
targets.

Fixes #715

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #715 

**Special notes for your reviewer**:
I've tested this build on both Linux and macOS, and the existing targets are producing the output in the same locations. I would like input on the naming of things here, and to know whether there's a more idiomatic way to do what I'm suggesting.

**Release note**:
```
None
```
