### PR TITLE
Add basic validation of configs

### DIFF
--- a/cmd/sonobuoy/app/retrieve.go
+++ b/cmd/sonobuoy/app/retrieve.go
@@ -34,12 +34,12 @@ var (
 	defaultOutDir = "."
 )
 
-type receiveFlags struct {
+type retrieveFlags struct {
 	namespace string
 	kubecfg   Kubeconfig
 }
 
-var rcvFlags receiveFlags
+var rcvFlags retrieveFlags
 
 func NewCmdRetrieve() *cobra.Command {
 	cmd := &cobra.Command{
@@ -68,7 +68,7 @@ func retrieveResults(cmd *cobra.Command, args []string) {
 	}
 
 	// Get a reader that contains the tar output of the results directory.
-	reader, ec := sbc.RetrieveResults(&client.RetrieveConfig{Namespace: rcvFlags.namespace})
+	reader, ec, err := sbc.RetrieveResults(&client.RetrieveConfig{Namespace: rcvFlags.namespace})
 	if err != nil {
 		errlog.LogError(err)
 		os.Exit(1)

--- a/pkg/client/defaults.go
+++ b/pkg/client/defaults.go
@@ -17,6 +17,8 @@ limitations under the License.
 package client
 
 import (
+	"os"
+
 	"github.com/heptio/sonobuoy/pkg/config"
 )
 
@@ -42,7 +44,7 @@ func NewRunConfig() *RunConfig {
 // NewDeleteConfig is a DeleteConfig using default images, RBAC enabled, and DeleteAll enabled.
 func NewDeleteConfig() *DeleteConfig {
 	return &DeleteConfig{
-		Namespace:  config.DefaultImage,
+		Namespace:  config.DefaultNamespace,
 		EnableRBAC: true,
 		DeleteAll:  false,
 	}
@@ -53,5 +55,6 @@ func NewLogConfig() *LogConfig {
 	return &LogConfig{
 		Follow:    false,
 		Namespace: config.DefaultNamespace,
+		Out:       os.Stdout,
 	}
 }

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -43,6 +43,14 @@ var (
 // its own namespace, cluster roles/bindings, and optionally e2e scoped
 // namespaces.
 func (c *SonobuoyClient) Delete(cfg *DeleteConfig) error {
+	if cfg == nil {
+		return errors.New("nil DeleteConfig provided")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return errors.Wrap(err, "config validation failed")
+	}
+
 	client, err := c.Client()
 	if err != nil {
 		return err

--- a/pkg/client/delete_test.go
+++ b/pkg/client/delete_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeleteInvalidConfig(t *testing.T) {
+	testcases := []struct {
+		desc             string
+		config           *DeleteConfig
+		expectedErrorMsg string
+	}{
+		{
+			desc:             "Passing a nil config results in an error",
+			config:           nil,
+			expectedErrorMsg: "nil DeleteConfig provided",
+		},
+		{
+			desc:             "Passing an invalid config with an empty namespace results in an error",
+			config:           &DeleteConfig{},
+			expectedErrorMsg: "config validation failed",
+		},
+	}
+
+	c, err := NewSonobuoyClient(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err = c.Delete(tc.config)
+			expectedError := len(tc.expectedErrorMsg) > 0
+			if !expectedError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if expectedError {
+				if err == nil {
+					t.Errorf("Expected provided config to be invalid but got no error")
+				} else if !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+					t.Errorf("Expected error to contain '%v', got '%v'", tc.expectedErrorMsg, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -64,6 +64,14 @@ type templateValues struct {
 
 // GenerateManifest fills in a template with a Sonobuoy config
 func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
+	if cfg == nil {
+		return nil, errors.New("nil GenConfig provided")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "config validation failed")
+	}
+
 	// Allow nil cfg.Config but avoid dereference errors.
 	conf := &config.Config{}
 	if cfg.Config != nil {

--- a/pkg/client/interfaces_test.go
+++ b/pkg/client/interfaces_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+)
+
+func TestConfigValidation(t *testing.T) {
+	testcases := []struct {
+		desc          string
+		config        validator
+		valid         bool
+		expectedError string
+	}{
+		{
+			desc:          "log config with no namespace is not valid",
+			config:        &LogConfig{},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:          "log config with empty namespace is not valid",
+			config:        &LogConfig{Namespace: "", Follow: true},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:   "log config with namespace is valid",
+			config: &LogConfig{Namespace: "valid-namespace"},
+			valid:  true,
+		},
+		{
+			desc:          "gen config without E2E config is not valid",
+			config:        &GenConfig{},
+			valid:         false,
+			expectedError: "nil E2EConfig provided",
+		},
+		{
+			desc: "gen config with E2E config is valid",
+			config: &GenConfig{
+				E2EConfig: &E2EConfig{},
+			},
+			valid: true,
+		},
+		{
+			desc:          "run config with invalid gen config is not valid",
+			config:        &RunConfig{},
+			valid:         false,
+			expectedError: "GenConfig validation failed: nil E2EConfig provided",
+		},
+		{
+			desc: "run config with valid gen config is valid",
+			config: &RunConfig{
+				GenConfig: GenConfig{
+					E2EConfig: &E2EConfig{},
+				},
+			},
+			valid: true,
+		},
+		{
+			desc:          "delete config with no namespace is not valid",
+			config:        &DeleteConfig{},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:          "delete config with empty namespace is not valid",
+			config:        &DeleteConfig{Namespace: "", EnableRBAC: true},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:   "delete config with namespace is valid",
+			config: &DeleteConfig{Namespace: "valid-namespace", DeleteAll: true},
+			valid:  true,
+		},
+		{
+			desc:          "retrieve config with no namespace is not valid",
+			config:        &RetrieveConfig{},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:          "retrieve config with empty namespace is not valid",
+			config:        &RetrieveConfig{Namespace: ""},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:   "retrieve config with namespace is valid",
+			config: &RetrieveConfig{Namespace: "valid-namespace"},
+			valid:  true,
+		},
+		{
+			desc:          "status config with no namespace is not valid",
+			config:        &StatusConfig{},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:          "status config with empty namespace is not valid",
+			config:        &StatusConfig{Namespace: ""},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:   "status config with namespace is valid",
+			config: &StatusConfig{Namespace: "valid-namespace"},
+			valid:  true,
+		},
+		{
+			desc:          "preflight config with no namespace is not valid",
+			config:        &PreflightConfig{},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:          "preflight config with no namespace is not valid",
+			config:        &PreflightConfig{Namespace: ""},
+			valid:         false,
+			expectedError: "namespace cannot be empty",
+		},
+		{
+			desc:   "preflight config with namespace is valid",
+			config: &PreflightConfig{Namespace: "valid-namespace"},
+			valid:  true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.valid && err != nil {
+				t.Errorf("Expected config to be valid, got error: %v", err)
+			}
+
+			if !tc.valid {
+				if err == nil {
+					t.Errorf("Expected config to not be valid but got no error")
+				} else if err.Error() != tc.expectedError {
+					t.Errorf("Expected error to be '%v', got '%v'", tc.expectedError, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/pkg/client/logs.go
+++ b/pkg/client/logs.go
@@ -111,10 +111,19 @@ func (r *Reader) Read(p []byte) (int, error) {
 
 // LogReader configures a Reader that provides an io.Reader interface to a merged stream of logs from various containers.
 func (s *SonobuoyClient) LogReader(cfg *LogConfig) (*Reader, error) {
+	if cfg == nil {
+		return nil, errors.New("nil LogConfig provided")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "config validation failed")
+	}
+
 	client, err := s.Client()
 	if err != nil {
 		return nil, err
 	}
+
 	pods, err := client.CoreV1().Pods(cfg.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list pods")

--- a/pkg/client/preflight.go
+++ b/pkg/client/preflight.go
@@ -57,6 +57,14 @@ type nsGetFunc func(string, metav1.GetOptions) (*apicorev1.Namespace, error)
 
 // PreflightChecks runs all preflight checks in order, returning the first error encountered.
 func (c *SonobuoyClient) PreflightChecks(cfg *PreflightConfig) []error {
+	if cfg == nil {
+		return []error{errors.New("nil PreflightConfig provided")}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return []error{errors.Wrap(err, "config validation failed")}
+	}
+
 	client, err := c.Client()
 	if err != nil {
 		return []error{err}

--- a/pkg/client/retrieve_test.go
+++ b/pkg/client/retrieve_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRetrieveInvalidConfig(t *testing.T) {
+	testcases := []struct {
+		config           *RetrieveConfig
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			config:           nil,
+			expectedError:    true,
+			expectedErrorMsg: "nil RetrieveConfig provided",
+		},
+		{
+			config:           &RetrieveConfig{},
+			expectedError:    true,
+			expectedErrorMsg: "config validation failed",
+		},
+	}
+
+	c, err := NewSonobuoyClient(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		_, _, err = c.RetrieveResults(tc.config)
+		if !tc.expectedError && err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		if tc.expectedError {
+			if err == nil {
+				t.Errorf("Expected provided config to be invalid but got no error")
+			} else if !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+				t.Errorf("Expected error to contain '%v', got '%v'", tc.expectedErrorMsg, err.Error())
+			}
+		}
+	}
+}

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -40,6 +40,14 @@ var (
 )
 
 func (c *SonobuoyClient) Run(cfg *RunConfig) error {
+	if cfg == nil {
+		return errors.New("nil RunConfig provided")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return errors.Wrap(err, "config validation failed")
+	}
+
 	manifest, err := c.GenerateManifest(&cfg.GenConfig)
 	if err != nil {
 		return errors.Wrap(err, "couldn't run invalid manifest")

--- a/pkg/client/run_test.go
+++ b/pkg/client/run_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunInvalidConfig(t *testing.T) {
+	testcases := []struct {
+		desc             string
+		config           *RunConfig
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			desc:             "Passing a nil config results in an error",
+			config:           nil,
+			expectedErrorMsg: "nil RunConfig provided",
+		},
+		{
+			desc:             "Passing an invalid config results in an error",
+			config:           &RunConfig{},
+			expectedErrorMsg: "config validation failed",
+		},
+	}
+
+	c, err := NewSonobuoyClient(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expectedError := len(tc.expectedErrorMsg) > 0
+			err = c.Run(tc.config)
+			if !expectedError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if expectedError {
+				if err == nil {
+					t.Errorf("Expected provided config to be invalid but got no error")
+				} else if !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tc.expectedErrorMsg, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -17,10 +17,20 @@ limitations under the License.
 package client
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
 
 func (c *SonobuoyClient) GetStatus(cfg *StatusConfig) (*aggregation.Status, error) {
+	if cfg == nil {
+		return nil, errors.New("nil StatusConfig provided")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "config validation failed")
+	}
+
 	client, err := c.Client()
 	if err != nil {
 		return nil, err

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright the Sonobuoy contributors 2019
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusInvalidConfig(t *testing.T) {
+	testcases := []struct {
+		desc             string
+		config           *StatusConfig
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			desc:             "Passing a nil config results in an error",
+			config:           nil,
+			expectedErrorMsg: "nil StatusConfig provided",
+		},
+		{
+			desc:             "Passing an invalid config without a namespace results in an error",
+			config:           &StatusConfig{},
+			expectedErrorMsg: "config validation failed",
+		},
+	}
+
+	c, err := NewSonobuoyClient(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expectedError := len(tc.expectedErrorMsg) > 0
+			_, err = c.GetStatus(tc.config)
+			if !expectedError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if expectedError {
+				if err == nil {
+					t.Errorf("Expected provided config to be invalid but got no error")
+				} else if !strings.Contains(err.Error(), tc.expectedErrorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tc.expectedErrorMsg, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds basic checking and validation of configs passed to some of the
interface function implementations in the Sonobuoy client. It is primarily
being added to prevent panics caused by passing nil configs to these
functions. It could be expanded in future to provide more comprehensive
validation of configuration objects.

Fixes #394

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>


**Which issue(s) this PR fixes**
- Fixes #394

**Special notes for your reviewer**:
This does not include comprehensive validation for some of the more
complex configuration objects (e.g. `GenConfig`). It primarily focuses on
the nil checks. A lot of the added tests in the client don't test the
"successful" case, where the execution of the function would proceed
past the validation. This is due to the complexity of the test set up that
would be required which seemed out of scope for this change.

**Release note**:
```
Fixed a bug that caused a panic if a nil configuration was provided to Sonobuoy client functions.
```
