### PR TITLE
Tweak the timing of considering pod as failing to be more permissive

### DIFF
--- a/pkg/plugin/aggregation/aggregator.go
+++ b/pkg/plugin/aggregation/aggregator.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	gzipMimeType       = "application/gzip"
-	defaultRetryWindow = 15 * time.Second
+	defaultRetryWindow = 120 * time.Second
 )
 
 // Aggregator is responsible for taking results from an HTTP server (configured
@@ -261,7 +261,7 @@ func (a *Aggregator) IngestResults(ctx context.Context, resultsCh <-chan *plugin
 		case result, more = <-resultsCh:
 		}
 
-		if !more {
+		if result == nil && !more {
 			return
 		}
 

--- a/pkg/plugin/aggregation/run.go
+++ b/pkg/plugin/aggregation/run.go
@@ -40,6 +40,9 @@ import (
 const (
 	annotationUpdateFreq = 5 * time.Second
 	jitterFactor         = 1.2
+
+	// pollingInterval is the time between polls when monitoring a plugin.
+	pollingInterval = 10 * time.Second
 )
 
 // Run runs an aggregation server and gathers results, in accordance with the
@@ -224,7 +227,7 @@ func (a *Aggregator) RunAndMonitorPlugin(ctx context.Context, p plugin.Interface
 		case <-ctx.Done():
 			cancel()
 			return
-		case <-sonotime.After(10 * time.Second):
+		case <-sonotime.After(pollingInterval):
 		}
 
 		hasResults := a.pluginHasResults(p)

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -38,6 +38,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// pollingInterval is the time between polls when monitoring the job status.
+	pollingInterval = 10 * time.Second
+)
+
 // Plugin is a plugin driver that dispatches containers to each node,
 // expecting each pod to report to the master.
 type Plugin struct {
@@ -186,7 +191,7 @@ func (p *Plugin) Monitor(ctx context.Context, kubeclient kubernetes.Interface, a
 		select {
 		case <-ctx.Done():
 			return
-		case <-sonotime.After(10 * time.Second):
+		case <-sonotime.After(pollingInterval):
 		}
 
 		done, errResults := p.monitorOnce(kubeclient, availableNodes, podsFound, podsReported)

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -37,6 +37,11 @@ import (
 	sonotime "github.com/heptio/sonobuoy/pkg/time"
 )
 
+const (
+	// pollingInterval is the time between polls when monitoring the job status.
+	pollingInterval = 10 * time.Second
+)
+
 // Plugin is a plugin driver that dispatches a single pod to the given
 // kubernetes cluster.
 type Plugin struct {
@@ -133,7 +138,7 @@ func (p *Plugin) Monitor(ctx context.Context, kubeclient kubernetes.Interface, _
 		select {
 		case <-ctx.Done():
 			return
-		case <-sonotime.After(10 * time.Second):
+		case <-sonotime.After(pollingInterval):
 		}
 
 		done, errResult := p.monitorOnce(kubeclient, nil)

--- a/pkg/plugin/driver/utils/utils.go
+++ b/pkg/plugin/driver/utils/utils.go
@@ -30,7 +30,10 @@ import (
 )
 
 const (
-	terminatedContainerWindow = 1 * time.Minute
+	// terminatedContainerWindow is the amount of time after a plugins main container terminates
+	// that we consider it a failure mode. This handles the situation where the plugin container
+	// exits without returning results.
+	terminatedContainerWindow = 5 * time.Minute
 )
 
 // GetSessionID generates a new session id.
@@ -44,8 +47,6 @@ func GetSessionID() string {
 
 // IsPodFailing returns whether a plugin's pod is failing and isn't likely to
 // succeed.
-// TODO: this may require more revisions as we get more experience with
-// various types of failures that can occur.
 func IsPodFailing(pod *v1.Pod) (bool, string) {
 	// Check if the pod is unschedulable
 	for _, cond := range pod.Status.Conditions {

--- a/pkg/plugin/driver/utils/utils_test.go
+++ b/pkg/plugin/driver/utils/utils_test.go
@@ -71,7 +71,7 @@ func TestPodFailing(t *testing.T) {
 							Reason:     "reason",
 							Message:    "msg",
 							ExitCode:   1,
-							FinishedAt: metav1.Time{Time: time.Now()},
+							FinishedAt: metav1.Time{Time: time.Now().Add(terminatedContainerWindow / -2)},
 						},
 					}},
 				}
@@ -87,7 +87,7 @@ func TestPodFailing(t *testing.T) {
 				t.Errorf("Expected %v but got %v", tc.expectFailing, failing)
 			}
 			if msg != tc.expectMsg {
-				t.Errorf("Expected %v but got %v", tc.expectMsg, msg)
+				t.Errorf("Expected %q but got %q", tc.expectMsg, msg)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If we are too aggressive with the timeframe, the main plugin container
may terminate and, while the sidecar is reporting the results and
the aggregator is reading them, the aggregator may instead too quickly
decide to consider the plugin a failure (because it hasn't seen the
final results yet).

This change just tries to extend some timing windows to give the
aggregator more time to see these results.

Lastly, it also adds logging into the worker when using retries. This
helps us better track what is happening on the worker's side.

**Which issue(s) this PR fixes**
Mitigates #759

**Special notes for your reviewer**:

**Release note**:
```
Timeframe extended (from 1m to 5m) for the aggregator to see results from a plugin before considering it to have terminated without reporting results. Timeframe also extended (from 15s to 2m) for which the aggregator will wait for clients to retry sending results if there is a problem in the connection.
```
