### PR TITLE
Update README to point to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ sonobuoy logs
 ## More information
 
 [The documentation][docs] provides further information about:
+
  * [conformance tests][conformance]
  * [plugins][plugins]
  * Testing of [air gapped clusters][airgap].
@@ -135,26 +136,26 @@ welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
 
 See [the list of releases][releases] to find out about feature changes.
 
-[airgap]: site/docs/master/airgap.md
+[airgap]: https://sonobuoy.io/docs/master/airgap.md
 [brew]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos
 [cncf]: https://github.com/cncf/k8s-conformance#certified-kubernetes
 [coc]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
-[conformance]: site/docs/master/conformance-testing.md
-[docs]: https://github.com/heptio/sonobuoy/tree/master/docs
-[e2e]: site/docs/master/conformance-testing.md
-[gen]: site/docs/master/gen.md
+[conformance]: https://sonobuoy.io/docs/master/conformance-testing.md
+[docs]: https://sonobuoy.io/docs/master/
+[e2e]: https://sonobuoy.io/docs/master/conformance-testing.md
+[gen]: https://sonobuoy.io/docs/master/gen.md
 [gimme]: https://github.com/travis-ci/gimme
 [issue]: https://github.com/heptio/sonobuoy/issues
 [k8s]: https://github.com/kubernetes/kubernetes
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
 [oview]: https://youtu.be/k-P4hXdruRs?t=9m27s
-[plugins]: site/docs/master/plugins.md
+[plugins]: https://sonobuoy.io/docs/master/plugins.md
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 [releases]: https://github.com/heptio/sonobuoy/releases
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
-[snapshot]: site/docs/master/snapshot.md
-[sonobuoyconfig]: site/docs/master/sonobuoy-config.md
+[snapshot]:https://sonobuoy.io/docs/master/snapshot.md
+[sonobuoyconfig]: https://sonobuoy.io/docs/master/sonobuoy-config.md
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master
 [travis]: https://travis-ci.org/heptio/sonobuoy/#
-[wait]: site/docs/master/wait.md
+[wait]: https://sonobuoy.io/docs/master/wait.md

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -67,6 +67,7 @@ else
         sed -i 's/site\/docs\/master\///g' /root/site/docs/${VERSION}/README.md && \
         sed -i 's/docs\/img/img/g' /root/site/docs/${VERSION}/README.md && \
         sed -i 's/sonobuoy\/tree\/master/sonobuoy\/tree\/${VERSION}/g' /root/site/docs/${VERSION}/README.md && \
+        sed -i 's/sonobuoy.io\/docs\/master/sonobuoy.io\/docs\/${VERSION}/g' /root/site/docs/${VERSION}/README.md && \
         cp /root/site/_data/master-toc.yml /root/site/_data/${TOC_NAME}.yml && \
         perl -i -0pe 's/${CONFIG_VERSION_BLOCK}/${NEW_VERSION_BLOCK}/' /root/site/_config.yml && \
         perl -i -0pe 's/${OLD_SCOPE_BLOCK}/${NEW_SCOPE_BLOCK}/' /root/site/_config.yml && \

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -1,4 +1,4 @@
-# <img src="/img/Sonobuoy.svg" width="400px" > [![Build Status][status]][travis]
+# <img src="img/sonobuoy-logo.png" width="400px" > [![Build Status][status]][travis]
 
 ## [Overview][oview]
 
@@ -88,6 +88,7 @@ sonobuoy logs
 ## More information
 
 [The documentation][docs] provides further information about:
+
  * [conformance tests][conformance]
  * [plugins][plugins]
  * Testing of [air gapped clusters][airgap].
@@ -135,26 +136,26 @@ welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
 
 See [the list of releases][releases] to find out about feature changes.
 
-[airgap]: docs/airgap.md
+[airgap]: airgap.md
 [brew]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos
 [cncf]: https://github.com/cncf/k8s-conformance#certified-kubernetes
 [coc]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
-[conformance]: docs/conformance-testing.md
-[docs]: https://github.com/heptio/sonobuoy/tree/master/docs
-[e2e]: /docs/conformance-testing.md
-[gen]: docs/gen.md
+[conformance]: conformance-testing.md
+[docs]: https://sonobuoy.io/docs/master/
+[e2e]: conformance-testing.md
+[gen]: gen.md
 [gimme]: https://github.com/travis-ci/gimme
 [issue]: https://github.com/heptio/sonobuoy/issues
 [k8s]: https://github.com/kubernetes/kubernetes
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
 [oview]: https://youtu.be/k-P4hXdruRs?t=9m27s
-[plugins]: docs/plugins.md
+[plugins]: plugins.md
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 [releases]: https://github.com/heptio/sonobuoy/releases
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
-[snapshot]: docs/snapshot.md
-[sonobuoyconfig]: docs/sonobuoy-config.md
+[snapshot]:snapshot.md
+[sonobuoyconfig]: sonobuoy-config.md
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master
 [travis]: https://travis-ci.org/heptio/sonobuoy/#
-[wait]: docs/wait.md
+[wait]: wait.md

--- a/site/docs/master/conformance-testing.md
+++ b/site/docs/master/conformance-testing.md
@@ -40,5 +40,5 @@ To customize the set of tests that are run as part of the report, the following 
 [4]: https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#conformance-tests
 [5]: plugins.md
 [6]: https://github.com/kubernetes/kubernetes/issues/49313
-[7]: ../examples/plugins.d/e2e.yaml#L9
+[7]: https://github.com/heptio/sonobuoy/examples/plugins.d/e2e.yaml#L9
 [8]: gen.md

--- a/site/docs/master/gen.md
+++ b/site/docs/master/gen.md
@@ -19,3 +19,6 @@ kubectl apply -f sonobuoy.yaml
 ```
 
 > Note: If you find that you need this flow to accomplish your work, talk to us about it in our [Slack][slack] channel or file an [issue][issue] in Github. Others may have the same need and we'd love to help support you.
+
+[slack]: https://kubernetes.slack.com/messages/sonobuoy
+[issue]: https://github.com/heptio/sonobuoy/issues

--- a/site/docs/master/plugins.md
+++ b/site/docs/master/plugins.md
@@ -119,9 +119,9 @@ Here's the current list:
 
 
 [gen]: gen.md
-[systemd]: /examples/plugins.d/systemd_logs.yaml
+[systemd]: https://github.com/heptio/sonobuoy/examples/plugins.d/systemd_logs.yaml
 [systemd-repo]: https://github.com/heptio/sonobuoy-plugin-systemd-logs
-[e2e]: /examples/plugins.d/heptio-e2e.yaml
+[e2e]: https://github.com/heptio/sonobuoy/examples/plugins.d/heptio-e2e.yaml
 [conformance]: https://github.com/heptio/kube-conformance
 [guide]: conformance-testing.md#integration-with-sonobuoy 
 [bulkhead]: https://github.com/bgeesaman/sonobuoy-plugin-bulkhead/blob/master/examples/benchmark.yml

--- a/site/docs/v0.15.0/README.md
+++ b/site/docs/v0.15.0/README.md
@@ -88,6 +88,7 @@ sonobuoy logs
 ## More information
 
 [The documentation][docs] provides further information about:
+
  * [conformance tests][conformance]
  * [plugins][plugins]
  * Testing of [air gapped clusters][airgap].
@@ -141,7 +142,7 @@ See [the list of releases][releases] to find out about feature changes.
 [coc]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
 [conformance]: conformance-testing.md
-[docs]: https://github.com/heptio/sonobuoy/tree/v0.15.0/docs
+[docs]: https://sonobuoy.io/docs/v0.15.0/
 [e2e]: conformance-testing.md
 [gen]: gen.md
 [gimme]: https://github.com/travis-ci/gimme


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Fixes a small formatting issue
 - Links to master docs on site, not github
 - Updated script to ensure the docs link gets updated on future releases
 - Updated the new v0.15.0 docs with the same change

**Release note**:
```
NONE
```
