### PR TITLE
Allow use of pod names other than "sonobuoy"

### DIFF
--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -99,6 +99,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -99,6 +99,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -70,6 +70,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -73,6 +73,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -70,6 +70,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -78,6 +78,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -90,6 +90,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -61,6 +61,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -70,6 +70,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/no-plugins-via-selection.golden
+++ b/pkg/client/testdata/no-plugins-via-selection.golden
@@ -45,6 +45,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -69,6 +69,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -94,6 +94,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: 
     imagePullPolicy: 
     name: kube-sonobuoy

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -82,6 +82,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: gcr.io/heptio-images/sonobuoy:static-version-for-testing
     imagePullPolicy: IfNotPresent
     name: kube-sonobuoy

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -96,6 +96,9 @@ func Run(restConf *rest.Config, cfg *config.Config) (errCount int) {
 		}
 	}
 
+	// Determine sonobuoy pod name
+	pluginaggregation.SetStatusPodName()
+
 	// Set initial annotation stating the pod is running. Ensures the annotation
 	// exists sooner for user/polling consumption and prevents issues were we try
 	// to patch a non-existant status later.

--- a/pkg/plugin/aggregation/update.go
+++ b/pkg/plugin/aggregation/update.go
@@ -19,6 +19,7 @@ package aggregation
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -31,7 +32,10 @@ import (
 
 const (
 	StatusAnnotationName = "sonobuoy.hept.io/status"
-	StatusPodName        = "sonobuoy"
+)
+
+var (
+	StatusPodName = "sonobuoy"
 )
 
 // node and name uniquely identify a single plugin result
@@ -155,5 +159,15 @@ func GetPatch(annotation string) map[string]interface{} {
 				StatusAnnotationName: annotation,
 			},
 		},
+	}
+}
+
+// Set the sonobuoy pod name
+// If the sonobuoy spec sets the SONOBUOY_POD_NAME env var using the downward API
+// this will pick that up and use it.  If not set, it will fall back to the default
+// pod name of "sonobuoy"
+func SetStatusPodName() {
+	if os.Getenv("SONOBUOY_POD_NAME") != "" {
+		StatusPodName = os.Getenv("SONOBUOY_POD_NAME")
 	}
 }

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -130,6 +130,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: SONOBUOY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     image: {{.SonobuoyImage}}
     imagePullPolicy: {{.ImagePullPolicy}}
     name: kube-sonobuoy

--- a/scripts/run_master.sh
+++ b/scripts/run_master.sh
@@ -16,6 +16,6 @@
 
 RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy}"
 # It's ok for these env vars to be unbound
-RESULTS_DIR="${RESULTS_DIR}" SONOBUOY_CONFIG="${SONOBUOY_CONFIG}" SONOBUOY_ADVERTISE_IP="${SONOBUOY_ADVERTISE_IP}" /sonobuoy master -v 3 --logtostderr
+RESULTS_DIR="${RESULTS_DIR}" SONOBUOY_CONFIG="${SONOBUOY_CONFIG}" SONOBUOY_ADVERTISE_IP="${SONOBUOY_ADVERTISE_IP}" SONOBUOY_POD_NAME="${SONOBUOY_POD_NAME}" /sonobuoy master -v 3 --logtostderr
 
 echo -n "${RESULTS_DIR}/$(ls -t "${RESULTS_DIR}" | grep -v done | head -n 1)" > "${RESULTS_DIR}"/done


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently sonobuoy always expects it's pod name to be `sonobuoy`.
So if you run sonobuoy with a CronJob, the controller will create a pod name
something like `sonobuoy-1561584180-zrwjf` and sonobuoy will fail to update
it's own status.

This change allows sonobuoy to fetch it's pod name from an environment
variable which enables using the downward API so that sonobuoy can use
whatever pod name it may be given.

If the environment variable is _not_ set, it will fall back to the
default hard-coded pod name it currently uses.

**Which issue(s) this PR fixes**
None I'm aware of

**Special notes for your reviewer**:
n/a

**Release note**:
```
Allow use of alternative pod names to enable using controllers (e.g. CronJob) to run sonobuoy scans.
```
