### PR TITLE
Add e2e-repo-config flag to images pull command

### DIFF
--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -59,6 +59,7 @@ func NewCmdImages() *cobra.Command {
 		Run:   pullImages,
 		Args:  cobra.ExactArgs(0),
 	}
+	AddE2ERegistryConfigFlag(&imagesflags.e2eRegistryConfig, pullCmd.Flags())
 	AddKubeconfigFlag(&imagesflags.kubeconfig, pullCmd.Flags())
 	AddPluginFlag(&imagesflags.plugin, pullCmd.Flags())
 
@@ -166,7 +167,7 @@ func pullImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		upstreamImages, err := image.GetImages(defaultE2ERegistries, version)
+		upstreamImages, err := image.GetImages(imagesflags.e2eRegistryConfig, version)
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "couldn't init upstream registry list"))
 			os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Most of the background is described here: https://github.com/heptio/sonobuoy/issues/780

TLDR: I would like to enable the --e2e-repo-config flag for the sonobuoy images pull command to validate that all required images are in place.

**Which issue(s) this PR fixes**
- Fixes #780 

**Special notes for your reviewer**:

**Release note**:
```
sonobuoy images pull supports now the "--e2e-repo-config" flag
```
