### PR TITLE
Preserve single file result names and keep job/ds depth the same

### DIFF
--- a/pkg/client/e2e.go
+++ b/pkg/client/e2e.go
@@ -35,6 +35,7 @@ func (*SonobuoyClient) GetTests(reader io.Reader, show string) ([]reporters.JUni
 	read := results.NewReaderWithVersion(reader, "irrelevant")
 	junitResults := reporters.JUnitTestSuite{}
 	e2eJunitPath := path.Join(results.PluginsDir, e2e.ResultsSubdirectory, e2e.JUnitResultsFile)
+	legacye2eJunitPath := path.Join(results.PluginsDir, e2e.LegacyResultsSubdirectory, e2e.JUnitResultsFile)
 
 	found := false
 	err := read.WalkFiles(
@@ -44,9 +45,9 @@ func (*SonobuoyClient) GetTests(reader io.Reader, show string) ([]reporters.JUni
 			}
 			// TODO(chuckha) consider reusing this function for any generic e2e-esque plugin results.
 			// TODO(chuckha) consider using path.Join()
-			if path == e2eJunitPath {
+			if path == e2eJunitPath || path == legacye2eJunitPath {
 				found = true
-				return results.ExtractFileIntoStruct(e2eJunitPath, path, info, &junitResults)
+				return results.ExtractFileIntoStruct(path, path, info, &junitResults)
 			}
 			return nil
 		})

--- a/pkg/client/e2e_test.go
+++ b/pkg/client/e2e_test.go
@@ -35,7 +35,7 @@ func TestGetTests(t *testing.T) {
 			path:      "results/testdata/results-0.10-missing-e2e.tar.gz",
 			show:      "failed",
 			expect:    0,
-			expectErr: `failed to find results file "plugins/e2e/results/junit_01.xml" in archive`,
+			expectErr: `failed to find results file "plugins/e2e/results/global/junit_01.xml" in archive`,
 		}, {
 			desc:      "Errs differently if not a tarfile",
 			path:      "testdata/test_ssh.key",
@@ -104,8 +104,8 @@ func TestString(t *testing.T) {
 		}, {
 			desc: "Should not end with extra new line",
 			cases: PrintableTestCases([]reporters.JUnitTestCase{
-				reporters.JUnitTestCase{Name: "a"},
-				reporters.JUnitTestCase{Name: "b"},
+				{Name: "a"},
+				{Name: "b"},
 			}),
 			expect: "a\nb",
 		},

--- a/pkg/client/results/e2e/consts.go
+++ b/pkg/client/results/e2e/consts.go
@@ -19,6 +19,11 @@ package e2e
 
 const (
 	// ResultsDirectory is the directory where the results will be found
-	ResultsSubdirectory = "e2e/results/"
-	JUnitResultsFile    = "junit_01.xml"
+	ResultsSubdirectory = "e2e/results/global/"
+
+	// LegacyResultsSubdirectory was the directory where e2e results were found before
+	// the global folder was added.
+	LegacyResultsSubdirectory = "e2e/results/"
+
+	JUnitResultsFile = "junit_01.xml"
 )

--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -40,7 +40,7 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 		},
 	}
 	testPluginExpectedResults := []plugin.ExpectedResult{
-		{ResultType: "myPlugin"},
+		{ResultType: "myPlugin", NodeName: "global"},
 	}
 	healthyPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"sonobuoy-run": ""}},
@@ -156,7 +156,7 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 
 			if tc.forceResults {
 				a.resultsMutex.Lock()
-				a.Results["myPlugin"] = &plugin.Result{}
+				a.Results["myPlugin/global"] = &plugin.Result{}
 				a.resultsMutex.Unlock()
 			}
 

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -72,12 +72,12 @@ func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy,
 // a Job only launches one pod, only one result type is expected.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return []plugin.ExpectedResult{
-		{ResultType: p.GetResultType()},
+		{ResultType: p.GetResultType(), NodeName: plugin.GlobalResult},
 	}
 }
 
 func getMasterAddress(hostname string) string {
-	return fmt.Sprintf("https://%s/api/v1/results/global", hostname)
+	return fmt.Sprintf("https://%s/api/v1/results/%v", hostname, plugin.GlobalResult)
 }
 
 //FillTemplate populates the internal Job YAML template with the values for this particular job.
@@ -160,7 +160,7 @@ func (p *Plugin) monitorOnce(kubeclient kubernetes.Interface, _ []v1.Node) (done
 	// Make sure there's a pod
 	pod, err := p.findPod(kubeclient)
 	if err != nil {
-		return true, utils.MakeErrorResult(p.GetResultType(), map[string]interface{}{"error": err.Error()}, "")
+		return true, utils.MakeErrorResult(p.GetResultType(), map[string]interface{}{"error": err.Error()}, plugin.GlobalResult)
 	}
 
 	// Make sure the pod isn't failing
@@ -168,7 +168,7 @@ func (p *Plugin) monitorOnce(kubeclient kubernetes.Interface, _ []v1.Node) (done
 		return true, utils.MakeErrorResult(p.GetResultType(), map[string]interface{}{
 			"error": reason,
 			"pod":   pod,
-		}, "")
+		}, plugin.GlobalResult)
 	}
 
 	return false, nil

--- a/pkg/plugin/driver/utils/utils.go
+++ b/pkg/plugin/driver/utils/utils.go
@@ -107,5 +107,6 @@ func MakeErrorResult(resultType string, errdata map[string]interface{}, nodeName
 		ResultType: resultType,
 		NodeName:   nodeName,
 		MimeType:   "application/json",
+		Filename:   "error.json",
 	}
 }

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -27,6 +27,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	// GlobalResult is used in place of a node name when the results apply
+	// to the entire cluster as opposed to a single node (e.g. when running
+	// a job and not a daemonset).
+	GlobalResult = "global"
+)
+
 // Interface represents what all plugins must implement to be run and have
 // results be aggregated.
 type Interface interface {
@@ -79,6 +86,7 @@ type Result struct {
 	NodeName   string
 	ResultType string
 	MimeType   string
+	Filename   string
 	Body       io.Reader
 	Error      string
 }
@@ -142,9 +150,12 @@ func (er *ExpectedResult) ID() string {
 // ExpectedResultID returns a unique identifier for this result to match it up
 // against an expected result.
 func (r *Result) ExpectedResultID() string {
+	// Jobs should default to stating they are global results, being
+	// safe and doing that defaulting here too.
+	nodeName := r.NodeName
 	if r.NodeName == "" {
-		return r.ResultType
+		nodeName = GlobalResult
 	}
 
-	return r.ResultType + "/" + r.NodeName
+	return r.ResultType + "/" + nodeName
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -72,8 +72,8 @@ func handleWaitFile(resultFile, url string, client *http.Client) error {
 	}()
 
 	// transmit back the results file.
-	return DoRequest(url, client, func() (io.Reader, string, error) {
+	return DoRequest(url, client, func() (io.Reader, string, string, error) {
 		outfile, err = os.Open(resultFile)
-		return outfile, mimeType, errors.WithStack(err)
+		return outfile, filepath.Base(resultFile), mimeType, errors.WithStack(err)
 	})
 }

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -66,7 +66,7 @@ func TestRunGlobal(t *testing.T) {
 
 	// Create an expectedResults array
 	expectedResults := []plugin.ExpectedResult{
-		plugin.ExpectedResult{ResultType: "systemd_logs"},
+		{ResultType: "systemd_logs", NodeName: "global"},
 	}
 
 	withAggregator(t, expectedResults, func(aggr *aggregation.Aggregator, srv *authtest.Server) {
@@ -92,7 +92,7 @@ func TestRunGlobal_noExtension(t *testing.T) {
 
 	// Create an expectedResults array
 	expectedResults := []plugin.ExpectedResult{
-		plugin.ExpectedResult{ResultType: "systemd_logs"},
+		{ResultType: "systemd_logs", NodeName: "global"},
 	}
 
 	withAggregator(t, expectedResults, func(aggr *aggregation.Aggregator, srv *authtest.Server) {
@@ -117,7 +117,7 @@ func TestRunGlobalCleanup(t *testing.T) {
 
 	// Create an expectedResults array
 	expectedResults := []plugin.ExpectedResult{
-		plugin.ExpectedResult{ResultType: "systemd_logs"},
+		{ResultType: "systemd_logs"},
 	}
 	stopc := make(chan struct{}, 1)
 	stopc <- struct{}{}

--- a/test/integration/stress_test.go
+++ b/test/integration/stress_test.go
@@ -91,8 +91,8 @@ func sendResults(t *testing.T, baseURL string, client *http.Client, n int) {
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			url := baseURL + "/api/v1/results/by-node/node" + strconv.Itoa(i) + "/fake"
-			err := worker.DoRequest(url, client, func() (io.Reader, string, error) {
-				return bytes.NewReader([]byte("hello")), "", nil
+			err := worker.DoRequest(url, client, func() (io.Reader, string, string, error) {
+				return bytes.NewReader([]byte("hello")), "fakefile", "", nil
 			})
 			if err != nil {
 				t.Errorf("Error doing request to %v: %v\n", url, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
If there is a job returning results it currently goes into the
tarball at plugins/name/results/<files> but this is different
from daemonset results which have an extra directory stating
the node name (plugins/name/node/results/<files>).

To prepare for consistent handling of results, it would be preferred
that these have the same layouts so we added a new level for jobs:
"global" so a job plugin results go to plugins/name/global/results.

In addition, if a single file was uploaded as results, it was handled
in a unique way. Instead of being put into the directories listed above,
the same path would refer, instead, to a file. The contents of which
were the result.

It would be much preferred to preserve the folder structure and the
filename being uploaded. This way automated processing is easier and
users can rationalize about what files they are uploading (when they
would reasonably expect them, by name, to appear in the tarball).

**Which issue(s) this PR fixes**
Fixes #741

**Special notes for your reviewer**:
TODO:
 - [x] Add more tests (waiting to see coverage report but I know I'll need some more)
 - [x] Will add details here how to test it and confirm different situations.
 - [x] Fixup existing unit tests
 - [x] Add new version of tarball structure

**Release note**:
```
Made the location of plugin results within the results tarball more consistent. Job type plugins will have their results placed into `plugins/<name>/global/results/<files>` to be at a consistent depth with daemonset plugins (which list their nodes in the path). In addition, when a plugin reports a single file (not an archive) of results, then that file is put into the same directory and with the same name, it had locally on the container.
```
