### PR TITLE
Return exit code 1 if sonobuoy can't pull all images required

### DIFF
--- a/cmd/sonobuoy/app/images.go
+++ b/cmd/sonobuoy/app/images.go
@@ -182,6 +182,10 @@ func pullImages(cmd *cobra.Command, args []string) {
 			errlog.LogError(err)
 		}
 
+		if len(errs) > 0 {
+			os.Exit(1)
+		}
+
 	default:
 		errlog.LogError(errors.Errorf("Unsupported plugin: %v", imagesflags.plugin))
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that `sonobuoy images pull` will return an exit code 1 if it can't pull all required images for the e2e tests. This is a follow up on https://github.com/heptio/sonobuoy/pull/781 and allows users to integrate a CI test in their pipelines to check if all images are present in the Docker registry (without any grep).

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
sonobuoy images pull will return an exit code 1 if some images are not available.
```
