### PR TITLE
Look up sonobuoy master pod name by label

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -96,6 +96,9 @@ func Run(restConf *rest.Config, cfg *config.Config) (errCount int) {
 		}
 	}
 
+	// Determine sonobuoy pod name
+	pluginaggregation.SetStatusPodName(kubeClient, cfg.Namespace)
+
 	// Set initial annotation stating the pod is running. Ensures the annotation
 	// exists sooner for user/polling consumption and prevents issues were we try
 	// to patch a non-existant status later.

--- a/pkg/plugin/aggregation/status.go
+++ b/pkg/plugin/aggregation/status.go
@@ -82,9 +82,12 @@ func GetStatus(client kubernetes.Interface, namespace string) (*Status, error) {
 		return nil, errors.Wrap(err, "sonobuoy namespace does not exist")
 	}
 
+	// Determine sonobuoy pod name
+	SetStatusPodName(client, namespace)
+
 	pod, err := client.CoreV1().Pods(namespace).Get(StatusPodName, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve sonobuoy pod")
+		return nil, errors.New("could not retrieve sonobuoy pod")
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently sonobuoy always expects it's pod name to be sonobuoy.
So if you run sonobuoy with a CronJob, the controller will create a pod name
something like `sonobuoy-1561584180-zrwjf` and sonobuoy will fail to update
it's own status.  Also the sonobuoy CLI will not find the pod if you
check status or try to retrieve results.

This change removes the statically-set sonobuoy master pod name and
looks up the pod name based on the label given to that pod:
'run=sonobuoy-master`.

This assumes that this label is always set and will fail if more than
one pod exists in the namespace with that label.

**Which issue(s) this PR fixes**
- https://github.com/heptio/sonobuoy/issues/782

**Special notes for your reviewer**:
This PR is an alternative implementation to: https://github.com/heptio/sonobuoy/pull/779

**Release note**:
```
Allow use of alternative pod names to enable using controllers (e.g. CronJob) to run sonobuoy scans.
```

Signed-off-by: Richard Lander <landerr@vmware.com>
