### PR TITLE
Fix retrieve command when using dynamic pod name

### DIFF
--- a/pkg/client/retrieve.go
+++ b/pkg/client/retrieve.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/heptio/sonobuoy/pkg/config"
+	pluginaggregation "github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,10 +59,13 @@ func (c *SonobuoyClient) RetrieveResults(cfg *RetrieveConfig) (io.Reader, <-chan
 		return nil, ec, nil
 	}
 
+	// Determine sonobuoy pod name
+	pluginaggregation.SetStatusPodName(client, cfg.Namespace)
+
 	restClient := client.CoreV1().RESTClient()
 	req := restClient.Post().
 		Resource("pods").
-		Name(config.MasterPodName).
+		Name(pluginaggregation.StatusPodName).
 		Namespace(cfg.Namespace).
 		SubResource("exec").
 		Param("container", config.MasterContainerName)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `sonobuoy retrieve` command currently uses a hard-coded pod name
when attempting to retrieve scan results.  This change uses the same
mechanism as `sonobuoy status` to look up the sonobuoy master pod by
label.

**Which issue(s) this PR fixes**
- N/A

**Special notes for your reviewer**:
This is related to this PR that introduced the ability to use dynamic pod names:
https://github.com/heptio/sonobuoy/pull/787

**Release note**:
N/A

Signed-off-by: Richard Lander <landerr@vmware.com>
