### PR TITLE
Fix preflight test error message

### DIFF
--- a/pkg/client/preflight.go
+++ b/pkg/client/preflight.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/heptio/sonobuoy/pkg/buildinfo"
@@ -110,7 +111,7 @@ func dnsCheck(listPods listFunc, dnsLabels ...string) error {
 	}
 
 	if nPods == 0 {
-		return errors.New("no dns pod tests found")
+		return fmt.Errorf("no dns pods found with the labels [%s] in namespace kube-system", strings.Join(dnsLabels, ", "))
 	}
 
 	return nil

--- a/pkg/client/preflight_test.go
+++ b/pkg/client/preflight_test.go
@@ -147,7 +147,7 @@ func TestDNSCheck(t *testing.T) {
 				return &apicorev1.PodList{}, nil
 			},
 			dnsLabels: []string{"foo"},
-			expectErr: "no dns pod tests found",
+			expectErr: "no dns pods found with the labels [foo] in namespace kube-system",
 		}, {
 			desc: "Skipped if no labels required",
 			lister: func(metav1.ListOptions) (*apicorev1.PodList, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes a confusing error message in the preflight checks. It's not strictly
needed, but it is nice as a user when error messages make sense.

**Which issue(s) this PR fixes**

There is currently no issue for this problem.

**Special notes for your reviewer**:

**Release note**:
```
Fix dns preflight test error message
```