### PR TITLE
Add redirect for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,26 +136,25 @@ welcome pull requests. Feel free to dig through the [issues][issue] and jump in.
 
 See [the list of releases][releases] to find out about feature changes.
 
-[airgap]: https://sonobuoy.io/docs/master/airgap
+[airgap]: https://sonobuoy.io/docs/airgap
 [brew]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos
 [cncf]: https://github.com/cncf/k8s-conformance#certified-kubernetes
 [coc]: https://github.com/heptio/sonobuoy/blob/master/CODE_OF_CONDUCT.md
 [contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
-[conformance]: https://sonobuoy.io/docs/master/conformance-testing
-[docs]: https://sonobuoy.io/docs/master/
-[e2e]: https://sonobuoy.io/docs/master/conformance-testing
-[gen]: https://sonobuoy.io/docs/master/gen
+[conformance]: https://sonobuoy.io/docs/conformance-testing
+[docs]: https://sonobuoy.io/docs
+[e2e]: https://sonobuoy.io/docs/conformance-testing
+[gen]: https://sonobuoy.io/docs/gen
 [gimme]: https://github.com/travis-ci/gimme
 [issue]: https://github.com/heptio/sonobuoy/issues
 [k8s]: https://github.com/kubernetes/kubernetes
 [linux]: https://kubernetes.io/docs/tasks/tools/install-kubectl/#tabset-1
 [oview]: https://youtu.be/k-P4hXdruRs?t=9m27s
-[plugins]: https://sonobuoy.io/docs/master/plugins
+[plugins]: https://sonobuoy.io/docs/plugins
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 [releases]: https://github.com/heptio/sonobuoy/releases
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
-[snapshot]:https://sonobuoy.io/docs/master/snapshot
-[sonobuoyconfig]: https://sonobuoy.io/docs/master/sonobuoy-config
+[snapshot]:https://sonobuoy.io/docs/snapshot
+[sonobuoyconfig]: https://sonobuoy.io/docs/sonobuoy-config
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master
 [travis]: https://travis-ci.org/heptio/sonobuoy/#
-[wait]: https://sonobuoy.io/docs/master/wait

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -86,6 +86,12 @@ defaults:
       gh: https:/github.com/heptio/sonobuoy/tree/v0.13.0
       layout: "docs"
 
+page_gen:
+  - data: shortlinks
+    template: redirect
+    name: key
+    dir: docs
+
 collections:
   - contributors
   - casestudies
@@ -116,6 +122,7 @@ plugins:
   - jekyll-readme-index # use README.md as index.html
   - jekyll-titles-from-headings # pull the page title from the first Markdown heading when none is specified.
   - jekyll-paginate # pagination object for collections (e.g. posts)
+  - jekyll-redirect-from
 
 
 # Include these subdirectories

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -14,7 +14,7 @@ footer:
   title: Getting Started
   content: To help you get started, see the documentation.
   cta_title:
-  cta_url: /docs/v0.15.0
+  cta_url: /docs
   cta_text: Documentation
   vm-link: http://vmware.github.io/
 

--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -1,0 +1,27 @@
+- title: Config
+  key: sonobuoy-config
+  destination: sonobuoy-config
+- title: Snapshot Layout
+  key: snapshot
+  destination: snapshot
+- title: ImagePullSecrets
+  key: pullsecrets
+  destination: pullsecrets
+- title: Conformance Testing
+  key: conformance-testing
+  destination: conformance-testing
+- title: Custom Registries & Airgap Testing
+  key: airgap
+  destination: airgap
+- title: Plugins
+  key: plugins
+  destination: plugins
+- title: Customization
+  key: gen
+  destination: gen
+- title: Make your own plugins
+  key: examples
+  destination: examples
+- title: Cut a release
+  key: release
+  destination: release

--- a/site/_includes/site-header.html
+++ b/site/_includes/site-header.html
@@ -7,7 +7,7 @@
             <li class="home"><a href="/" title="{{ site.title }}">Home</a></li>
             <li class="blog"><a href="/blog" title="Blog Posts">Blog</a></li>
             <li class="community"><a href="/community" title="Community">Community</a></li>
-            <li class="docs"><a href="/docs/v0.15.0">Documentation</a></li>
+            <li class="docs"><a href="/docs">Documentation</a></li>
             <li class="resources"><a href="/resources" title="Resources">Resources</a></li>
         </ul>
         <div class="nav-mobile-link">

--- a/site/_layouts/redirect.html
+++ b/site/_layouts/redirect.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url=/docs/{{ site.latest }}/{{ page.destination }}" />
+  <script type="text/javascript">
+    window.location.href = "/docs/{{ site.latest }}/{{ page.destination }}"
+  </script>
+  <title>Redirecting...</title>
+</head>
+<body>
+Redirecting to {{ page.destination }}. If it doesn't load, click <a href="/docs/{{ site.latest }}/{{ page.destination }}" />here</a>.
+</body>
+</html>

--- a/site/_plugins/data_page_generator.rb
+++ b/site/_plugins/data_page_generator.rb
@@ -1,0 +1,135 @@
+# coding: utf-8
+# Generate pages from individual records in yml files
+# (c) 2014-2016 Adolfo Villafiorita
+# Distributed under the conditions of the MIT License
+
+module Jekyll
+
+  module Sanitizer
+    # strip characters and whitespace to create valid filenames, also lowercase
+    def sanitize_filename(name)
+      if(name.is_a? Integer)
+        return name.to_s
+      end
+      return name.tr(
+  "ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÑñÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž",
+  "AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz"
+).downcase.strip.gsub(' ', '-').gsub(/[^\w.-]/, '')
+    end
+  end
+
+  # this class is used to tell Jekyll to generate a page
+  class DataPage < Page
+    include Sanitizer
+
+    # - site and base are copied from other plugins: to be honest, I am not sure what they do
+    #
+    # - `index_files` specifies if we want to generate named folders (true) or not (false)
+    # - `dir` is the default output directory
+    # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
+    # - `name` is the key in `data` which determines the output filename
+    # - `template` is the name of the template for generating the page
+    # - `extension` is the extension for the generated file
+    def initialize(site, base, index_files, dir, data, name, template, extension)
+      @site = site
+      @base = base
+
+      # @dir is the directory where we want to output the page
+      # @name is the name of the page to generate
+      #
+      # the value of these variables changes according to whether we
+      # want to generate named folders or not
+      if data[name] == nil
+        puts "error (datapage_gen). empty value for field '#{name}' in record #{data}"
+      else
+        filename = sanitize_filename(data[name]).to_s
+
+        @dir = dir + (index_files ? "/" + filename + "/" : "")
+        @name = (index_files ? "index" : filename) + "." + extension.to_s
+
+        self.process(@name)
+        self.read_yaml(File.join(base, '_layouts'), template + ".html")
+        self.data['title'] = data[name]
+        # add all the information defined in _data for the current record to the
+        # current page (so that we can access it with liquid tags)
+        self.data.merge!(data)
+      end
+    end
+  end
+
+  class DataPagesGenerator < Generator
+    safe true
+
+    # generate loops over _config.yml/page_gen invoking the DataPage
+    # constructor for each record for which we want to generate a page
+
+    def generate(site)
+      # page_gen_dirs determines whether we want to generate index pages
+      # (name/index.html) or standard files (name.html). This information
+      # is passed to the DataPage constructor, which sets the @dir variable
+      # as required by this directive
+      index_files = site.config['page_gen-dirs'] == true
+
+      # data contains the specification of the data for which we want to generate
+      # the pages (look at the README file for its specification)
+      data = site.config['page_gen']
+      if data
+        data.each do |data_spec|
+          index_files_for_this_data = data_spec['index_files'] != nil ? data_spec['index_files'] : index_files
+          template = data_spec['template'] || data_spec['data']
+          name = data_spec['name']
+          dir = data_spec['dir'] || data_spec['data']
+          extension = data_spec['extension'] || "html"
+
+          if site.layouts.key? template
+            # records is the list of records defined in _data.yml
+            # for which we want to generate different pages
+            records = nil
+            data_spec['data'].split('.').each do |level|
+              if records.nil?
+                records = site.data[level]
+              else
+                records = records[level]
+              end
+            end
+
+            # apply filtering conditions:
+            # - filter requires the name of a boolean field
+            # - filter_condition evals a ruby expression
+            records = records.select { |r| r[data_spec['filter']] } if data_spec['filter']
+            records = records.select { |record| eval(data_spec['filter_condition']) } if data_spec['filter_condition']
+
+            records.each do |record|
+              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, template, extension)
+            end
+          else
+            puts "error (datapage_gen). could not find template #{template}" if not site.layouts.key? template
+          end
+        end
+      end
+    end
+  end
+
+  module DataPageLinkGenerator
+    include Sanitizer
+
+    # use it like this: {{input | datapage_url: dir}}
+    # to generate a link to a data_page.
+    #
+    # the filter is smart enough to generate different link styles
+    # according to the data_page-dirs directive ...
+    #
+    # ... however, the filter is not smart enough to support different
+    # extensions for filenames.
+    #
+    # Thus, if you use the `extension` feature of this plugin, you
+    # need to generate the links by hand
+    def datapage_url(input, dir)
+      extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
+      "#{dir}/#{sanitize_filename(input)}#{extension}"
+    end
+  end
+
+end
+
+Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+- LATEST
+---


### PR DESCRIPTION
This fixes the need to specify `master` or `v0.15.0` or similar when linking to the latest docs from the README and other sources.

It will automatically redirect https://sonobuoy.io/docs to the latest version, as specified in _config.yml.

It also redirects any links specified in _data/shortlinks.yml, to their latest counterpart.
For example, https://sonobuoy.io/docs/gen will redirect to the latest version, currently https://sonobuoy.io/docs/v0.15.0/gen.

This also fixes the need to specify the latest version in the navigation header.

Signed-off-by: jonasrosland <jrosland@vmware.com>