### PR TITLE
Allow cleanup to be skipped on a per plugin basis

### DIFF
--- a/pkg/plugin/aggregation/run.go
+++ b/pkg/plugin/aggregation/run.go
@@ -199,9 +199,11 @@ func Run(client kubernetes.Interface, plugins []plugin.Interface, cfg plugin.Agg
 
 // Cleanup calls cleanup on all plugins
 func Cleanup(client kubernetes.Interface, plugins []plugin.Interface) {
-	// Cleanup after each plugin
+	// Cleanup after each plugin unless cleanup is explicitly skipped
 	for _, p := range plugins {
-		p.Cleanup(client)
+		if !p.SkipCleanup() {
+			p.Cleanup(client)
+		}
 	}
 }
 

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -80,6 +80,11 @@ func (b *Base) GetResultType() string {
 	return b.Definition.ResultType
 }
 
+// SkipCleanup returns whether cleanup for this plugin should be skipped or not.
+func (b *Base) SkipCleanup() bool {
+	return b.Definition.SkipCleanup
+}
+
 //GetTemplateData fills a TemplateData struct with the passed in and state variables.
 func (b *Base) GetTemplateData(masterAddress string, cert *tls.Certificate) (*TemplateData, error) {
 

--- a/pkg/plugin/driver/base_test.go
+++ b/pkg/plugin/driver/base_test.go
@@ -83,3 +83,21 @@ func TestMakeTLSSecret(t *testing.T) {
 		t.Error("cert fingerprint didn't match")
 	}
 }
+
+func TestSkipCleanup(t *testing.T) {
+	b := &Base{
+		Definition: plugin.Definition{
+			SkipCleanup: false,
+		},
+	}
+
+	if b.SkipCleanup() {
+		t.Error("Expected SkipCleanup to be false but was true")
+	}
+
+	b.Definition.SkipCleanup = true
+
+	if !b.SkipCleanup() {
+		t.Error("Expected SkipCleanup to be true but was false")
+	}
+}

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -51,6 +51,8 @@ type Interface interface {
 	GetResultType() string
 	// GetName returns the name of this plugin
 	GetName() string
+	// SkipCleanup returns whether cleanup for this plugin should be skipped or not.
+	SkipCleanup() bool
 }
 
 // Definition defines a plugin's features, method of launch, and other
@@ -58,6 +60,7 @@ type Interface interface {
 type Definition struct {
 	Name         string
 	ResultType   string
+	SkipCleanup  bool
 	Spec         manifest.Container
 	ExtraVolumes []manifest.Volume
 }

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -127,6 +127,7 @@ func loadPlugin(def *manifest.Manifest, namespace, sonobuoyImage, imagePullPolic
 	pluginDef := plugin.Definition{
 		Name:         def.SonobuoyConfig.PluginName,
 		ResultType:   def.SonobuoyConfig.ResultType,
+		SkipCleanup:  def.SonobuoyConfig.SkipCleanup,
 		ExtraVolumes: def.ExtraVolumes,
 		Spec:         def.Spec,
 	}

--- a/pkg/plugin/loader/loader_test.go
+++ b/pkg/plugin/loader/loader_test.go
@@ -100,6 +100,50 @@ func TestLoadValidPlugin(t *testing.T) {
 	}
 }
 
+func TestLoadValidPluginWithSkipCleanup(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		jobDefFileName string
+		expectedValue  bool
+	}{
+		{
+			desc:           "skip-cleanup set to true results in true",
+			jobDefFileName: "testdata/skip-cleanup/set-true.yml",
+			expectedValue:  true,
+		},
+		{
+			desc:           "skip-cleanup set to true results in true",
+			jobDefFileName: "testdata/skip-cleanup/set-false.yml",
+			expectedValue:  false,
+		},
+		{
+			desc:           "skip-cleanup not set defaults to false",
+			jobDefFileName: "testdata/skip-cleanup/not-set.yml",
+			expectedValue:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			jobDefFile, err := loadDefinitionFromFile(tc.jobDefFileName)
+			if err != nil {
+				t.Fatalf("Unexpected error reading job plugin: %v", err)
+			}
+
+			jobDef, err := loadDefinition(jobDefFile)
+			if err != nil {
+				t.Fatalf("Unexpected error loading job plugin: %v", err)
+			}
+
+			if jobDef.SonobuoyConfig.SkipCleanup != tc.expectedValue {
+				t.Errorf("expected skip-cleanup to be %v but was %v", tc.expectedValue, jobDef.SonobuoyConfig.SkipCleanup)
+			}
+
+		})
+
+	}
+}
+
 func TestLoadJobPlugin(t *testing.T) {
 	namespace := "loader_test"
 	image := "gcr.io/heptio-images/sonobuoy:latest"

--- a/pkg/plugin/loader/testdata/skip-cleanup/not-set.yml
+++ b/pkg/plugin/loader/testdata/skip-cleanup/not-set.yml
@@ -1,0 +1,12 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: test-plugin-skip-cleanup
+  result-type: test-plugin-skip-cleanup
+spec:
+  image: gcr.io/heptio-images/heptio-e2e:master
+  imagePullPolicy: Always
+  name: heptio-e2e
+  volumeMounts:
+    - mountPath: /tmp/results
+      name: results
+      readOnly: false

--- a/pkg/plugin/loader/testdata/skip-cleanup/set-false.yml
+++ b/pkg/plugin/loader/testdata/skip-cleanup/set-false.yml
@@ -1,0 +1,13 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: test-plugin-skip-cleanup
+  result-type: test-plugin-skip-cleanup
+  skip-cleanup: false
+spec:
+  image: gcr.io/heptio-images/heptio-e2e:master
+  imagePullPolicy: Always
+  name: heptio-e2e
+  volumeMounts:
+    - mountPath: /tmp/results
+      name: results
+      readOnly: false

--- a/pkg/plugin/loader/testdata/skip-cleanup/set-true.yml
+++ b/pkg/plugin/loader/testdata/skip-cleanup/set-true.yml
@@ -1,0 +1,13 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: test-plugin-skip-cleanup
+  result-type: test-plugin-skip-cleanup
+  skip-cleanup: true
+spec:
+  image: gcr.io/heptio-images/heptio-e2e:master
+  imagePullPolicy: Always
+  name: heptio-e2e
+  volumeMounts:
+    - mountPath: /tmp/results
+      name: results
+      readOnly: false

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -24,19 +24,21 @@ import (
 
 // SonobuoyConfig is the Sonobuoy metadata that plugins all supply
 type SonobuoyConfig struct {
-	Driver     string `json:"driver"`
-	PluginName string `json:"plugin-name"`
-	ResultType string `json:"result-type"`
+	Driver      string `json:"driver"`
+	PluginName  string `json:"plugin-name"`
+	ResultType  string `json:"result-type"`
+	SkipCleanup bool   `json:"skip-cleanup,omitempty"`
 	objectKind
 }
 
 // DeepCopy makes a deep copy (needed by DeepCopyObject)
 func (s *SonobuoyConfig) DeepCopy() *SonobuoyConfig {
 	return &SonobuoyConfig{
-		Driver:     s.Driver,
-		PluginName: s.PluginName,
-		ResultType: s.ResultType,
-		objectKind: objectKind{s.objectKind.gvk},
+		Driver:      s.Driver,
+		PluginName:  s.PluginName,
+		ResultType:  s.ResultType,
+		SkipCleanup: s.SkipCleanup,
+		objectKind:  objectKind{s.objectKind.gvk},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Introduces a new field to the plugin definition which allows
cleanup for a given plugin to be skipped. This can be used in the
case where a user wants to inspect the resources after a plugin
has finished running.
 
If this field is set to true, cleanup for that plugin will be skipped.
If it is omitted or set to false, cleanup will happen as usual.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #299 

**Special notes for your reviewer**:
This change will also require documentation to be updated
which I haven't yet done.

**Release note**:
```
Introduced a new plugin configuration option which allows clean up of resources for that plugin to be skipped.
```
