### PR TITLE
Fix a broken link on "Conformance Testing" page

### DIFF
--- a/site/docs/master/conformance-testing.md
+++ b/site/docs/master/conformance-testing.md
@@ -37,7 +37,7 @@ To customize the set of tests that are run as part of the report, the following 
 [1]: #integration-with-sonobuoy
 [2]: https://docs.google.com/spreadsheets/d/1LxSqBzjOxfGx3cmtZ4EbB_BGCxT_wlxW_xgHVVa23es/edit#gid=0
 [3]: https://kubernetes.io/docs/admin/node-conformance/
-[4]: https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#conformance-tests
+[4]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md#conformance-tests
 [5]: plugins.md
 [6]: https://github.com/kubernetes/kubernetes/issues/49313
 [7]: https://github.com/heptio/sonobuoy/examples/plugins.d/e2e.yaml#L9

--- a/site/docs/v0.15.0/conformance-testing.md
+++ b/site/docs/v0.15.0/conformance-testing.md
@@ -37,7 +37,7 @@ To customize the set of tests that are run as part of the report, the following 
 [1]: #integration-with-sonobuoy
 [2]: https://docs.google.com/spreadsheets/d/1LxSqBzjOxfGx3cmtZ4EbB_BGCxT_wlxW_xgHVVa23es/edit#gid=0
 [3]: https://kubernetes.io/docs/admin/node-conformance/
-[4]: https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#conformance-tests
+[4]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md#conformance-tests
 [5]: plugins.md
 [6]: https://github.com/kubernetes/kubernetes/issues/49313
 [7]: ../examples/plugins.d/e2e.yaml#L9


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a broken link on [Conformance Testing](https://sonobuoy.io/docs/v0.15.0/conformance-testing/).
