### PR TITLE
Generate Plugins ConfigMap if no plugins specified

### DIFF
--- a/pkg/client/testdata/no-plugins-via-selection.golden
+++ b/pkg/client/testdata/no-plugins-via-selection.golden
@@ -24,6 +24,13 @@ metadata:
   name: sonobuoy-config-cm
   namespace: heptio-sonobuoy
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: heptio-sonobuoy
 ---
 apiVersion: v1
 kind: Pod

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -91,11 +91,12 @@ metadata:
   name: sonobuoy-config-cm
   namespace: {{.Namespace}}
 ---
-{{- if .Plugins }}
 apiVersion: v1
+{{- if .Plugins }}
 data:{{- range $i, $v := .Plugins }}
   plugin-{{- $i -}}.yaml: |
     {{ indent 4 $v }}
+{{- end }}
 {{- end }}
 kind: ConfigMap
 metadata:
@@ -103,7 +104,6 @@ metadata:
     component: sonobuoy
   name: sonobuoy-plugins-cm
   namespace: {{.Namespace}}
-{{- end }}
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
**What this PR does / why we need it**:
If the Sonobuoy config specified that no plugins should be run (by
overriding `Plugins` with an empty array), the ConfigMap which holds the
YAML for the plugins would not be created. The Sonobuoy aggregator would
then attempt to mount a non-existent ConfigMap and the container would
fail to start.

This change ensures that the ConfigMap is always created. In the case
where there are no plugins, no data is added.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>


**Which issue(s) this PR fixes**
- Fixes #784

**Special notes for your reviewer**:

**Release note**:
```
Fixed a bug where the Sonobuoy aggregator container would fail to start if the config specified no plugins to run.
```
