### PR TITLE
Ensure only failed tests are run with --rerun-failed

### DIFF
--- a/cmd/sonobuoy/app/e2e.go
+++ b/cmd/sonobuoy/app/e2e.go
@@ -127,6 +127,11 @@ func e2es(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("Rerunning %d tests:\n", len(testCases))
+
+	// Ensure that we run the failed test cases and don't skip any
+	runCfg.E2EConfig.Focus = client.Focus(testCases)
+	runCfg.E2EConfig.Skip = ""
+
 	if err := sonobuoy.Run(runCfg); err != nil {
 		errlog.LogError(errors.Wrap(err, "error attempting to rerun failed tests"))
 		os.Exit(1)

--- a/pkg/client/e2e.go
+++ b/pkg/client/e2e.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -75,11 +76,9 @@ func (*SonobuoyClient) GetTests(reader io.Reader, show string) ([]reporters.JUni
 // Focus returns a value to be used in the E2E_FOCUS variable that is
 // representative of the test cases in the struct.
 func Focus(testCases []reporters.JUnitTestCase) string {
-	// YAML doesn't like escaped characters and regex needs escaped characters. Therefore a double escape is necessary.
-	r := strings.NewReplacer("[", `\\[`, "]", `\\]`)
 	testNames := make([]string, len(testCases))
 	for i, tc := range testCases {
-		testNames[i] = r.Replace(tc.Name)
+		testNames[i] = regexp.QuoteMeta(tc.Name)
 	}
 	return strings.Join(testNames, "|")
 }

--- a/pkg/client/e2e_test.go
+++ b/pkg/client/e2e_test.go
@@ -119,3 +119,47 @@ func TestString(t *testing.T) {
 		})
 	}
 }
+
+func TestFocus(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		cases  PrintableTestCases
+		expect string
+	}{
+		{
+			desc:   "No test should result in an empty string",
+			cases:  []reporters.JUnitTestCase{},
+			expect: "",
+		},
+		{
+			desc: "Single test with no regexp characters is not changed",
+			cases: []reporters.JUnitTestCase{
+				reporters.JUnitTestCase{Name: "this is a test"},
+			},
+			expect: "this is a test",
+		},
+		{
+			desc: "Test with special regexp characters should be escaped",
+			cases: []reporters.JUnitTestCase{
+				reporters.JUnitTestCase{Name: "[sig-apps] test-1 (1.15) [Conformance]"},
+			},
+			expect: `\[sig-apps\] test-1 \(1\.15\) \[Conformance\]`,
+		},
+		{
+			desc: "Multiple tests should be separated with '|'",
+			cases: []reporters.JUnitTestCase{
+				reporters.JUnitTestCase{Name: "[sig-apps] test-1 [Conformance]"},
+				reporters.JUnitTestCase{Name: "[sig-apps] test-2"},
+			},
+			expect: `\[sig-apps\] test-1 \[Conformance\]|\[sig-apps\] test-2`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := Focus(tc.cases)
+			if out != tc.expect {
+				t.Errorf("Expected %q but got %q", tc.expect, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This reintroduces the `e2e --rerun-failed` behaviour which had been
accidentally removed as part of a refactor. As part of reintroducing this
behaviour, it was noticed that the generated rergex for running specific
tests was invalid and would cause a panic when running ginkgo. In the
generated regex, we were double escaping `[]` characters. This doesn't
seem to be necessary as we do not double escape these characters for
other regexes (e.g. [`defaultSkipList`](https://github.com/heptio/sonobuoy/blob/master/pkg/client/mode.go#L42)).

**Which issue(s) this PR fixes**
- Fixes #797 

**Special notes for your reviewer**:
This behaviour was removed in [#315](https://github.com/heptio/sonobuoy/pull/315/files#diff-f6f1cbdfc63048c2340177ccd708d6b6L108). I have verified the fix works manually but I don't know if there is a better way to test this so that is covered under CI. I wasn't sure if it was worth adding another more testing logic to our Travis CI script so I would appreciate any input that you might have.

**Release note**:
```
Fixed a bug where the `--rerun-failed` flag for the `e2e` command would run all the tests, not only the failed tests.
```
