### PR TITLE
Upgrade kind to v0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 
 before_install:
   # Download and install Kind
-  - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 --output kind && chmod +x kind
+  - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64 --output kind && chmod +x kind
   - ./kind create cluster --config kind-config.yaml
   - export KUBECONFIG="$(./kind get kubeconfig-path --name="kind")"
   - curl -L https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 --output dep && chmod +x dep

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,5 +1,5 @@
-kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
This upgrades our Travis CI script to use the latest version of Kind ([v0.4.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.4.0)).

As part of this upgrade, we also need to update our kind config to no longer use the `kind.sigs.k8s.io/v1alpha2` API as that was removed in this release. The new API no longer supports the `Config` type, and instead it should be `Cluster`. The config has been updated according to the changes in the [example kind config](https://raw.githubusercontent.com/kubernetes-sigs/kind/master/site/content/docs/user/kind-example-config.yaml).