### PR TITLE
Create a UUID for loaded configs if necessary

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -27,6 +27,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	pluginloader "github.com/heptio/sonobuoy/pkg/plugin/loader"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -77,6 +78,12 @@ func LoadConfig() (*Config, error) {
 	// Make the results dir overridable with an environment variable
 	if resultsDir, ok := os.LookupEnv("RESULTS_DIR"); ok {
 		cfg.ResultsDir = resultsDir
+	}
+
+	// If the loaded config doesn't have its own UUID, create one
+	if cfg.UUID == "" {
+		cfgUuid, _ := uuid.NewV4()
+		cfg.UUID = cfgUuid.String()
 	}
 
 	// 5 - Load any plugins we have

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -118,16 +118,35 @@ func TestSaveAndLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// And we can't predict what advertise address we'll detect
+	// We can't predict what advertise address we'll detect
 	cfg2.Aggregation.AdvertiseAddress = cfg.Aggregation.AdvertiseAddress
-	// And UUID's won't match either
-	cfg.UUID = ""
-	cfg2.UUID = ""
 
 	if !reflect.DeepEqual(cfg2, cfg) {
 		t.Fatalf("Defaults should match but didn't \n\n%v\n\n%v", cfg2, cfg)
 	}
+}
 
+func TestLoadConfigSetsUUID(t *testing.T) {
+	cfg := New()
+	cfg.UUID = ""
+
+	if blob, err := json.Marshal(&cfg); err == nil {
+		if err = ioutil.WriteFile("./config.json", blob, 0644); err != nil {
+			t.Fatalf("Failed to write default config.json: %v", err)
+		}
+		defer os.Remove("./config.json")
+	} else {
+		t.Fatalf("Failed to serialize %v", err)
+	}
+
+	loadedCfg, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loadedCfg.UUID == "" {
+		t.Error("loaded config should have a UUID but was empty")
+	}
 }
 
 func TestDefaultResources(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When loading a config without a UUID, we don't generate one and it
remains empty. It is necessary for the config to have a UUID as it is
used to create a uniquely named directory for storing results. Without
this, we don't correctly create a child directory to store the results.
We create a tarball within a directory that we also try to add to that
tarball, effectively adding the created tarball to itself resulting in a
write error.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #806

**Release note**:
```
Fixed a bug where a config without a UUID would result in an error when writing results
```
