### PR TITLE
Remove plugin.Definition

### DIFF
--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/job"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	sonotime "github.com/heptio/sonobuoy/pkg/time/timetest"
 	"github.com/pkg/errors"
 
@@ -32,9 +33,11 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 	// a job plugin is much simpler to test against.
 	testPlugin := &job.Plugin{
 		Base: driver.Base{
-			Definition: plugin.Definition{
-				Name:       "myPlugin",
-				ResultType: "myPlugin",
+			Definition: manifest.Manifest{
+				SonobuoyConfig: manifest.SonobuoyConfig{
+					PluginName: "myPlugin",
+					ResultType: "myPlugin",
+				},
 			},
 			Namespace: "testNS",
 		},

--- a/pkg/plugin/driver/base_test.go
+++ b/pkg/plugin/driver/base_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/heptio/sonobuoy/pkg/backplane/ca"
-	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 )
 
 func TestMakeTLSSecret(t *testing.T) {
@@ -43,8 +43,8 @@ func TestMakeTLSSecret(t *testing.T) {
 
 	driver := &Base{
 		Namespace: expectedNamespace,
-		Definition: plugin.Definition{
-			Name: expectedName,
+		Definition: manifest.Manifest{
+			SonobuoyConfig: manifest.SonobuoyConfig{PluginName: expectedName},
 		},
 		SessionID: sessionID,
 	}
@@ -86,8 +86,8 @@ func TestMakeTLSSecret(t *testing.T) {
 
 func TestSkipCleanup(t *testing.T) {
 	b := &Base{
-		Definition: plugin.Definition{
-			SkipCleanup: false,
+		Definition: manifest.Manifest{
+			SonobuoyConfig: manifest.SonobuoyConfig{SkipCleanup: false},
 		},
 	}
 
@@ -95,7 +95,7 @@ func TestSkipCleanup(t *testing.T) {
 		t.Error("Expected SkipCleanup to be false but was true")
 	}
 
-	b.Definition.SkipCleanup = true
+	b.Definition.SonobuoyConfig.SkipCleanup = true
 
 	if !b.SkipCleanup() {
 		t.Error("Expected SkipCleanup to be true but was false")

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -34,6 +34,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/utils"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	sonotime "github.com/heptio/sonobuoy/pkg/time"
 	"github.com/pkg/errors"
 )
@@ -54,7 +55,7 @@ var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
 // and sonobuoy master address.
-func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
+func NewPlugin(dfn manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
 	return &Plugin{
 		driver.Base{
 			Definition:        dfn,
@@ -93,11 +94,11 @@ func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, e
 
 	tmplData, err := p.GetTemplateData(getMasterAddress(hostname), cert)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't get template data for %q", p.Definition.Name)
+		return nil, errors.Wrapf(err, "couldn't get template data for %q", p.GetName())
 	}
 
 	if err := daemonSetTemplate.Execute(&b, tmplData); err != nil {
-		return nil, errors.Wrapf(err, "couldn't fill template %q", p.Definition.Name)
+		return nil, errors.Wrapf(err, "couldn't fill template %q", p.GetName())
 	}
 	return b.Bytes(), nil
 }
@@ -169,7 +170,7 @@ func (p *Plugin) findDaemonSet(kubeclient kubernetes.Interface) (*appsv1.DaemonS
 	}
 
 	if len(dsets.Items) != 1 {
-		return nil, errors.Errorf("expected plugin %v to create 1 daemonset, found %v", p.Definition.Name, len(dsets.Items))
+		return nil, errors.Errorf("expected plugin %v to create 1 daemonset, found %v", p.GetName(), len(dsets.Items))
 	}
 
 	return &dsets.Items[0], nil
@@ -264,7 +265,7 @@ func (p *Plugin) monitorOnce(kubeclient kubernetes.Interface, availableNodes []v
 					"No pod was scheduled on node %v within %v. Check tolerations for plugin %v",
 					node.Name,
 					time.Now().Sub(ds.CreationTimestamp.Time),
-					p.Definition.Name,
+					p.GetName(),
 				),
 			}, node.Name))
 		}

--- a/pkg/plugin/driver/daemonset/daemonset_test.go
+++ b/pkg/plugin/driver/daemonset/daemonset_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/heptio/sonobuoy/pkg/backplane/ca"
-	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver"
 	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 
@@ -43,37 +42,40 @@ const (
 )
 
 func TestFillTemplate(t *testing.T) {
-	testDaemonSet := NewPlugin(plugin.Definition{
-		Name:       "test-plugin",
-		ResultType: "test-plugin-result",
-		Spec: manifest.Container{
-			Container: corev1.Container{
-				Name: "producer-container",
+	testDaemonSet := NewPlugin(
+		manifest.Manifest{
+			SonobuoyConfig: manifest.SonobuoyConfig{
+				PluginName: "test-plugin",
+				ResultType: "test-plugin-result",
 			},
-		},
-		ExtraVolumes: []manifest.Volume{
-			{
-				Volume: corev1.Volume{
-					Name: "test1",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/test",
+			Spec: manifest.Container{
+				Container: corev1.Container{
+					Name: "producer-container",
+				},
+			},
+			ExtraVolumes: []manifest.Volume{
+				{
+					Volume: corev1.Volume{
+						Name: "test1",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/test",
+							},
+						},
+					},
+				},
+				{
+					Volume: corev1.Volume{
+						Name: "test2",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/test2",
+							},
 						},
 					},
 				},
 			},
-			{
-				Volume: corev1.Volume{
-					Name: "test2",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/test2",
-						},
-					},
-				},
-			},
-		},
-	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
+		}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
 
 	auth, err := ca.NewAuthority()
 	if err != nil {
@@ -178,7 +180,7 @@ func TestMonitorOnce(t *testing.T) {
 
 	// We will need to be able to grab these items repeatedly and tweak the minor details
 	// so these helpers make the test cases much more readable.
-	testPlugin := &Plugin{Base: driver.Base{Definition: plugin.Definition{Name: "myPlugin"}}}
+	testPlugin := &Plugin{Base: driver.Base{Definition: manifest.Manifest{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myPlugin"}}}}
 	validDS := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"sonobuoy-run": ""}},
 	}

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -34,6 +34,7 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver/utils"
+	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	sonotime "github.com/heptio/sonobuoy/pkg/time"
 )
 
@@ -53,7 +54,7 @@ var _ plugin.Interface = &Plugin{}
 
 // NewPlugin creates a new DaemonSet plugin from the given Plugin Definition
 // and sonobuoy master address.
-func NewPlugin(dfn plugin.Definition, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
+func NewPlugin(dfn manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy, imagePullSecrets string, customAnnotations map[string]string) *Plugin {
 	return &Plugin{
 		driver.Base{
 			Definition:        dfn,
@@ -86,11 +87,11 @@ func (p *Plugin) FillTemplate(hostname string, cert *tls.Certificate) ([]byte, e
 
 	tmplData, err := p.GetTemplateData(getMasterAddress(hostname), cert)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't get template data for %q", p.Definition.Name)
+		return nil, errors.Wrapf(err, "couldn't get template data for %q", p.GetName())
 	}
 
 	if err := jobTemplate.Execute(&b, tmplData); err != nil {
-		return nil, errors.Wrapf(err, "couldn't fill template %q", p.Definition.Name)
+		return nil, errors.Wrapf(err, "couldn't fill template %q", p.GetName())
 	}
 
 	return b.Bytes(), nil
@@ -219,7 +220,7 @@ func (p *Plugin) findPod(kubeclient kubernetes.Interface) (*v1.Pod, error) {
 	}
 
 	if len(pods.Items) != 1 {
-		return nil, errors.Errorf("no pods were created by plugin %v", p.Definition.Name)
+		return nil, errors.Errorf("no pods were created by plugin %v", p.GetName())
 	}
 
 	return &pods.Items[0], nil

--- a/pkg/plugin/driver/job/job_test.go
+++ b/pkg/plugin/driver/job/job_test.go
@@ -45,37 +45,40 @@ const (
 )
 
 func TestFillTemplate(t *testing.T) {
-	testJob := NewPlugin(plugin.Definition{
-		Name:       "test-job",
-		ResultType: "test-job-result",
-		Spec: manifest.Container{
-			Container: corev1.Container{
-				Name: "producer-container",
+	testJob := NewPlugin(
+		manifest.Manifest{
+			SonobuoyConfig: manifest.SonobuoyConfig{
+				PluginName: "test-job",
+				ResultType: "test-job-result",
 			},
-		},
-		ExtraVolumes: []manifest.Volume{
-			{
-				Volume: corev1.Volume{
-					Name: "test1",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/test",
+			Spec: manifest.Container{
+				Container: corev1.Container{
+					Name: "producer-container",
+				},
+			},
+			ExtraVolumes: []manifest.Volume{
+				{
+					Volume: corev1.Volume{
+						Name: "test1",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/test",
+							},
+						},
+					},
+				},
+				{
+					Volume: corev1.Volume{
+						Name: "test2",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/test2",
+							},
 						},
 					},
 				},
 			},
-			{
-				Volume: corev1.Volume{
-					Name: "test2",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/test2",
-						},
-					},
-				},
-			},
-		},
-	}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
+		}, expectedNamespace, expectedImageName, "Always", "image-pull-secret", map[string]string{"key1": "val1", "key2": "val2"})
 
 	auth, err := ca.NewAuthority()
 	if err != nil {

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"path"
 
-	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -60,16 +59,6 @@ type Interface interface {
 	GetName() string
 	// SkipCleanup returns whether cleanup for this plugin should be skipped or not.
 	SkipCleanup() bool
-}
-
-// Definition defines a plugin's features, method of launch, and other
-// metadata about it.
-type Definition struct {
-	Name         string
-	ResultType   string
-	SkipCleanup  bool
-	Spec         manifest.Container
-	ExtraVolumes []manifest.Volume
 }
 
 // ExpectedResult is an expected result that a plugin will submit.  This is so

--- a/pkg/plugin/loader/loader_test.go
+++ b/pkg/plugin/loader/loader_test.go
@@ -147,7 +147,7 @@ func TestLoadValidPluginWithSkipCleanup(t *testing.T) {
 func TestLoadJobPlugin(t *testing.T) {
 	namespace := "loader_test"
 	image := "gcr.io/heptio-images/sonobuoy:latest"
-	jobDef := &manifest.Manifest{
+	jobDef := manifest.Manifest{
 		SonobuoyConfig: manifest.SonobuoyConfig{
 			Driver:     "Job",
 			PluginName: "test-job-plugin",
@@ -170,8 +170,8 @@ func TestLoadJobPlugin(t *testing.T) {
 		t.Fatalf("loaded plugin not a job.Plugin")
 	}
 
-	if jobPlugin.Definition.Name != "test-job-plugin" {
-		t.Errorf("expected plugin name 'test-job-plugin', got '%v'", jobPlugin.Definition.Name)
+	if jobPlugin.GetName() != "test-job-plugin" {
+		t.Errorf("expected plugin name 'test-job-plugin', got '%v'", jobPlugin.GetName())
 	}
 	if jobPlugin.Definition.Spec.Image != "gcr.io/heptio-images/heptio-e2e:master" {
 		t.Errorf("expected plugin name 'gcr.io/heptio-images/heptio-e2e:master', got '%v'", jobPlugin.Definition.Spec.Image)
@@ -187,7 +187,7 @@ func TestLoadJobPlugin(t *testing.T) {
 func TestLoadDaemonSet(t *testing.T) {
 	namespace := "loader_test"
 	image := "gcr.io/heptio-images/sonobuoy:latest"
-	daemonDef := &manifest.Manifest{
+	daemonDef := manifest.Manifest{
 		SonobuoyConfig: manifest.SonobuoyConfig{
 			Driver:     "DaemonSet",
 			PluginName: "test-daemon-set-plugin",
@@ -210,8 +210,8 @@ func TestLoadDaemonSet(t *testing.T) {
 		t.Fatalf("loaded plugin not a daemon.Plugin")
 	}
 
-	if daemonPlugin.Definition.Name != "test-daemon-set-plugin" {
-		t.Errorf("expected plugin name 'test-daemon-set-plugin', got '%v'", daemonPlugin.Definition.Name)
+	if daemonPlugin.GetName() != "test-daemon-set-plugin" {
+		t.Errorf("expected plugin name 'test-daemon-set-plugin', got '%v'", daemonPlugin.GetName())
 	}
 	if daemonPlugin.Definition.Spec.Image != "gcr.io/heptio-images/heptio-e2e:master" {
 		t.Errorf("expected plugin name 'gcr.io/heptio-images/heptio-e2e:master', got '%v'", daemonPlugin.Definition.Spec.Image)
@@ -225,7 +225,7 @@ func TestLoadDaemonSet(t *testing.T) {
 }
 
 func TestFilterList(t *testing.T) {
-	definitions := []*manifest.Manifest{
+	definitions := []manifest.Manifest{
 		{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "test1"}},
 		{SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "test2"}},
 	}
@@ -235,7 +235,7 @@ func TestFilterList(t *testing.T) {
 		{Name: "test3"},
 	}
 
-	expected := []*manifest.Manifest{definitions[0]}
+	expected := []manifest.Manifest{definitions[0]}
 	filtered := filterPluginDef(definitions, selections)
 	if !reflect.DeepEqual(filtered, expected) {
 		t.Errorf("expected %+#v, got %+#v", expected, filtered)

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -24,10 +24,20 @@ import (
 
 // SonobuoyConfig is the Sonobuoy metadata that plugins all supply
 type SonobuoyConfig struct {
-	Driver      string `json:"driver"`
-	PluginName  string `json:"plugin-name"`
-	ResultType  string `json:"result-type"`
-	SkipCleanup bool   `json:"skip-cleanup,omitempty"`
+	// Driver is the way in which this plugin is run. Either 'Job' or 'Daemonset'.
+	Driver string `json:"driver"`
+
+	// Name is the user-facing name for the plugin.
+	PluginName string `json:"plugin-name"`
+
+	// ResultType should uniquely identify the plugin and is used by the aggregator
+	// to track what results should be reported back to it.
+	ResultType string `json:"result-type"`
+
+	// SkipCleanup informs Sonobuoy to leave the pods created for this plugin running,
+	// after the run completes instead of deleting them as part of default, cleanup behavior.
+	SkipCleanup bool `json:"skip-cleanup,omitempty"`
+
 	objectKind
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The type plugin.Definition completely duplicates fields that exist
inside of manifest.Manifest and adds nothing new. Though I prefer
the name plugin.Definition, the users currently use the manifest.Manifest
object locally and expect the nested sonobuoy-config object so we
needed to keep that in order to not break existing plugins. In addition,
the plugin.Definition type was missing the Driver field, so the server
was actually losing that data when using that type.

This change should have no impact other than clarifying the landscape
of types on the backend.

**Which issue(s) this PR fixes**
Helps facilitate #306

**Release note**:
```
NONE
```
