### PR TITLE
Remove use of global sonobuoy pod name

### DIFF
--- a/pkg/client/retrieve.go
+++ b/pkg/client/retrieve.go
@@ -60,12 +60,15 @@ func (c *SonobuoyClient) RetrieveResults(cfg *RetrieveConfig) (io.Reader, <-chan
 	}
 
 	// Determine sonobuoy pod name
-	pluginaggregation.SetStatusPodName(client, cfg.Namespace)
+	podName, err := pluginaggregation.GetStatusPodName(client, cfg.Namespace)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get the name of the aggregator pod to fetch results from")
+	}
 
 	restClient := client.CoreV1().RESTClient()
 	req := restClient.Post().
 		Resource("pods").
-		Name(pluginaggregation.StatusPodName).
+		Name(podName).
 		Namespace(cfg.Namespace).
 		SubResource("exec").
 		Param("container", config.MasterContainerName)

--- a/pkg/plugin/aggregation/status.go
+++ b/pkg/plugin/aggregation/status.go
@@ -83,9 +83,12 @@ func GetStatus(client kubernetes.Interface, namespace string) (*Status, error) {
 	}
 
 	// Determine sonobuoy pod name
-	SetStatusPodName(client, namespace)
+	podName, err := GetStatusPodName(client, namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get the name of the aggregator pod to get the status from")
+	}
 
-	pod, err := client.CoreV1().Pods(namespace).Get(StatusPodName, metav1.GetOptions{})
+	pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.New("could not retrieve sonobuoy pod")
 	}

--- a/pkg/plugin/aggregation/update_test.go
+++ b/pkg/plugin/aggregation/update_test.go
@@ -20,6 +20,13 @@ import (
 	"testing"
 
 	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCreateUpdater(t *testing.T) {
@@ -45,5 +52,77 @@ func TestCreateUpdater(t *testing.T) {
 
 	if updater.status.Status != FailedStatus {
 		t.Errorf("expected status to be failed, got %v", updater.status.Status)
+	}
+}
+
+func TestGetStatusPodName(t *testing.T) {
+	createPodWithRunLabel := func(name string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"run": "sonobuoy-master"},
+			},
+		}
+	}
+
+	testCases := []struct {
+		desc            string
+		podsOnServer    corev1.PodList
+		errFromServer   error
+		expectedPodName string
+	}{
+		{
+			desc:            "Error retrieving pods from server results in no pod name and an error being returned",
+			podsOnServer:    corev1.PodList{},
+			errFromServer:   errors.New("could not retrieve pods"),
+			expectedPodName: "",
+		},
+		{
+			desc:            "No pods results in default pod name being used",
+			podsOnServer:    corev1.PodList{},
+			errFromServer:   nil,
+			expectedPodName: "sonobuoy",
+		},
+		{
+			desc: "Only one pod results in that pod name being used",
+			podsOnServer: corev1.PodList{
+				Items: []corev1.Pod{
+					createPodWithRunLabel("sonobuoy-run-pod"),
+				},
+			},
+			errFromServer:   nil,
+			expectedPodName: "sonobuoy-run-pod",
+		},
+		{
+			desc: "More that one pod results in the first pod name being used",
+			podsOnServer: corev1.PodList{
+				Items: []corev1.Pod{
+					createPodWithRunLabel("sonobuoy-run-pod-1"),
+					createPodWithRunLabel("sonobuoy-run-pod-2"),
+				},
+			},
+			errFromServer:   nil,
+			expectedPodName: "sonobuoy-run-pod-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fclient := fake.NewSimpleClientset()
+			fclient.PrependReactor("*", "*", func(action k8stesting.Action) (handled bool, ret kuberuntime.Object, err error) {
+				return true, &tc.podsOnServer, tc.errFromServer
+			})
+
+			podName, err := GetStatusPodName(fclient, "sonobuoy")
+			if tc.errFromServer == nil && err != nil {
+				t.Errorf("Unexpected error returned, expected nil but got %q", err)
+			}
+			if tc.errFromServer != nil && err == nil {
+				t.Errorf("Error not returned, expected %q but was nil", tc.errFromServer)
+			}
+			if podName != tc.expectedPodName {
+				t.Errorf("Incorrect pod name returned, expected %q but got %q", tc.expectedPodName, podName)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the sonobuoy pod name was stored in a global variable and was
updated before it was used. Now, instead of updating the global variable
the function that determines the pod name returns it instead.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
