### PR TITLE
Default to ResultFormat=raw if unset

### DIFF
--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -119,6 +119,9 @@ func PostProcessPlugin(p plugin.Interface, dir string) (Item, error) {
 	case ResultFormatRaw:
 		i, err = processPluginWithProcessor(p, dir, processRawFile, fileOrAny(p.GetResultFile()))
 	default:
+		// Default to raw format so that consumers can still expect the aggregate file to exist and
+		// can navigate the output of the plugin more easily.
+		i, err = processPluginWithProcessor(p, dir, processRawFile, fileOrAny(p.GetResultFile()))
 	}
 
 	i.Status = aggregateStatus(i.Items...)

--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -106,6 +106,14 @@ func TestPostProcessPlugin(t *testing.T) {
 			key:    "job-raw-01",
 			plugin: getPlugin("job-raw-01", "job", "raw", "output.xml"),
 		}, {
+			desc:   "Job default 2 files",
+			key:    "job-default-02",
+			plugin: getPlugin("job-default-02", "job", "", ""),
+		}, {
+			desc:   "Job default 1 file, others ignored",
+			key:    "job-default-01",
+			plugin: getPlugin("job-default-01", "job", "", "output.xml"),
+		}, {
 			desc:   "Daemonset raw 2 files",
 			key:    "ds-raw-02",
 			plugin: getPlugin("ds-raw-02", "daemonset", "raw", ""),

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
@@ -1,0 +1,1 @@
+{"name":"job-default-01","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}}]}

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-01/results/global/output.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-01/results/global/output.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="204" failures="0" time="0.0574002">
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-01/results/global/output2-ignored.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-01/results/global/output2-ignored.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="204" failures="0" time="0.0574002">
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.308404">
+          <failure type="Failure">/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696&#xA;Conformance test suite needs a cluster with at least 2 nodes.&#xA;Expected&#xA;    &lt;int&gt;: 1&#xA;to be &gt;&#xA;    &lt;int&gt;: 1&#xA;/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385</failure>
+          <system-out>[BeforeEach]... </system-out>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
@@ -1,0 +1,1 @@
+{"name":"job-default-02","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-02/results/global/output.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-02/results/global/output.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="204" failures="0" time="0.0574002">
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-02/results/global/output2.xml
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-02/results/global/output2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="204" failures="0" time="0.0574002">
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="0"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.308404">
+          <failure type="Failure">/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696&#xA;Conformance test suite needs a cluster with at least 2 nodes.&#xA;Expected&#xA;    &lt;int&gt;: 1&#xA;to be &gt;&#xA;    &lt;int&gt;: 1&#xA;/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385</failure>
+          <system-out>[BeforeEach] ...</system-out>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>


### PR DESCRIPTION
**What this PR does / why we need it**:
When unset (or invalid), currently no post-processing is done which
means that users won't find the sonobuoy_results.yaml file.

By defaulting to 'raw' we make users immediately get a benefit from
the post-processing regardless of if they take extra steps to
customize the type/output.

**Which issue(s) this PR fixes**
Fixes #820

**Special notes for your reviewer**:

**Release note**:
```
Post-processing defaults to ResultFormat=raw if unset or invalid in order to ensure users gain the benefit of the post-processing and "sonobuoy results" command.
```
