### PR TITLE
Add results info to the status annotation and status cmd output

### DIFF
--- a/cmd/sonobuoy/app/status_test.go
+++ b/cmd/sonobuoy/app/status_test.go
@@ -24,19 +24,18 @@ import (
 	"github.com/heptio/sonobuoy/pkg/plugin/aggregation"
 )
 
-var expectedSummary = `PLUGIN		STATUS		COUNT
-e2e		complete	1
-systemd_logs	complete	1
-systemd_logs	running		2
+var expectedSummary = `         PLUGIN     STATUS   RESULT   COUNT
+            e2e   complete   passed       1
+   systemd_logs   complete   failed       1
+   systemd_logs    running                2
 
 Sonobuoy is still running. Runs can take up to 60 minutes.
 `
-
-var expectedShowAll = `PLUGIN		NODE	STATUS
-e2e			complete
-systemd_logs	node01	running
-systemd_logs	node02	complete
-systemd_logs	node03	running
+var expectedShowAll = `         PLUGIN     NODE     STATUS   RESULT
+            e2e            complete   passed
+   systemd_logs   node01    running         
+   systemd_logs   node02   complete   failed
+   systemd_logs   node03    running         
 
 Sonobuoy is still running. Runs can take up to 60 minutes.
 `
@@ -45,9 +44,10 @@ var exampleStatus = aggregation.Status{
 	Status: "running",
 	Plugins: []aggregation.PluginStatus{
 		{
-			Plugin: "e2e",
-			Node:   "",
-			Status: "complete",
+			Plugin:       "e2e",
+			Node:         "",
+			Status:       "complete",
+			ResultStatus: "passed",
 		},
 		{
 			Plugin: "systemd_logs",
@@ -55,9 +55,10 @@ var exampleStatus = aggregation.Status{
 			Status: "running",
 		},
 		{
-			Plugin: "systemd_logs",
-			Node:   "node02",
-			Status: "complete",
+			Plugin:       "systemd_logs",
+			Node:         "node02",
+			Status:       "complete",
+			ResultStatus: "failed",
 		},
 		{
 			Plugin: "systemd_logs",
@@ -94,7 +95,7 @@ func TestPrintStatus(t *testing.T) {
 			}
 
 			if b.String() != test.expected {
-				t.Errorf("expected output to be %q, got %q", test.expected, b.String())
+				t.Errorf("expected output to be \n%v, got \n%v", test.expected, b.String())
 			}
 		})
 	}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -1,8 +1,12 @@
 package discovery
 
 import (
-	"github.com/heptio/sonobuoy/pkg/config"
 	"testing"
+
+	"github.com/heptio/sonobuoy/pkg/client/results"
+	"github.com/heptio/sonobuoy/pkg/config"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestGetPodLogNamespaceFilter(t *testing.T) {
@@ -12,12 +16,12 @@ func TestGetPodLogNamespaceFilter(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Provided both Namespaces and SonobuoyNamespace will generate filter to concatenate them by OR",
-			input:    &config.Config{
+			name: "Provided both Namespaces and SonobuoyNamespace will generate filter to concatenate them by OR",
+			input: &config.Config{
 				Namespace: config.DefaultNamespace,
 				Limits: config.LimitConfig{
 					PodLogs: config.PodLogLimits{
-						Namespaces: ".*",
+						Namespaces:        ".*",
 						SonobuoyNamespace: &[]bool{true}[0],
 					},
 				},
@@ -25,12 +29,12 @@ func TestGetPodLogNamespaceFilter(t *testing.T) {
 			expected: ".*|" + config.DefaultNamespace,
 		},
 		{
-			name:     "Provided only Namespaces will generate filter which includes only Namespaces regex",
-			input:    &config.Config{
+			name: "Provided only Namespaces will generate filter which includes only Namespaces regex",
+			input: &config.Config{
 				Namespace: config.DefaultNamespace,
 				Limits: config.LimitConfig{
 					PodLogs: config.PodLogLimits{
-						Namespaces: ".*",
+						Namespaces:        ".*",
 						SonobuoyNamespace: &[]bool{false}[0],
 					},
 				},
@@ -38,12 +42,12 @@ func TestGetPodLogNamespaceFilter(t *testing.T) {
 			expected: ".*",
 		},
 		{
-			name:     "Provided neither Namespaces nor SonobuoyNamespace will output an empty filter",
-			input:    &config.Config{
+			name: "Provided neither Namespaces nor SonobuoyNamespace will output an empty filter",
+			input: &config.Config{
 				Namespace: config.DefaultNamespace,
 				Limits: config.LimitConfig{
 					PodLogs: config.PodLogLimits{
-						Namespaces: "",
+						Namespaces:        "",
 						SonobuoyNamespace: &[]bool{false}[0],
 					},
 				},
@@ -58,5 +62,64 @@ func TestGetPodLogNamespaceFilter(t *testing.T) {
 		if nsFilter != tc.expected {
 			t.Errorf("GetPodLogNamespaceFilter() expected %s, got %s", tc.expected, nsFilter)
 		}
+	}
+}
+
+func TestStatusCounts(t *testing.T) {
+	tcs := []struct {
+		desc        string
+		input       *results.Item
+		inputCounts map[string]int
+		expected    map[string]int
+	}{
+		{
+			desc:        "Nil item",
+			inputCounts: map[string]int{},
+			expected:    map[string]int{},
+		}, {
+			desc:        "Single leaf",
+			input:       &results.Item{Status: "foo"},
+			inputCounts: map[string]int{},
+			expected:    map[string]int{"foo": 1},
+		}, {
+			desc: "Multiple leafs",
+			input: &results.Item{
+				Status: "not-leaf-dont-count",
+				Items: []results.Item{
+					{Status: "foo"},
+					{Status: "foo"},
+					{Status: "bar"},
+				},
+			},
+			inputCounts: map[string]int{},
+			expected:    map[string]int{"foo": 2, "bar": 1},
+		}, {
+			desc: "Multiple leafs, varying depth",
+			input: &results.Item{
+				Status: "not-leaf-dont-count",
+				Items: []results.Item{
+					{Status: "foo"},
+					{Status: "foo"},
+					{
+						Status: "also-not-leaf",
+						Items: []results.Item{
+							{Status: "foo"},
+							{Status: "bar"},
+						},
+					},
+				},
+			},
+			inputCounts: map[string]int{},
+			expected:    map[string]int{"foo": 3, "bar": 1},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			statusCounts(tc.input, tc.inputCounts)
+			if diff := pretty.Compare(tc.expected, tc.inputCounts); diff != "" {
+				t.Fatalf("\n\n%s\n", diff)
+			}
+		})
 	}
 }

--- a/pkg/plugin/aggregation/status.go
+++ b/pkg/plugin/aggregation/status.go
@@ -19,6 +19,7 @@ package aggregation
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
@@ -45,6 +46,9 @@ type PluginStatus struct {
 	Plugin string `json:"plugin"`
 	Node   string `json:"node"`
 	Status string `json:"status"`
+
+	ResultStatus       string         `json:"result-status"`
+	ResultStatusCounts map[string]int `json:"result-counts"`
 }
 
 // Status represents the current status of a Sonobuoy run.
@@ -52,6 +56,16 @@ type PluginStatus struct {
 type Status struct {
 	Plugins []PluginStatus `json:"plugins"`
 	Status  string         `json:"status"`
+	Tarball TarInfo        `json:"tar-info,omitempty"`
+}
+
+// TarInfo is the type that contains information regarding the tarball
+// that a user would get after running `sonobuoy retrieve`.
+type TarInfo struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created"`
+	SHA256    string    `json:"sha256"`
+	Size      int64     `json:"size"`
 }
 
 func (s *Status) updateStatus() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #819 

**Special notes for your reviewer**:
Example output as of now:
```
"sonobuoy.hept.io/status": "{\"plugins\":[{\"plugin\":\"e2e\",\"node\":\"global\",\"status\":\"complete\",\"result-status\":\"passed\",\"result-counts\":{\"passed\":1,\"skipped\":3584}},{\"plugin\":\"systemd-logs\",\"node\":\"kind-control-plane\",\"status\":\"complete\",\"result-status\":\"passed\",\"result-counts\":{\"passed\":1}}],\"status\":\"complete\",\"tar-info\":{\"name\":\"201908081539_sonobuoy_e3a5f742-7cb2-490e-b0ee-91c6e2c8decb.tar.gz\",\"created\":\"2019-08-08T15:39:45.1724467Z\",\"sha256\":\"bbf3d5e43fe26e101d6c10b0a829ce94e6b2954366a46775172c0696793ce20b\",\"size\":601067}}"
```

TODO:
 - [x] Update the `status` command to show some of this info
 - [ ] Clean up the code and ensure someone using this as a library can easily gather this information.
 - [x] Main piece of code that needs a test is the code that checks all the leaf nodes' status.
 - [x] TBD: Should I also _always_ add a `total` field to the result counts? It would make it so people dont have to add them, but it also is a special case that wouldn't really be a count of a particular status so I'm not sure it is a great idea.

**Release note**:
```release-note
Added plugin results (based on post-processing results) to the PluginStatus object: both the overall status and the count of all the individual test results. In addition, the Status object itself (which wraps all the PluginStatus objects) has added information on the tarball name, size, and SHA256.
```
