### PR TITLE
Sync master/root README.md and provide a script to do this

### DIFF
--- a/scripts/sync_readme.sh
+++ b/scripts/sync_readme.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+
+SCRIPTS_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+DIR=$(cd $SCRIPTS_DIR; cd ..; pwd)
+ROOT_README=$DIR/README.md
+MASTER_SITE_README=$DIR/site/docs/master/README.md
+
+# Users should update the README.md in the root of the repo and
+# run this script to sync the README.md in the master docs. The reason
+# the root version is taken as the source of truth is because it is more
+# simple to remove prefixes from URLs and paths than to figure out
+# where to add them.
+
+# Following translations occur:
+#  - use relative path to images
+#  - use relative path to other pages (e.g. foo instead of sonobuoy.io/docs/foo)
+#  - link to master docs instead of "docs" (which will go to the latest tagged version)
+sed 's/img src="site\/docs\/master\/img/img src="img/' $ROOT_README |
+sed 's/https:\/\/sonobuoy.io\/docs\///' |
+sed 's/sonobuoy.io\/docs/sonobuoy.io\/docs\/master/' > $MASTER_SITE_README

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -153,7 +153,7 @@ See [the list of releases][releases] to find out about feature changes.
 [contrib]: https://github.com/heptio/sonobuoy/blob/master/CONTRIBUTING.md
 [conformance]: conformance-testing
 [docker]: https://docs.docker.com/install
-[docs]: https://sonobuoy.io/docs/master/
+[docs]: https://sonobuoy.io/docs/master
 [e2e]: conformance-testing
 [gen]: gen
 [gimme]: https://github.com/travis-ci/gimme
@@ -169,4 +169,3 @@ See [the list of releases][releases] to find out about feature changes.
 [sonobuoyconfig]: sonobuoy-config
 [status]: https://travis-ci.org/heptio/sonobuoy.svg?branch=master
 [travis]: https://travis-ci.org/heptio/sonobuoy/#
-[wait]: wait

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -12,6 +12,14 @@ if [ -n "$git_status" ]; then
     exit 1
 fi
 
+./scripts/sync_readme.sh
+git_status=$(git status -s)
+if [ -n "$git_status" ]; then
+    echo $git_status
+    echo "scripts/sync_readme.sh modified the git status. If updating the README.md, update the root README.md and run that script."
+    exit 1
+fi
+
 make container deploy_kind
 
 echo "|---- Creating new Sonobuoy run/waiting for results..."


### PR DESCRIPTION
**What this PR does / why we need it**:
The README for the master version of the docs and in the root
of the repo (used by Github) should always be in sync but
require minor changes due to different relative locations of
resources and links.

Also added this script as part of our CI to ensure that the two
files don't drift.

**Which issue(s) this PR fixes**
Fixes #772

**Special notes for your reviewer**:
Also found that there was drift; the master docs had a link to the page about `wait` functionality, but the root readme did not. The link wasn't actually used/needed so I removed it.

**Release note**:
```
NONE
```
