### PR TITLE
Use gcloud auth instead of docker-credential-gcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,6 @@ LINUX_ARCH := amd64 arm64
 DOCKERFILE :=
 PLATFORMS := $(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
 
-# SECRET is used when pushing the manifest. docker-credential-gcr may not be
-# available locally (except in Jenkins) so delay the evaluation unless the secret
-# is needed.
-SECRET = $(shell echo "https://gcr.io" | docker-credential-gcr get | jq '.Secret')
-
 # Not used for pushing images, just for local building on other GOOS. Defaults to
 # grabbing from the local go env but can be set manually to avoid that requirement.
 HOST_GOOS ?= $(shell go env GOOS)
@@ -152,7 +147,7 @@ push_images:
 	fi
 
 push_manifest:
-	./manifest-tool --username oauth2accesstoken --password $(SECRET) push from-args --platforms $(PLATFORMS) --template $(REGISTRY)/$(TARGET)-ARCH:$(VERSION) --target $(REGISTRY)/$(TARGET):$(VERSION)
+	./manifest-tool --username oauth2accesstoken --password "`gcloud auth print-access-token`" push from-args --platforms $(PLATFORMS) --template $(REGISTRY)/$(TARGET)-ARCH:$(VERSION) --target $(REGISTRY)/$(TARGET):$(VERSION)
 
 push: pre container
 	for arch in $(LINUX_ARCH); do \


### PR DESCRIPTION
**What this PR does / why we need it**:
We used docker-credential-gcr only once we moved to Jenkins and
it was available on the agents already. This change moves back
to using gcloud auth like it was when we originally published
images via Travis.

**Which issue(s) this PR fixes**
Related to #808 

**Special notes for your reviewer**:
Unable to test this on non-master branches since creds are protected. Will have to merge and iterate.

**Release note**:
```
NONE
```
