### PR TITLE
Add ability to override pod spec options

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -263,6 +263,15 @@ func AddTimeoutFlag(flag *int, flags *pflag.FlagSet) {
 	)
 }
 
+// AddShowDefaultPodSpecFlag adds an bool flag for determining whether or not to include the default pod spec
+// used by Sonobuoy in the output
+func AddShowDefaultPodSpecFlag(flag *bool, flags *pflag.FlagSet) {
+	flags.BoolVar(
+		flag, "show-default-podspec", false,
+		"If true, include the default pod spec used for plugins in the output",
+	)
+}
+
 // AddWaitOutputFlag adds a flag for spinner when wait flag is set for Sonobuoy operations.
 func AddWaitOutputFlag(mode *WaitOutputMode, flags *pflag.FlagSet, defaultMode WaitOutputMode) {
 	*mode = defaultMode

--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -46,6 +46,7 @@ type genFlags struct {
 	imagePullPolicy             ImagePullPolicy
 	e2eRepoList                 string
 	timeoutSeconds              int
+	showDefaultPodSpec          bool
 
 	// plugins will keep a list of the plugins we want. Custom type for
 	// flag support.
@@ -74,6 +75,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	AddRBACModeFlags(&cfg.rbacMode, genset, rbac)
 	AddImagePullPolicyFlag(&cfg.imagePullPolicy, genset)
 	AddTimeoutFlag(&cfg.timeoutSeconds, genset)
+	AddShowDefaultPodSpecFlag(&cfg.showDefaultPodSpec, genset)
 
 	AddNamespaceFlag(&cfg.namespace, genset)
 	AddSonobuoyImage(&cfg.sonobuoyImage, genset)
@@ -149,6 +151,7 @@ func (g *genFlags) Config() (*client.GenConfig, error) {
 		DynamicPlugins:       g.plugins.DynamicPlugins,
 		StaticPlugins:        g.plugins.StaticPlugins,
 		PluginEnvOverrides:   g.pluginEnvs,
+		ShowDefaultPodSpec:   g.showDefaultPodSpec,
 	}, nil
 }
 

--- a/cmd/sonobuoy/app/gen_plugin_def_test.go
+++ b/cmd/sonobuoy/app/gen_plugin_def_test.go
@@ -89,6 +89,18 @@ func TestPluginGenDef(t *testing.T) {
 				env: map[string]string{"FOO": "- bar"},
 			},
 			expectFile: "testdata/pluginDef-quotes.golden",
+		}, {
+			desc: "default PodSpec is included if requested",
+			cfg: GenPluginDefConfig{
+				showDefaultPodSpec: true,
+				def: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{
+						PluginName: "n",
+					},
+					Spec: manifest.Container{},
+				},
+			},
+			expectFile: "testdata/pluginDef-default-podspec.golden",
 		},
 	}
 	for _, tC := range testCases {

--- a/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
@@ -1,0 +1,17 @@
+podSpec:
+  containers: []
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+sonobuoy-config:
+  driver: ""
+  plugin-name: "n"
+  result-type: "n"
+spec:
+  name: ""
+  resources: {}

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/heptio/sonobuoy/pkg/config"
 	"github.com/heptio/sonobuoy/pkg/plugin"
+	"github.com/heptio/sonobuoy/pkg/plugin/driver"
 	"github.com/heptio/sonobuoy/pkg/plugin/manifest"
 	"github.com/heptio/sonobuoy/pkg/templates"
 
@@ -159,6 +160,11 @@ func (*SonobuoyClient) GenerateManifest(cfg *GenConfig) ([]byte, error) {
 
 	pluginYAML := []string{}
 	for _, v := range plugins {
+		if cfg.ShowDefaultPodSpec && v.PodSpec == nil {
+			v.PodSpec = &manifest.PodSpec{
+				PodSpec: driver.DefaultPodSpec(v.SonobuoyConfig.Driver),
+			}
+		}
 		yaml, err := kuberuntime.Encode(manifest.Encoder, v)
 		if err != nil {
 			return nil, errors.Wrapf(err, "serializing plugin %v as YAML", v.SonobuoyConfig.PluginName)

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -325,6 +325,26 @@ func TestGenerateManifestGolden(t *testing.T) {
 				},
 			},
 			expectErr: "failed to override env vars for plugin e2e2, no plugin with that name found; have plugins: [e2e]",
+		}, {
+			name: "Default pod spec is included if requested and no other pod spec provided",
+			inputcm: &client.GenConfig{
+				E2EConfig:          &client.E2EConfig{},
+				ShowDefaultPodSpec: true,
+			},
+			goldenFile: filepath.Join("testdata", "default-pod-spec.golden"),
+		}, {
+			name: "Existing pod spec is not modified if default pod spec is requested",
+			inputcm: &client.GenConfig{
+				E2EConfig:          &client.E2EConfig{},
+				ShowDefaultPodSpec: true,
+				StaticPlugins: []*manifest.Manifest{
+					{
+						SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "a"},
+						PodSpec:        &manifest.PodSpec{},
+					},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "use-existing-pod-spec.golden"),
 		},
 	}
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -78,6 +78,10 @@ type GenConfig struct {
 	// out of band from the plugins because of how the dynamic plugins are not
 	// yet able to be manipulated in this way.
 	PluginEnvOverrides map[string]map[string]string
+
+	// ShowDefaultPodSpec determines whether or not the default pod spec for
+	// the plugin should be incuded in the output.
+	ShowDefaultPodSpec bool
 }
 
 // Validate checks the config to determine if it is valid.

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -1,0 +1,164 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":null,"FieldSelectors":null,"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    podSpec:
+      containers: []
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-format: junit
+      result-type: e2e
+    spec:
+      command:
+      - /run_e2e.sh
+      env:
+      - name: E2E_FOCUS
+      - name: E2E_SKIP
+      - name: E2E_PARALLEL
+      name: e2e
+      resources: {}
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+  plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-format: raw
+      result-type: systemd-logs
+    spec:
+      command:
+      - /bin/sh
+      - -c
+      - /get_systemd_logs.sh && sleep 3600
+      env:
+      - name: CHROOT_DIR
+        value: /node
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      image: gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest
+      name: systemd-logs
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+      - mountPath: /node
+        name: root
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -1,0 +1,103 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: 
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"","UUID":"","Version":"","ResultsDir":"","Resources":null,"Filters":{"Namespaces":"","LabelSelector":""},"Limits":{"PodLogs":{"Namespaces":"","SonobuoyNamespace":null,"FieldSelectors":null,"LabelSelector":"","Previous":false,"SinceSeconds":null,"SinceTime":null,"Timestamps":false,"TailLines":null,"LimitBytes":null,"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"","bindport":0,"advertiseaddress":"","timeoutseconds":0},"Plugins":null,"PluginSearchPath":null,"Namespace":"","WorkerImage":"","ImagePullPolicy":"","ImagePullSecrets":""}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: 
+---
+apiVersion: v1
+data:
+  plugin-0.yaml: |
+    podSpec:
+      containers: null
+    sonobuoy-config:
+      driver: ""
+      plugin-name: a
+      result-type: ""
+    spec:
+      name: ""
+      resources: {}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: 
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: 
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: 
+    imagePullPolicy: 
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: 
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/pkg/plugin/manifest/manifest.go
+++ b/pkg/plugin/manifest/manifest.go
@@ -67,6 +67,7 @@ type Manifest struct {
 	SonobuoyConfig SonobuoyConfig `json:"sonobuoy-config"`
 	Spec           Container      `json:"spec"`
 	ExtraVolumes   []Volume       `json:"extra-volumes,omitempty"`
+	PodSpec        *PodSpec       `json:"podSpec,omitempty"`
 	objectKind
 }
 
@@ -75,6 +76,7 @@ func (m *Manifest) DeepCopyObject() kuberuntime.Object {
 	return &Manifest{
 		SonobuoyConfig: *m.SonobuoyConfig.DeepCopy(),
 		Spec:           *m.Spec.DeepCopy(),
+		PodSpec:        m.PodSpec.DeepCopy(),
 		objectKind:     objectKind{m.gvk},
 	}
 }
@@ -121,3 +123,23 @@ func (v *Volume) DeepCopyObject() kuberuntime.Object { return v.DeepCopy() }
 
 // GetObjectKind returns the underlying objectKind, needed for runtime.Object
 func (v *Volume) GetObjectKind() schema.ObjectKind { return v }
+
+// PodSpec is a thin wrapper around coreV1.PodSpec that supplies DeepCopyObject and GetObjectKind
+type PodSpec struct {
+	corev1.PodSpec
+	objectKind
+}
+
+// DeepCopy wraps PodSpec.DeepCopy, copying the objectKind as well.
+func (ps *PodSpec) DeepCopy() *PodSpec {
+	return &PodSpec{
+		PodSpec:    *ps.PodSpec.DeepCopy(),
+		objectKind: objectKind{ps.gvk},
+	}
+}
+
+// DeepCopyObject is just DeepCopy, needed for runtime.Object
+func (ps *PodSpec) DeepCopyObject() kuberuntime.Object { return ps.DeepCopy() }
+
+// GetObjectKind returns the underlying objectKind, needed for runtime.Object
+func (ps *PodSpec) GetObjectKind() schema.ObjectKind { return ps }

--- a/pkg/plugin/manifest/serializer.go
+++ b/pkg/plugin/manifest/serializer.go
@@ -31,6 +31,7 @@ const (
 	kindContainer string = "container"
 	kindVolume    string = "volume"
 	kindManifest  string = "manifest"
+	kindPodSpec   string = "podSpec"
 )
 
 // Encoder is a runtime.Encoder for Sonobuoy's manifest objects
@@ -48,6 +49,7 @@ func init() {
 		&Container{},
 		&Manifest{},
 		&Volume{},
+		&PodSpec{},
 	)
 	codecs := serializer.NewCodecFactory(schema)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This change introduces the ability to override PodSpec options for
plugins. A new flag `--show-default-podspec` has been added to the
`gen` and `gen plugin` commands. When used, Sonobuoy will include the
default PodSpec options for the given plugin driver in the resulting
yaml. This allows users to change these values or they can provide their
own. If one is provided in the plugin definition, Sonobuoy will use that
as is, otherwise it will use the default.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #809 

**Special notes for your reviewer**:


**Release note**:
```
Sonobuoy now includes the option to edit the PodSpec used when running plugins. Users can provide their own PodSpec or adapt the default one used by Sonobuoy. The default can be obtained using the '--show-default-podspec' flag with the 'gen' and 'gen plugin' commands.
```
