### PR TITLE
Ensure a plugin isn't reported as passed if no results were read

### DIFF
--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -86,8 +86,15 @@ func (i Item) Empty() bool {
 }
 
 // aggregateStatus defines the aggregation rules for status. Failures bubble
-// up and otherwise the status is assumed to pass.
+// up and otherwise the status is assumed to pass as long as there are >=1 result.
+// If 0 items are aggregated, StatusUnknown is returned.
 func aggregateStatus(items ...Item) string {
+	// Avoid the situation where we get 0 results (because the plugin partially failed to run)
+	// but we report it as passed.
+	if len(items) == 0 {
+		return StatusUnknown
+	}
+
 	for i := range items {
 		// Branches should just aggregate their leaves and return the result.
 		if len(items[i].Items) > 0 {
@@ -163,12 +170,10 @@ func processPluginWithProcessor(p plugin.Interface, baseDir string, processor po
 		if err != nil {
 			logrus.Warningf("Error processing results entries for plugin %v: %v", p.GetName(), err)
 		}
-		// I think logging is correct here, but then why return an error at all and we can't test those paths
-		// as easily...
 		results.Items = items
-		results.Status = aggregateStatus(results.Items...)
 	}
 
+	results.Status = aggregateStatus(results.Items...)
 	return results, nil
 }
 

--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -183,8 +183,8 @@ func TestAggregateStatus(t *testing.T) {
 		expectedItems []Item
 	}{
 		{
-			desc:     "Empty defaults to passed",
-			expected: StatusPassed,
+			desc:     "Empty defaults to unknown",
+			expected: StatusUnknown,
 		}, {
 			desc:          "Single pass passes",
 			input:         []Item{{Status: StatusPassed}},


### PR DESCRIPTION

**What this PR does / why we need it**:
In the case where the e2e plugin reported results (a tarball) but
it did not contain an xml file of junit results we want to be sure
to NOT count this as a success.

It may be reasonable to consider this a failure but I think it is
more generic/safe to just report it as unknown and users can
handle that case differently.

Also, I found another bug which was causing daemonsets to not
properly be bubbling up their results.

**Which issue(s) this PR fixes**
Fixes #840

**Special notes for your reviewer**:

**Release note**:
```
Fixes a bug which caused `sonobuoy results` to report success if no results were processed at all. Modified this case to return 'unknown' instead.
```
