### PR TITLE
Ensure we filter resources by namespace

### DIFF
--- a/pkg/discovery/queries.go
+++ b/pkg/discovery/queries.go
@@ -168,6 +168,10 @@ func QueryResources(
 		}
 	}
 
+	if ns != nil && len(*ns) > 0 {
+		opts.FieldSelector = "metadata.namespace=" + *ns
+	}
+
 	// 3. Execute the query
 	for _, gvr := range resources {
 		lister := func() (*unstructured.UnstructuredList, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This got removed in a recent PR but should not have.

When querying namespaced resources you need the field selector
set. This is not something that can easily be tested in unit tests
since that logic happens on the server-side and mocks would not
hit that code.

**Which issue(s) this PR fixes**
Fixes #839

**Special notes for your reviewer**:
Removed here: https://github.com/heptio/sonobuoy/commit/8380685d55c7f41c3b81cc26811315dfb0859650#diff-799ef0bfefbd18913fd0fa8a3679e9e0L170-L172

I'd like to have a think about how we want to test some of these things. We need them to be part of our integration suite: run sonobuoy against the kind cluster, inspect the results. I don't want it to be a long set of bash scripts though.

Probably, we will want to add another suite of go integration tests that just accept a parameter of where to look for results or expect sonobuoy to already be running in the cluster so it can grab the results and manipulate them as necessary.

**Release note**:
```
Fixed a bug which caused every namespaced query to return the objects in every namespace of that type.
```
