### PR TITLE
Modify some old docs to avoid liquid syntax warnings

### DIFF
--- a/site/docs/v0.13.0/enhancements/streamlined-templates.md
+++ b/site/docs/v0.13.0/enhancements/streamlined-templates.md
@@ -9,6 +9,7 @@ By way of illustration, here is the current `heptio-e2e` plugin file. Every part
 of user configuration is in green, all boilerplate required by Sonobuoy is in
 red.
 
+{% raw %}
 ```diff
 - ---
 - apiVersion: v1
@@ -67,6 +68,7 @@ red.
 -   - emptyDir: {}
 -     name: results
 ```
+{% endraw %}
 
 ## Summary
 
@@ -114,6 +116,7 @@ spec:
 This will be merged into a larger Pod document provided by the Sonobuoy YAML
 driver
 
+{% raw %}
 ```yaml
 ---
 apiVersion: v1
@@ -166,6 +169,7 @@ spec:
   - emptyDir: {}
    name: results
 ```
+{% endraw %}
 
 #### Advantages:
 * Simple substitution
@@ -179,6 +183,7 @@ spec:
 
 In this scenario, the user provides a (templated) valid Kubernetes API Document.
 
+{% raw %}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -199,6 +204,7 @@ spec:
   - {{.SonobuoyConsumer}}
   {{.SonobuySpecExtras}}
 ```
+{% endraw %}
 
 Then, at runtime, the template would be filled with values by the plugin driver.
 These could be based on several templates themselves, or created at runtime out

--- a/site/docs/v0.14.0/enhancements/streamlined-templates.md
+++ b/site/docs/v0.14.0/enhancements/streamlined-templates.md
@@ -9,6 +9,7 @@ By way of illustration, here is the current `heptio-e2e` plugin file. Every part
 of user configuration is in green, all boilerplate required by Sonobuoy is in
 red.
 
+{% raw %}
 ```diff
 - ---
 - apiVersion: v1
@@ -67,6 +68,7 @@ red.
 -   - emptyDir: {}
 -     name: results
 ```
+{% endraw %}
 
 ## Summary
 
@@ -114,6 +116,7 @@ spec:
 This will be merged into a larger Pod document provided by the Sonobuoy YAML
 driver
 
+{% raw %}
 ```yaml
 ---
 apiVersion: v1
@@ -166,6 +169,7 @@ spec:
   - emptyDir: {}
    name: results
 ```
+{% endraw %}
 
 #### Advantages:
 * Simple substitution
@@ -179,6 +183,7 @@ spec:
 
 In this scenario, the user provides a (templated) valid Kubernetes API Document.
 
+{% raw %}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -199,6 +204,7 @@ spec:
   - {{.SonobuoyConsumer}}
   {{.SonobuySpecExtras}}
 ```
+{% endraw %}
 
 Then, at runtime, the template would be filled with values by the plugin driver.
 These could be based on several templates themselves, or created at runtime out

--- a/site/docs/v0.14.1/enhancements/streamlined-templates.md
+++ b/site/docs/v0.14.1/enhancements/streamlined-templates.md
@@ -9,6 +9,7 @@ By way of illustration, here is the current `heptio-e2e` plugin file. Every part
 of user configuration is in green, all boilerplate required by Sonobuoy is in
 red.
 
+{% raw %}
 ```diff
 - ---
 - apiVersion: v1
@@ -67,6 +68,7 @@ red.
 -   - emptyDir: {}
 -     name: results
 ```
+{% endraw %}
 
 ## Summary
 
@@ -114,6 +116,7 @@ spec:
 This will be merged into a larger Pod document provided by the Sonobuoy YAML
 driver
 
+{% raw %}
 ```yaml
 ---
 apiVersion: v1
@@ -166,6 +169,7 @@ spec:
   - emptyDir: {}
    name: results
 ```
+{% endraw %}
 
 #### Advantages:
 * Simple substitution
@@ -179,6 +183,7 @@ spec:
 
 In this scenario, the user provides a (templated) valid Kubernetes API Document.
 
+{% raw %}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -199,6 +204,7 @@ spec:
   - {{.SonobuoyConsumer}}
   {{.SonobuySpecExtras}}
 ```
+{% endraw %}
 
 Then, at runtime, the template would be filled with values by the plugin driver.
 These could be based on several templates themselves, or created at runtime out

--- a/site/docs/v0.14.2/enhancements/streamlined-templates.md
+++ b/site/docs/v0.14.2/enhancements/streamlined-templates.md
@@ -9,6 +9,7 @@ By way of illustration, here is the current `heptio-e2e` plugin file. Every part
 of user configuration is in green, all boilerplate required by Sonobuoy is in
 red.
 
+{% raw %}
 ```diff
 - ---
 - apiVersion: v1
@@ -67,6 +68,7 @@ red.
 -   - emptyDir: {}
 -     name: results
 ```
+{% endraw %}
 
 ## Summary
 
@@ -114,6 +116,7 @@ spec:
 This will be merged into a larger Pod document provided by the Sonobuoy YAML
 driver
 
+{% raw %}
 ```yaml
 ---
 apiVersion: v1
@@ -166,6 +169,7 @@ spec:
   - emptyDir: {}
    name: results
 ```
+{% endraw %}
 
 #### Advantages:
 * Simple substitution
@@ -179,6 +183,7 @@ spec:
 
 In this scenario, the user provides a (templated) valid Kubernetes API Document.
 
+{% raw %}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -199,6 +204,7 @@ spec:
   - {{.SonobuoyConsumer}}
   {{.SonobuySpecExtras}}
 ```
+{% endraw %}
 
 Then, at runtime, the template would be filled with values by the plugin driver.
 These could be based on several templates themselves, or created at runtime out

--- a/site/docs/v0.14.3/enhancements/streamlined-templates.md
+++ b/site/docs/v0.14.3/enhancements/streamlined-templates.md
@@ -9,6 +9,7 @@ By way of illustration, here is the current `heptio-e2e` plugin file. Every part
 of user configuration is in green, all boilerplate required by Sonobuoy is in
 red.
 
+{% raw %}
 ```diff
 - ---
 - apiVersion: v1
@@ -67,6 +68,7 @@ red.
 -   - emptyDir: {}
 -     name: results
 ```
+{% endraw %}
 
 ## Summary
 
@@ -114,6 +116,7 @@ spec:
 This will be merged into a larger Pod document provided by the Sonobuoy YAML
 driver
 
+{% raw %}
 ```yaml
 ---
 apiVersion: v1
@@ -166,6 +169,7 @@ spec:
   - emptyDir: {}
    name: results
 ```
+{% endraw %}
 
 #### Advantages:
 * Simple substitution
@@ -179,6 +183,7 @@ spec:
 
 In this scenario, the user provides a (templated) valid Kubernetes API Document.
 
+{% raw %}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -199,6 +204,7 @@ spec:
   - {{.SonobuoyConsumer}}
   {{.SonobuySpecExtras}}
 ```
+{% endraw %}
 
 Then, at runtime, the template would be filled with values by the plugin driver.
 These could be based on several templates themselves, or created at runtime out

--- a/site/index.html
+++ b/site/index.html
@@ -72,7 +72,7 @@ secondary_ctas:
             <figure>
               <img src="{{ page.hero.promo1.icon }}" alt="{{ page.hero.promo1.title }}" />
             </figure>
-            {% if page.hero.promo1.url | size > 0 %}
+            {% if page.hero.promo1.url.size > 0 %}
             <h5><a href="{{ page.hero.promo1.url }}" class="dark">{{ page.hero.promo1.title }}</a></h5>
             {% else %}
             <h5>{{ page.hero.promo1.title }}</h5>
@@ -87,7 +87,7 @@ secondary_ctas:
             <figure>
               <img src="{{ page.hero.promo2.icon }}" alt="{{ page.hero.promo2.title }}" />
             </figure>
-            {% if page.hero.promo2.url | size > 0 %}
+            {% if page.hero.promo2.url.size > 0 %}
             <h5><a href="{{ page.hero.promo2.url }}" class="dark">{{ page.hero.promo2.title }}</a></h5>
             {% else %}
             <h5>{{ page.hero.promo2.title }}</h5>
@@ -102,7 +102,7 @@ secondary_ctas:
             <figure>
               <img src="{{ page.hero.promo3.icon }}" alt="{{ page.hero.promo3.title }}" />
             </figure>
-            {% if page.hero.promo3.url  | size > 0 %}
+            {% if page.hero.promo3.url.size > 0 %}
             <h5><a href="{{ page.hero.promo3.url }}" class="dark">{{ page.hero.promo3.title }}</a></h5>
             {% else %}
             <h5>{{ page.hero.promo3.title }}</h5>


### PR DESCRIPTION
**What this PR does / why we need it**:
Markdown docs that tried to show go template style code like
`{{ .Foo }}` would cause liquid syntax warnings in netlify.

We always just assumed they were warnings but it actually did fail
to parse those sections so those pages are rendered incorrectly.
That is not too serious since in general we dont link to those
but it causes it to be hard to see _real_ problems in the netlify
logs and also, if you go to the page manually, shows the wrong
data.

This resolves that issue by wrapping the sections in question with
tags to make it treat those sections as 'raw' data.

**Which issue(s) this PR fixes**
Fixes #775

**Special notes for your reviewer**:
https://github.com/Shopify/liquid/issues/927

**Release note**:
```
NONE
```
