### PR TITLE
Set OwnerReference on Plugin resources

### DIFF
--- a/pkg/client/retrieve.go
+++ b/pkg/client/retrieve.go
@@ -60,7 +60,7 @@ func (c *SonobuoyClient) RetrieveResults(cfg *RetrieveConfig) (io.Reader, <-chan
 	}
 
 	// Determine sonobuoy pod name
-	podName, err := pluginaggregation.GetStatusPodName(client, cfg.Namespace)
+	podName, err := pluginaggregation.GetAggregatorPodName(client, cfg.Namespace)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get the name of the aggregator pod to fetch results from")
 	}

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -358,7 +358,7 @@ func setStatus(client kubernetes.Interface, namespace string, status *pluginaggr
 	}
 
 	// Determine sonobuoy pod name
-	podName, err := pluginaggregation.GetStatusPodName(client, namespace)
+	podName, err := pluginaggregation.GetAggregatorPodName(client, namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the name of the aggregator pod to set the status on")
 	}

--- a/pkg/plugin/aggregation/run_test.go
+++ b/pkg/plugin/aggregation/run_test.go
@@ -153,7 +153,7 @@ func TestRunAndMonitorPlugin(t *testing.T) {
 			}
 
 			go func() {
-				a.RunAndMonitorPlugin(ctx, tc.plugin, fclient, nil, "testname", testCert)
+				a.RunAndMonitorPlugin(ctx, tc.plugin, fclient, nil, "testname", testCert, &corev1.Pod{})
 				doneCh <- struct{}{}
 			}()
 
@@ -207,7 +207,7 @@ type MockCleanupPlugin struct {
 	cleanedUp   bool
 }
 
-func (cp *MockCleanupPlugin) Run(_ kubernetes.Interface, _ string, _ *tls.Certificate) error {
+func (cp *MockCleanupPlugin) Run(_ kubernetes.Interface, _ string, _ *tls.Certificate, _ *corev1.Pod) error {
 	return nil
 }
 

--- a/pkg/plugin/aggregation/status.go
+++ b/pkg/plugin/aggregation/status.go
@@ -97,7 +97,7 @@ func GetStatus(client kubernetes.Interface, namespace string) (*Status, error) {
 	}
 
 	// Determine sonobuoy pod name
-	podName, err := GetStatusPodName(client, namespace)
+	podName, err := GetAggregatorPodName(client, namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get the name of the aggregator pod to get the status from")
 	}

--- a/pkg/plugin/aggregation/update_test.go
+++ b/pkg/plugin/aggregation/update_test.go
@@ -55,7 +55,102 @@ func TestCreateUpdater(t *testing.T) {
 	}
 }
 
-func TestGetStatusPodName(t *testing.T) {
+func TestGetAggregatorPod(t *testing.T) {
+	createPodWithRunLabel := func(name string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"run": "sonobuoy-master"},
+			},
+		}
+	}
+
+	testPods := []corev1.Pod{
+		createPodWithRunLabel("sonobuoy-run-pod-1"),
+		createPodWithRunLabel("sonobuoy-run-pod-2"),
+	}
+
+	checkNoError := func(err error) error {
+		if err != nil {
+			return errors.Wrap(err, "expected no error")
+		}
+		return nil
+	}
+
+	checkErrorFromServer := func(err error) error {
+		if err == nil {
+			return errors.New("expected error but got nil")
+		}
+		return nil
+	}
+
+	checkNoPodWithLabelError := func(err error) error {
+		if _, ok := err.(NoPodWithLabelError); !ok {
+			return errors.Wrap(err, "expected error to have type NoPodWithLabelError")
+		}
+		return nil
+	}
+
+	testCases := []struct {
+		desc          string
+		podsOnServer  corev1.PodList
+		errFromServer error
+		checkError    func(err error) error
+		expectedPod   *corev1.Pod
+	}{
+		{
+			desc:          "Error retrieving pods from server results in no pod and an error being returned",
+			podsOnServer:  corev1.PodList{},
+			errFromServer: errors.New("could not retrieve pods"),
+			checkError:    checkErrorFromServer,
+			expectedPod:   nil,
+		},
+		{
+			desc:         "No pods results in no pod and no error",
+			podsOnServer: corev1.PodList{},
+			checkError:   checkNoPodWithLabelError,
+			expectedPod:  nil,
+		},
+		{
+			desc:         "Only one pod results in that pod being returned",
+			podsOnServer: corev1.PodList{Items: []corev1.Pod{testPods[0]}},
+			checkError:   checkNoError,
+			expectedPod:  &testPods[0],
+		},
+		{
+			desc:         "More that one pod results in the first pod being returned",
+			podsOnServer: corev1.PodList{Items: testPods},
+			checkError:   checkNoError,
+			expectedPod:  &testPods[0],
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fclient := fake.NewSimpleClientset()
+			fclient.PrependReactor("*", "*", func(action k8stesting.Action) (handled bool, ret kuberuntime.Object, err error) {
+				return true, &tc.podsOnServer, tc.errFromServer
+			})
+
+			pod, err := GetAggregatorPod(fclient, "sonobuoy")
+			if checkErr := tc.checkError(err); checkErr != nil {
+				t.Errorf("error check failed: %v", checkErr)
+			}
+			if tc.expectedPod == nil {
+				if pod != nil {
+					t.Errorf("Expected no pod to be found but found pod %q", pod.GetName())
+				}
+			} else {
+				if pod.GetName() != tc.expectedPod.GetName() {
+					t.Errorf("Incorrect pod returned, expected %q but got %q", tc.expectedPod.GetName(), pod.GetName())
+				}
+			}
+
+		})
+	}
+}
+
+func TestGetAggregatorPodName(t *testing.T) {
 	createPodWithRunLabel := func(name string) corev1.Pod {
 		return corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -84,7 +179,7 @@ func TestGetStatusPodName(t *testing.T) {
 			expectedPodName: "sonobuoy",
 		},
 		{
-			desc: "Only one pod results in that pod name being used",
+			desc: "A returned pod results in that pod name being used",
 			podsOnServer: corev1.PodList{
 				Items: []corev1.Pod{
 					createPodWithRunLabel("sonobuoy-run-pod"),
@@ -92,17 +187,6 @@ func TestGetStatusPodName(t *testing.T) {
 			},
 			errFromServer:   nil,
 			expectedPodName: "sonobuoy-run-pod",
-		},
-		{
-			desc: "More that one pod results in the first pod name being used",
-			podsOnServer: corev1.PodList{
-				Items: []corev1.Pod{
-					createPodWithRunLabel("sonobuoy-run-pod-1"),
-					createPodWithRunLabel("sonobuoy-run-pod-2"),
-				},
-			},
-			errFromServer:   nil,
-			expectedPodName: "sonobuoy-run-pod-1",
 		},
 	}
 
@@ -113,7 +197,7 @@ func TestGetStatusPodName(t *testing.T) {
 				return true, &tc.podsOnServer, tc.errFromServer
 			})
 
-			podName, err := GetStatusPodName(fclient, "sonobuoy")
+			podName, err := GetAggregatorPodName(fclient, "sonobuoy")
 			if tc.errFromServer == nil && err != nil {
 				t.Errorf("Unexpected error returned, expected nil but got %q", err)
 			}

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -38,7 +38,7 @@ const (
 type Interface interface {
 	// Run runs a plugin, declaring all resources it needs, and then
 	// returns.  It does not block and wait until the plugin has finished.
-	Run(kubeClient kubernetes.Interface, hostname string, cert *tls.Certificate) error
+	Run(kubeClient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod) error
 	// Cleanup cleans up all resources created by the plugin
 	Cleanup(kubeClient kubernetes.Interface)
 	// Monitor continually checks for problems in the resources created by a


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating Pod or DaemonSet resources when running plugins, we didn't
mark them as owned by the Sonobuoy aggregator pod. This meant that if
the aggregator pod was deleted, the resources created by that pod would
be orphaned and would have to be deleted manually. This change sets the
OwnerReference for all resources to be the Sonobuoy aggregator pod so
that when the aggregator is deleted, all child resources are also
deleted.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #818 

**Release note**:
```
Sonobuoy now sets the `OwnerReference` on all Pod and DaemonSet resources that are created when running plugins. This means that if the main aggregator pod is deleted, all resources created by that pod will also be deleted.
```
