### PR TITLE
Easy diff golden files

### DIFF
--- a/pkg/client/results/processing_test.go
+++ b/pkg/client/results/processing_test.go
@@ -147,7 +147,7 @@ func TestPostProcessPlugin(t *testing.T) {
 			}
 			if *update {
 				// Update all the golden files instead of actually testing against them.
-				itemBytes, err := json.Marshal(item)
+				itemBytes, err := json.MarshalIndent(item, "", "")
 				if err != nil {
 					t.Fatalf("Failed to marshal item: %v", err)
 				}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-01/ds-junit-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-01/ds-junit-01.golden.json
@@ -1,1 +1,41 @@
-{"name":"ds-junit-01","status":"passed","items":[{"name":"global","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}]}
+{
+"name": "ds-junit-01",
+"status": "passed",
+"items": [
+{
+"name": "global",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-02/ds-junit-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-02/ds-junit-02.golden.json
@@ -1,1 +1,70 @@
-{"name":"ds-junit-02","status":"failed","items":[{"name":"global","status":"failed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]},{"name":"output2.xml","status":"failed","meta":{"file":"results/global/output2.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]","status":"failed","details":{"failure":"/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385","system-out":"[BeforeEach] ..."}},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}]}
+{
+"name": "ds-junit-02",
+"status": "failed",
+"items": [
+{
+"name": "global",
+"status": "failed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+},
+{
+"name": "output2.xml",
+"status": "failed",
+"meta": {
+"file": "results/global/output2.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]",
+"status": "failed",
+"details": {
+"failure": "/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385",
+"system-out": "[BeforeEach] ..."
+}
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-junit-03/ds-junit-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-junit-03/ds-junit-03.golden.json
@@ -1,1 +1,70 @@
-{"name":"ds-junit-03","status":"failed","items":[{"name":"global","status":"failed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]},{"name":"output2.xml","status":"failed","meta":{"file":"results/global/output2.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]","status":"failed","details":{"failure":"/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385","system-out":"[BeforeEach] ..."}},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}]}
+{
+"name": "ds-junit-03",
+"status": "failed",
+"items": [
+{
+"name": "global",
+"status": "failed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+},
+{
+"name": "output2.xml",
+"status": "failed",
+"meta": {
+"file": "results/global/output2.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]",
+"status": "failed",
+"details": {
+"failure": "/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385",
+"system-out": "[BeforeEach] ..."
+}
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-01/ds-raw-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-01/ds-raw-01.golden.json
@@ -1,1 +1,19 @@
-{"name":"ds-raw-01","status":"passed","items":[{"name":"global","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}}]}]}
+{
+"name": "ds-raw-01",
+"status": "passed",
+"items": [
+{
+"name": "global",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-02/ds-raw-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-02/ds-raw-02.golden.json
@@ -1,1 +1,26 @@
-{"name":"ds-raw-02","status":"passed","items":[{"name":"global","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}]}
+{
+"name": "ds-raw-02",
+"status": "passed",
+"items": [
+{
+"name": "global",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+},
+{
+"name": "output2.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output2.xml"
+}
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/ds-raw-03/ds-raw-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/ds-raw-03/ds-raw-03.golden.json
@@ -1,1 +1,26 @@
-{"name":"ds-raw-03","status":"passed","items":[{"name":"global","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}]}
+{
+"name": "ds-raw-03",
+"status": "passed",
+"items": [
+{
+"name": "global",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+},
+{
+"name": "output2.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output2.xml"
+}
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-01/job-default-01.golden.json
@@ -1,1 +1,13 @@
-{"name":"job-default-01","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}}]}
+{
+"name": "job-default-01",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-default-02/job-default-02.golden.json
@@ -1,1 +1,20 @@
-{"name":"job-default-02","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}
+{
+"name": "job-default-02",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+},
+{
+"name": "output2.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output2.xml"
+}
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-01/job-junit-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-01/job-junit-01.golden.json
@@ -1,1 +1,35 @@
-{"name":"job-junit-01","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}
+{
+"name": "job-junit-01",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-02/job-junit-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-02/job-junit-02.golden.json
@@ -1,1 +1,64 @@
-{"name":"job-junit-02","status":"failed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]},{"name":"output2.xml","status":"failed","meta":{"file":"results/global/output2.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]","status":"failed","details":{"failure":"/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385","system-out":"[BeforeEach] ..."}},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}
+{
+"name": "job-junit-02",
+"status": "failed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+},
+{
+"name": "output2.xml",
+"status": "failed",
+"meta": {
+"file": "results/global/output2.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]",
+"status": "failed",
+"details": {
+"failure": "/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385",
+"system-out": "[BeforeEach] ..."
+}
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-junit-03/job-junit-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-junit-03/job-junit-03.golden.json
@@ -1,1 +1,64 @@
-{"name":"job-junit-03","status":"failed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]","status":"passed"},{"name":"[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]},{"name":"output2.xml","status":"failed","meta":{"file":"results/global/output2.xml"},"items":[{"name":"[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]","status":"passed"},{"name":"[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]","status":"failed","details":{"failure":"/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385","system-out":"[BeforeEach] ..."}},{"name":"[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource","status":"skipped"},{"name":"[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]","status":"skipped"}]}]}
+{
+"name": "job-junit-03",
+"status": "failed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-node] ConfigMap should fail to create ConfigMap with empty key [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] Downward API volume should set DefaultMode on files [LinuxOnly] [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+},
+{
+"name": "output2.xml",
+"status": "failed",
+"meta": {
+"file": "results/global/output2.xml"
+},
+"items": [
+{
+"name": "[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]",
+"status": "passed"
+},
+{
+"name": "[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]",
+"status": "failed",
+"details": {
+"failure": "/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696\nConformance test suite needs a cluster with at least 2 nodes.\nExpected\n    \u003cint\u003e: 1\nto be \u003e\n    \u003cint\u003e: 1\n/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:385",
+"system-out": "[BeforeEach] ..."
+}
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Dynamic PV (default fs)] subPath should support existing directories when readOnly specified in the volumeSource",
+"status": "skipped"
+},
+{
+"name": "[sig-storage] In-tree Volumes [Driver: rbd][Feature:Volumes] [Testpattern: Pre-provisioned PV (default fs)] subPath should support restarting containers using file as subpath [Slow]",
+"status": "skipped"
+}
+]
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-01/job-raw-01.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-01/job-raw-01.golden.json
@@ -1,1 +1,13 @@
-{"name":"job-raw-01","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}}]}
+{
+"name": "job-raw-01",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-02/job-raw-02.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-02/job-raw-02.golden.json
@@ -1,1 +1,20 @@
-{"name":"job-raw-02","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}
+{
+"name": "job-raw-02",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+},
+{
+"name": "output2.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output2.xml"
+}
+}
+]
+}

--- a/pkg/client/results/testdata/mockResults/plugins/job-raw-03/job-raw-03.golden.json
+++ b/pkg/client/results/testdata/mockResults/plugins/job-raw-03/job-raw-03.golden.json
@@ -1,1 +1,20 @@
-{"name":"job-raw-03","status":"passed","items":[{"name":"output.xml","status":"passed","meta":{"file":"results/global/output.xml"}},{"name":"output2.xml","status":"passed","meta":{"file":"results/global/output2.xml"}}]}
+{
+"name": "job-raw-03",
+"status": "passed",
+"items": [
+{
+"name": "output.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output.xml"
+}
+},
+{
+"name": "output2.xml",
+"status": "passed",
+"meta": {
+"file": "results/global/output2.xml"
+}
+}
+]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For large JSON objects stored as goldenfiles, identifying
changes is difficult when it is one large line due to the
fact that a single character change shows the entire object
as the 1 line diff.

This change makes those tests use MarshalIndent so the lines
are split up and sets the indent to 0 so that if we change the
nesting, the changes don't cascade to the rest of the file
simply due to indentation changes (which dont change the
object once unmarshalled).

**Which issue(s) this PR fixes**
Fixes #855 

**Special notes for your reviewer**:
Only the first commit is going to be merged; when you give me the 👍 I'll remove the second commit. The second commit is just to show what diffs in the future would look like. In those cases, I wrapped every test result item within another, new Item obejct.

**Release note**:
```
NONE
```
