### PR TITLE
Bubble up unknown results just like failures

### DIFF
--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -97,6 +97,7 @@ func aggregateStatus(items ...Item) string {
 		return StatusUnknown
 	}
 
+	unknownFound := false
 	for i := range items {
 		// Branches should just aggregate their leaves and return the result.
 		if len(items[i].Items) > 0 {
@@ -107,6 +108,14 @@ func aggregateStatus(items ...Item) string {
 		if items[i].Status == StatusFailed {
 			return StatusFailed
 		}
+
+		if items[i].Status == StatusUnknown {
+			unknownFound = true
+		}
+	}
+
+	if unknownFound {
+		return StatusUnknown
 	}
 
 	// Only pass if no failures found.


### PR DESCRIPTION
When doing post processing if a plugin (or file) results
in an 'unknown' status, it should bubble up according
to the following rules:
 - if any failures exist, failure bubbles up
 - if any unknowns exist (and no failures), unknown bubbles up
 - pass otherwise

Fixes #848

**Release note**:
```
When looking at the results of plugins, Sonobuoy will now bubble up unknown values. If one result is unknown and others pass, the aggregate is unknown. If one result is unknown and any others failure, the aggregate result is still failure.
```
