### PR TITLE
Adjust MASTER_URL to be just the hostname

### DIFF
--- a/pkg/plugin/aggregation/handler.go
+++ b/pkg/plugin/aggregation/handler.go
@@ -32,10 +32,19 @@ const (
 	// have an /api/v2 later we'll figure out a good strategy for splitting up the
 	// handling.
 
+	// PathResultsByNode is the path for node-specific results to be PUT to. Callers should
+	// add two path elements as a suffix to this to specify the node and plugin (e.g. `<path>/node/plugin`)
+	PathResultsByNode = "/api/v1/results/by-node"
+
+	// PathResultsGlobal is the path for global (non-node-specific) results to be PUT to. Callers should
+	// add one path elements as a suffix to this to specify the plugin name (e.g. `<path>/plugin`)
+	PathResultsGlobal = "/api/v1/results/global"
+
 	// resultsGlobal is the path for node-specific results to be PUT
-	resultsByNode = "/api/v1/results/by-node/{node}/{plugin}"
-	// resultsGlobal is the path for global (non node-specific) results to be PUT
-	resultsGlobal = "/api/v1/results/global/{plugin}"
+	resultsByNode = PathResultsByNode + "/{node}/{plugin}"
+
+	// resultsGlobal is the path for global (non-node-specific) results to be PUT
+	resultsGlobal = PathResultsGlobal + "/{plugin}"
 
 	// defaultFilename is the name given to the file if no filename is given in the
 	// content-disposition header

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -190,6 +190,7 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate) []v1.En
 			},
 		},
 	}
+
 	return envVars
 }
 

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -81,10 +81,6 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	return ret
 }
 
-func getAggregatorAddress(hostname string) string {
-	return fmt.Sprintf("https://%s/api/v1/results/by-node", hostname)
-}
-
 func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificate, ownerPod *v1.Pod) appsv1.DaemonSet {
 	ds := appsv1.DaemonSet{}
 	annotations := map[string]string{
@@ -159,7 +155,7 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 
 // Run dispatches worker pods according to the DaemonSet's configuration.
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod) error {
-	daemonSet := p.createDaemonSetDefinition(getAggregatorAddress(hostname), cert, ownerPod)
+	daemonSet := p.createDaemonSetDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod)
 
 	secret, err := p.MakeTLSSecret(cert)
 	if err != nil {

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -74,10 +74,6 @@ func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
 	}
 }
 
-func getAggregatorAddress(hostname string) string {
-	return fmt.Sprintf("https://%s/api/v1/results/%v", hostname, plugin.GlobalResult)
-}
-
 func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, ownerPod *v1.Pod) v1.Pod {
 	pod := v1.Pod{}
 	annotations := map[string]string{
@@ -143,7 +139,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 // Run dispatches worker pods according to the Job's configuration.
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod) error {
-	job := p.createPodDefinition(getAggregatorAddress(hostname), cert, ownerPod)
+	job := p.createPodDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod)
 
 	secret, err := p.MakeTLSSecret(cert)
 	if err != nil {


### PR DESCRIPTION
In preparation of supporting status updates, I want to clarify
the meaning of the MASTER_URL env var on the worker.

Up until now the only URL of importance was the results URL so
that is what the MASTER_URL was set to. Soon, we will have results
and status updates, so it makes sense to have the MASTER_URL simply
be the hostname and add the path on the fly depending on which
endpoint we are trying to hit.

ref #735

**Release note**:
```
MASTER_URL set on the Sonobuoy worker container now refers to just `https://<hostname>` instead of the full results URL in order to more easily support manipulating the path used. This should have no impact on users since this is just a value used internally.
```
