### PR TITLE
Show logs for a specific plugin

### DIFF
--- a/cmd/sonobuoy/app/logs.go
+++ b/cmd/sonobuoy/app/logs.go
@@ -35,6 +35,7 @@ const (
 var logFlags struct {
 	namespace  string
 	follow     bool
+	plugin     string
 	kubeconfig Kubeconfig
 }
 
@@ -52,6 +53,7 @@ func NewCmdLogs() *cobra.Command {
 	)
 	AddKubeconfigFlag(&logFlags.kubeconfig, cmd.Flags())
 	AddNamespaceFlag(&logFlags.namespace, cmd.Flags())
+	cmd.Flags().StringVarP(&logFlags.plugin, pluginFlag, "p", "", "Show logs for a specific plugin")
 	return cmd
 }
 
@@ -65,6 +67,7 @@ func getLogs(cmd *cobra.Command, args []string) {
 	logConfig := client.NewLogConfig()
 	logConfig.Namespace = logFlags.namespace
 	logConfig.Follow = logFlags.follow
+	logConfig.Plugin = logFlags.plugin
 
 	logreader, err := sbc.LogReader(logConfig)
 	if err != nil {

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -40,6 +40,8 @@ type LogConfig struct {
 	Follow bool
 	// Namespace is the namespace the sonobuoy aggregator is running in.
 	Namespace string
+	// Plugin is the name of the plugin to show the logs of.
+	Plugin string
 	// Out is the writer to write to.
 	Out io.Writer
 }

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -91,9 +91,10 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 		annotations[k] = v
 	}
 	labels := map[string]string{
-		"component":    "sonobuoy",
-		"tier":         "analysis",
-		"sonobuoy-run": p.SessionID,
+		"component":       "sonobuoy",
+		"tier":            "analysis",
+		"sonobuoy-run":    p.SessionID,
+		"sonobuoy-plugin": p.GetName(),
 	}
 
 	ds.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -84,9 +84,10 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 		annotations[k] = v
 	}
 	labels := map[string]string{
-		"component":    "sonobuoy",
-		"tier":         "analysis",
-		"sonobuoy-run": p.SessionID,
+		"component":       "sonobuoy",
+		"tier":            "analysis",
+		"sonobuoy-run":    p.SessionID,
+		"sonobuoy-plugin": p.GetName(),
 	}
 
 	pod.ObjectMeta = metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new flag to the `logs` command to show the logs only for a
specific plugin. If not provided, or no pods are found for the plugin,
default to showing all logs.

We didn't have a way to uniquely identify pods for a plugin, so this
change adds a new label when creating Pods and DaemonSets which can
be used to filter the pods. This means that the flag will not work
for older versions of Sonobuoy, but it will still default to showing
all logs which was the original behaviour.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #702 

**Release note**:
```
Sonobuoy can now show only the logs for a specific plugin by using the flag `--plugin <plugin_name>` when using the logs command.
```
