### PR TITLE
Update Go to v1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-- '1.12'
+- '1.13'
 services:
 - docker
 install: true

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
 BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.12.1-stretch
+BUILD_IMAGE ?= golang:1.13.0-stretch
 AMD_IMAGE ?= debian:stretch-slim
 ARM_IMAGE ?= arm64v8/ubuntu:16.04
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Alternatively, you can install the CLI by running:
 go get -u -v github.com/heptio/sonobuoy
 ```
 
-Golang version 1.12 or greater is recommended. Golang can be installed via
+Golang version 1.13 or greater is recommended. Golang can be installed via
 [gimme][gimme].
 
 ## Getting Started

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -41,7 +41,7 @@ Alternatively, you can install the CLI by running:
 go get -u -v github.com/heptio/sonobuoy
 ```
 
-Golang version 1.12 or greater is recommended. Golang can be installed via
+Golang version 1.13 or greater is recommended. Golang can be installed via
 [gimme][gimme].
 
 ## Getting Started


### PR DESCRIPTION
Update the build image and also the Go version in Travis.

**Which issue(s) this PR fixes**
- Fixes #870 
