### PR TITLE
Add a disruptive taint to list of default tolerations

### DIFF
--- a/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
+++ b/cmd/sonobuoy/app/testdata/pluginDef-default-podspec.golden
@@ -8,6 +8,8 @@ podSpec:
     operator: Exists
   - key: CriticalAddonsOnly
     operator: Exists
+  - key: kubernetes.io/e2e-evict-taint-key
+    operator: Exists
 sonobuoy-config:
   driver: ""
   plugin-name: "n"

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -111,6 +111,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -37,6 +37,8 @@ data:
         operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: kubernetes.io/e2e-evict-taint-key
+        operator: Exists
     sonobuoy-config:
       driver: Job
       plugin-name: e2e
@@ -134,6 +136,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -111,6 +111,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -82,6 +82,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -85,6 +85,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -84,6 +84,9 @@ spec:
   - name: foo
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -89,6 +89,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -101,6 +101,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -72,6 +72,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -82,6 +82,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/no-plugins-via-selection.golden
+++ b/pkg/client/testdata/no-plugins-via-selection.golden
@@ -64,6 +64,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -79,6 +79,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -106,6 +106,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -94,6 +94,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -74,6 +74,9 @@ spec:
       name: output-volume
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -258,6 +258,10 @@ func defaultJobPodSpec() v1.PodSpec {
 				Key:      "CriticalAddonsOnly",
 				Operator: v1.TolerationOpExists,
 			},
+			{
+				Key:      "kubernetes.io/e2e-evict-taint-key",
+				Operator: v1.TolerationOpExists,
+			},
 		},
 		Volumes: []v1.Volume{},
 	}

--- a/pkg/plugin/driver/job/job_test.go
+++ b/pkg/plugin/driver/job/job_test.go
@@ -207,7 +207,7 @@ func TestCreatePodDefinitionUsesDefaultPodSpec(t *testing.T) {
 	}
 
 	// Check something specific to the job default pod spec
-	expectedNumTolerations := 2
+	expectedNumTolerations := 3
 	actualNumTolerations := len(pod.Spec.Tolerations)
 	if actualNumTolerations != expectedNumTolerations {
 		t.Errorf("expected pod spec to %v tolerations, got %v", expectedNumTolerations, actualNumTolerations)

--- a/pkg/templates/manifest.go
+++ b/pkg/templates/manifest.go
@@ -146,6 +146,9 @@ spec:
   {{- end }}
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - key: "kubernetes.io/e2e-evict-taint-key"
+    operator: "Exists"
   volumes:
   - configMap:
       name: sonobuoy-config-cm


### PR DESCRIPTION
**What this PR does / why we need it**:
A new conformance test in v1.16 will add a taint to a node which
can impact the sonobuoy aggregator pod as well as the e2e pod.

This change adds the toleration to both the default job podspec
and the aggregator. The default daemonset podspec already tolerates
all taints.

**Which issue(s) this PR fixes**
Fixes #876

**Special notes for your reviewer**:
I created a v1.16 cluster which may not be strictly necessary. You may just need to target the newer tests:

```
sonobuoy run --e2e-focus "removing taint cancels eviction" --kube-conformance-image-version=v1.16.0-rc.2 --sonobuoy-image schnake/sonobuoy:testTaint
```

**Release note**:
```
Added a new toleration to jobs plugins and the Sonobuoy aggregator in order to avoid disruptive effects of some E2E tests.
```
