### PR TITLE
Re-trigger custom podspec blog publishing

### DIFF
--- a/site/_posts/2019-09-16-customizing-plugin-podspecs.md
+++ b/site/_posts/2019-09-16-customizing-plugin-podspecs.md
@@ -127,7 +127,6 @@ cat sonobuoy-output/podlogs/heptio-sonobuoy/sonobuoy-customized-pod-spec-job-ee3
 32708 ?        00:00:00 ps
 ```
 
-
 ## Adapting Existing Plug-ins
 
 If you already have an existing plug-in, you can take the default PodSpec for your plug-in type and add it to your definition, or you can generate a Sonobuoy manifest, specifying your plug-in and the flag `--show-default-podspec`, and then edit the resulting YAML code:


### PR DESCRIPTION
I submitted this post with a future date of September 16 and thought it
would be visible on the Sonobuoy website on that date. Checking the
website this morning, this post is not visible so it didn't work as
expected.

To retrigger the publishing of the post, this change just includes a
minor change that does not impact the content or style (removing an
extra blank line).

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>