### PR TITLE
Remove 'extended' mode

### DIFF
--- a/pkg/client/mode.go
+++ b/pkg/client/mode.go
@@ -32,11 +32,9 @@ type Mode string
 const (
 	// Quick runs a single E2E test and the systemd log tests.
 	Quick Mode = "Quick"
+
 	// Conformance runs all of the E2E tests and the systemd log tests.
 	Conformance Mode = "Conformance"
-	// Extended run all of the E2E tests, the systemd log tests, and
-	// Heptio's E2E Tests.
-	Extended Mode = "Extended"
 )
 
 const defaultSkipList = `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]`
@@ -44,8 +42,6 @@ const defaultSkipList = `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]`
 var modeMap = map[string]Mode{
 	string(Conformance): Conformance,
 	string(Quick):       Quick,
-	// Removing until the extended tests are open sourced
-	//	string(Extended):    Extended,
 }
 
 // ModeConfig represents the sonobuoy configuration for a given mode.
@@ -99,19 +95,6 @@ func (m *Mode) Get() *ModeConfig {
 			},
 			Selectors: []plugin.Selection{
 				{Name: "e2e"},
-			},
-		}
-	case Extended:
-		return &ModeConfig{
-			E2EConfig: E2EConfig{
-				Focus:    `\[Conformance\]`,
-				Skip:     defaultSkipList,
-				Parallel: "1",
-			},
-			Selectors: []plugin.Selection{
-				{Name: "e2e"},
-				{Name: "systemd-logs"},
-				{Name: "heptio-e2e"},
 			},
 		}
 	default:


### PR DESCRIPTION
This was a mode based on a closed-source image and not generally
available. No need to support it here, especially with how easy
it is to create/use custom plugins now.

Ref #872