### PR TITLE
Add certified conformance mode and non-disruptive-conformance mode

### DIFF
--- a/cmd/sonobuoy/app/args.go
+++ b/cmd/sonobuoy/app/args.go
@@ -55,7 +55,7 @@ func AddNamespaceFlag(str *string, flags *pflag.FlagSet) {
 // Mode can be partially or fully overridden by specifying config, e2e-focus, and e2e-skip.
 // The variables specified by those flags will overlay the defaults provided by the given mode.
 func AddModeFlag(mode *ops.Mode, flags *pflag.FlagSet) {
-	*mode = ops.Conformance // default
+	*mode = ops.NonDisruptiveConformance // default
 	flags.VarP(
 		mode, "mode", "m",
 		fmt.Sprintf("What mode to run sonobuoy in. Valid modes are %s.", strings.Join(ops.GetModes(), ", ")),
@@ -132,7 +132,7 @@ const (
 // users. Using e2e-parallel incorrectly has the potential to destroy clusters!
 func AddE2EConfigFlags(flags *pflag.FlagSet) *pflag.FlagSet {
 	e2eFlags := pflag.NewFlagSet("e2e", pflag.ExitOnError)
-	modeName := ops.Conformance
+	modeName := ops.NonDisruptiveConformance
 	defaultMode := modeName.Get()
 	e2eFlags.String(
 		e2eFocusFlag, defaultMode.E2EConfig.Focus,

--- a/cmd/sonobuoy/app/args_test.go
+++ b/cmd/sonobuoy/app/args_test.go
@@ -34,16 +34,15 @@ func TestGetE2EConfig(t *testing.T) {
 	}{
 		{
 			desc:     "Default",
-			mode:     "Conformance",
+			mode:     "certified-conformance",
 			flagArgs: []string{},
 			expect: &ops.E2EConfig{
 				Focus:    `\[Conformance\]`,
-				Skip:     `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]`,
 				Parallel: "1",
 			},
 		}, {
 			desc:     "Flags settable",
-			mode:     "Conformance",
+			mode:     "certified-conformance",
 			flagArgs: []string{"--e2e-focus=foo", "--e2e-skip=bar", "--e2e-parallel=2"},
 			expect: &ops.E2EConfig{
 				Focus:    `foo`,
@@ -52,12 +51,12 @@ func TestGetE2EConfig(t *testing.T) {
 			},
 		}, {
 			desc:      "Focus regexp validated settable",
-			mode:      "Conformance",
+			mode:      "certified-conformance",
 			flagArgs:  []string{"--e2e-focus=*"},
 			expectErr: true,
 		}, {
 			desc:      "Skip regexp validated settable",
-			mode:      "Conformance",
+			mode:      "certified-conformance",
 			flagArgs:  []string{"--e2e-skip=*"},
 			expectErr: true,
 		},

--- a/cmd/sonobuoy/app/gen_test.go
+++ b/cmd/sonobuoy/app/gen_test.go
@@ -93,9 +93,9 @@ func TestResolveConfig(t *testing.T) {
 		cliInput string
 	}{
 		{
-			name: "Conformance mode when supplied config is nil (nothing interesting happens)",
+			name: "NonDisruptiveConformance mode when supplied config is nil (nothing interesting happens)",
 			input: &genFlags{
-				mode:           client.Conformance,
+				mode:           client.NonDisruptiveConformance,
 				sonobuoyConfig: SonobuoyConfig{},
 			},
 			expected: &config.Config{
@@ -139,9 +139,9 @@ func TestResolveConfig(t *testing.T) {
 				Resources:        config.DefaultResources,
 			},
 		}, {
-			name: "Conformance mode with plugin selection specified",
+			name: "NonDisruptiveConformance mode with plugin selection specified",
 			input: &genFlags{
-				mode: client.Conformance,
+				mode: client.NonDisruptiveConformance,
 				sonobuoyConfig: SonobuoyConfig{
 					Config: config.Config{
 						PluginSelections: []plugin.Selection{

--- a/pkg/client/defaults.go
+++ b/pkg/client/defaults.go
@@ -22,9 +22,9 @@ import (
 	"github.com/heptio/sonobuoy/pkg/config"
 )
 
-// NewGenConfig is a GenConfig using the default config and Conformance mode
+// NewGenConfig is a GenConfig using the default config and NonDisruptiveConformance mode
 func NewGenConfig() *GenConfig {
-	modeName := Conformance
+	modeName := NonDisruptiveConformance
 	defaultE2E := modeName.Get().E2EConfig
 
 	return &GenConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
With K8s v1.16, disruptive tests may not be part of the conformance
suite. As a result, we need to ensure that user workloads are
protected by default while still allowing for CNCF certification
test runs.

In this PR we:
 - rename the default `conformance` mode to be `non-disruptive-conformance`
and modified the skip list appropriately.
 - added a `certified-conformance` mode which does not provide a skip list
and will run even the disruptive tests
 - tweaked the naming to use lower case values by default to be more
consistent with our other flags/naming

**Which issue(s) this PR fixes**
Fixes #877
Fixes #875

**Special notes for your reviewer**:
I could have written the skip list in a slightly different way, naming the tests individually, but instead chose a higher level term that filtered both and, IMO, seems more clear why they may be skipped.

However, we need to talk about this issue in general because we are actually in a situation now where the `E2E_SKIP` value is dependent on the version of the cluster :( I think we can get away with this because the only real risks are:
 - someone uses this version of Sonobuoy with an older cluster
    - the non-disruptive-conformance run should hit all the conformance tests anyways since the NoExecuteTaintManager tests were not part of conformance on older clusters
 - someone uses this version of Sonobuoy with a newer cluster
    - the non-disruptive-conformance run may skip the NoExecuteTaintManager tests, even if the tests get updated somehow to not be disruptive or other NoExecuteTaintManager tests which are non-disruptive get added to Conformance. The only downside here is that a few tests don't get run, but since these are non-certification runs it doesn't matter much.

If there is a situation I've failed to think of, they can still set the e2e-focus/e2e-skip values on the CLI or the env vars in the YAML directly so we are not a blocker.

**Release note**:
```
Default `sonobuoy run` commands will run a subset of the `Conformance` tests which are safe to run on clusters with production workloads (avoids running known disruptive tests). To generate results for CNCF certification, you must run `sonobuoy run --mode=certified-conformance`
```
