### PR TITLE
Links in new docs script

### DIFF
--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -63,7 +63,6 @@ else
         /bin/sh -c \
         "rm -rf /root/site/docs/${VERSION} && \
         cp -r /root/site/docs/master /root/site/docs/${VERSION} && \
-        cp /root/README.md /root/site/docs/${VERSION}/README.md && \
         sed -i 's/site\/docs\/master\///g' /root/site/docs/${VERSION}/README.md && \
         sed -i 's/docs\/img/img/g' /root/site/docs/${VERSION}/README.md && \
         sed -i 's/sonobuoy\/tree\/master/sonobuoy\/tree\/${VERSION}/g' /root/site/docs/${VERSION}/README.md && \


### PR DESCRIPTION
**What this PR does / why we need it**:
This script was written to consider the root README as the source
of truth but I think that was before we realized that the docs
for the site have slightly different linking requirements.

As a result, the appropriate place to take the README from is the
master docs.

**Which issue(s) this PR fixes**
Fixes #887

**Special notes for your reviewer**:
To test this, I'd do the following:
 - checkout this branch
 - run the script to generate the 'new' docs for a phony version: `./scripts/update_docs.sh v0.15.999`
 - commit the change locally (so we can look at the diff later)
 - add back the line I removed
 - run the same command again `./scripts/update_docs.sh v0.15.999`
 - run `git diff` to look at the difference.

You'll see some redundant things (it adds to the TOC and a few other files, but the script is meant to be just for 'new' versions of the docs).

The main thing to see is that the diff should show just a small change in the links. It used to show full URLs for doc pages but it should now be showing relative URLs/paths.

**NOTE**
I'm going to add a second commit showing what the 'new' docs look like. When approved I'll remove that commit before merging.

**Release note**:
```
NONE
```
