### PR TITLE
Add integration test to check version information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install: true
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
-- VERBOSE=true make test int
+- VERBOSE=true make test stress int
 - ./travis-ci.sh
 before_install:
 - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,11 @@ TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
 TEST_CMD = go test $(TESTARGS)
 TEST = $(TEST_CMD) $(COVERARGS) $(TEST_PKGS)
 
-INT_TEST_PKGS ?= $(GOTARGET)/test/...
-INT_TEST= $(TEST_CMD) $(INT_TEST_PKGS)
+INT_TEST_PKGS ?= $(GOTARGET)/test/integration/...
+INT_TEST= $(TEST_CMD) $(INT_TEST_PKGS) -tags=integration
+
+STRESS_TEST_PKGS ?= $(GOTARGET)/test/stress/...
+STRESS_TEST= $(TEST_CMD) $(STRESS_TEST_PKGS)
 
 VET = go vet $(TEST_PKGS)
 
@@ -79,6 +82,10 @@ local-test:
 # Unit tests
 test: sonobuoy vet
 	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(TEST)'
+
+# Stress tests
+stress: sonobuoy
+	$(DOCKER_BUILD) 'CGO_ENABLED=0 $(STRESS_TEST)'
 
 # Integration tests
 int: sonobuoy

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -1,0 +1,71 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	defaultSonobuoyPath = "../../sonobuoy"
+)
+
+var (
+	// Path to the Sonobuoy CLI
+	sonobuoy string
+)
+
+func findSonobuoyCLI() (string, error) {
+	sonobuoyPath := os.Getenv("SONOBUOY_CLI")
+	if sonobuoyPath == "" {
+		sonobuoyPath = defaultSonobuoyPath
+	}
+	if _, err := os.Stat(sonobuoyPath); os.IsNotExist(err) {
+		return "", err
+	}
+
+	return sonobuoyPath, nil
+}
+
+// TestSonobuoyVersion checks that all fields in the output from `version` are non-empty
+func TestSonobuoyVersion(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	command := exec.Command(sonobuoy, "version")
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	t.Logf("Running %q\n", command.String())
+	if err := command.Run(); err != nil {
+		t.Errorf("Sonobuoy exited with an error: %v", err)
+		t.Log(stderr.String())
+		t.FailNow()
+	}
+
+	lines := strings.Split(stdout.String(), "\n")
+	for _, line := range lines {
+		versionComponents := strings.Split(line, ":")
+		// If a Kubeconfig is not provided, a warning is included that the API version check is skipped.
+		// Only check lines where a split on ":" actually happened.
+		if len(versionComponents) == 2 && strings.TrimSpace(versionComponents[1]) == "" {
+			t.Errorf("expected value for %v to be set, but was empty", versionComponents[0])
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	sonobuoy, err = findSonobuoyCLI()
+	if err != nil {
+		fmt.Printf("Skipping integration tests: failed to find sonobuoy CLI: %v\n", err)
+		os.Exit(1)
+	}
+
+	result := m.Run()
+	os.Exit(result)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new package, `integration`, which is the starting point
for adding integration testing for Sonobuoy. The package only contains
one test so far which runs `sonobuoy version` and checks that all fields
in the output from `version` are non-empty.

To separate these tests, a new Makefile target has been added which
sets the appropriate flags for running these tests. They are currently
run conditionally with the tag `integration` under the assumption that
as this package grows, we may not want to run these tests every time.

**Which issue(s) this PR fixes**
- Part of #668 

**Special notes for your reviewer**:
You can verify this test by building the sonobuoy executable with your
local go toolchain then running it:
```
go build
go test test/integration/sonobuoy_integration_test.go
```
This test should fail since the GitSHA information is not set.

To see it pass, build the executable using the Makefile and then run
the test again.
```
rm sonobuoy && make build_sonobuoy
go test test/integration/sonobuoy_integration_test.go
```