### PR TITLE
Update images for k8s v1.16

### DIFF
--- a/pkg/image/manifest.go
+++ b/pkg/image/manifest.go
@@ -25,12 +25,17 @@ import (
 
 // RegistryList holds public and private image registries
 type RegistryList struct {
-	DockerLibraryRegistry string `yaml:"dockerLibraryRegistry"`
-	E2eRegistry           string `yaml:"e2eRegistry"`
-	EtcdRegistry          string `yaml:"etcdRegistry"`
-	GcRegistry            string `yaml:"gcRegistry"`
-	PrivateRegistry       string `yaml:"privateRegistry"`
-	SampleRegistry        string `yaml:"sampleRegistry"`
+	GcAuthenticatedRegistry string `yaml:"gcAuthenticatedRegistry"`
+	DockerLibraryRegistry   string `yaml:"dockerLibraryRegistry"`
+	E2eRegistry             string `yaml:"e2eRegistry"`
+	InvalidRegistry         string `yaml:"invalidRegistry"`
+	GcRegistry              string `yaml:"gcRegistry"`
+	GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
+	GoogleContainerRegistry string `yaml:"googleContainerRegistry"`
+	EtcdRegistry            string `yaml:"etcdRegistry"`
+	PrivateRegistry         string `yaml:"privateRegistry"`
+	SampleRegistry          string `yaml:"sampleRegistry"`
+	QuayK8sCSI              string `yaml:"quayK8sCSI"`
 
 	K8sVersion *version.Version
 	Images     map[int]Config
@@ -46,12 +51,17 @@ type Config struct {
 // NewRegistryList returns a default registry or one that matches a config file passed
 func NewRegistryList(repoConfig, k8sVersion string) (*RegistryList, error) {
 	registry := &RegistryList{
-		DockerLibraryRegistry: "docker.io/library",
-		E2eRegistry:           "gcr.io/kubernetes-e2e-test-images",
-		EtcdRegistry:          "quay.io/coreos",
-		GcRegistry:            "k8s.gcr.io",
-		PrivateRegistry:       "gcr.io/k8s-authenticated-test",
-		SampleRegistry:        "gcr.io/google-samples",
+		DockerLibraryRegistry:   "docker.io/library",
+		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
+		EtcdRegistry:            "quay.io/coreos",
+		GcRegistry:              "k8s.gcr.io",
+		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
+		SampleRegistry:          "gcr.io/google-samples",
+		GcAuthenticatedRegistry: "gcr.io/authenticated-image-pulling",
+		InvalidRegistry:         "invalid.com/invalid",
+		GcrReleaseRegistry:      "gcr.io/gke-release",
+		GoogleContainerRegistry: "gcr.io/google-containers",
+		QuayK8sCSI:              "quay.io/k8scsi",
 	}
 
 	// Load in a config file
@@ -90,6 +100,8 @@ func (r *RegistryList) GetImageConfigs() (map[string]Config, error) {
 			return r.v1_14(), nil
 		case 15:
 			return r.v1_15(), nil
+		case 16:
+			return r.v1_16(), nil
 		}
 	}
 	return map[string]Config{}, fmt.Errorf("No matching configuration for k8s version: %v", r.K8sVersion)

--- a/pkg/image/v1.16.go
+++ b/pkg/image/v1.16.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE: This is manually replicated from: https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go
+
+package image
+
+func (r *RegistryList) v1_16() map[string]Config {
+
+	e2eRegistry := r.E2eRegistry
+	dockerLibraryRegistry := r.DockerLibraryRegistry
+	sampleRegistry := r.SampleRegistry
+	gcRegistry := r.GcRegistry
+	gcAuthenticatedRegistry := r.GcAuthenticatedRegistry
+	googleContainerRegistry := r.GoogleContainerRegistry
+	invalidRegistry := r.InvalidRegistry
+
+	configs := map[string]Config{}
+	configs["Agnhost"] = Config{e2eRegistry, "agnhost", "2.6"}
+	configs["Alpine"] = Config{dockerLibraryRegistry, "alpine", "3.7"}
+	configs["AuthenticatedAlpine"] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
+	configs["AuthenticatedWindowsNanoServer"] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}
+	configs["APIServer"] = Config{e2eRegistry, "sample-apiserver", "1.10"}
+	configs["AppArmorLoader"] = Config{e2eRegistry, "apparmor-loader", "1.0"}
+	configs["BusyBox"] = Config{dockerLibraryRegistry, "busybox", "1.29"}
+	configs["CheckMetadataConcealment"] = Config{e2eRegistry, "metadata-concealment", "1.2"}
+	configs["CudaVectorAdd"] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
+	configs["CudaVectorAdd2"] = Config{e2eRegistry, "cuda-vector-add", "2.0"}
+	configs["Dnsutils"] = Config{e2eRegistry, "dnsutils", "1.1"}
+	configs["DebianBase"] = Config{googleContainerRegistry, "debian-base", "0.4.1"}
+	configs["EchoServer"] = Config{e2eRegistry, "echoserver", "2.2"}
+	configs["Etcd"] = Config{gcRegistry, "etcd", "3.3.15"}
+	configs["GBFrontend"] = Config{sampleRegistry, "gb-frontend", "v6"}
+	configs["Httpd"] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
+	configs["HttpdNew"] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}
+	configs["Invalid"] = Config{gcRegistry, "invalid-image", "invalid-tag"}
+	configs["InvalidRegistryImage"] = Config{invalidRegistry, "alpine", "3.1"}
+	configs["IpcUtils"] = Config{e2eRegistry, "ipc-utils", "1.0"}
+	configs["JessieDnsutils"] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
+	configs["Kitten"] = Config{e2eRegistry, "kitten", "1.0"}
+	configs["Mounttest"] = Config{e2eRegistry, "mounttest", "1.0"}
+	configs["MounttestUser"] = Config{e2eRegistry, "mounttest-user", "1.0"}
+	configs["Nautilus"] = Config{e2eRegistry, "nautilus", "1.0"}
+	configs["Nginx"] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
+	configs["NginxNew"] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
+	configs["Nonewprivs"] = Config{e2eRegistry, "nonewprivs", "1.0"}
+	configs["NonRoot"] = Config{e2eRegistry, "nonroot", "1.0"}
+	configs["Pause"] = Config{gcRegistry, "pause", "3.1"}
+	configs["Perl"] = Config{dockerLibraryRegistry, "perl", "5.26"}
+	configs["PrometheusDummyExporter"] = Config{gcRegistry, "prometheus-dummy-exporter", "v0.1.0"}
+	configs["PrometheusToSd"] = Config{gcRegistry, "prometheus-to-sd", "v0.5.0"}
+	configs["Redis"] = Config{dockerLibraryRegistry, "redis", "5.0.5-alpine"}
+	configs["ResourceConsumer"] = Config{e2eRegistry, "resource-consumer", "1.5"}
+	configs["ResourceController"] = Config{e2eRegistry, "resource-consumer-controller", "1.0"}
+	configs["SdDummyExporter"] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}
+	configs["StartupScript"] = Config{googleContainerRegistry, "startup-script", "v1"}
+	configs["TestWebserver"] = Config{e2eRegistry, "test-webserver", "1.0"}
+	configs["VolumeNFSServer"] = Config{e2eRegistry, "volume/nfs", "1.0"}
+	configs["VolumeISCSIServer"] = Config{e2eRegistry, "volume/iscsi", "2.0"}
+	configs["VolumeGlusterServer"] = Config{e2eRegistry, "volume/gluster", "1.0"}
+	configs["VolumeRBDServer"] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
+	configs["WindowsNanoServer"] = Config{e2eRegistry, "windows-nanoserver", "v1"}
+	return configs
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With each new minor version of k8s we update the image list
so that commands like `sonobuoy images` pull the right set of images
for testing airgapped envs.

**Which issue(s) this PR fixes**
Prepares for v0.16 release

**Special notes for your reviewer**:
We don't have a great way to test this exactly. The best thing we can do is really just manually check the values against the upstream.

See the values for v1.16 here: https://github.com/kubernetes/kubernetes/blob/v1.16.0/test/utils/image/manifest.go

Note that there are a number of new registries added. Also, in the upstream there is another value `e2eGcRegistry` which was just set to a constant rather than a value from the registry list. This is inappropriate and I've made the intuitive decision to map that value to the corresponding registry list value (which defaults to the same value as the upstream)