### PR TITLE
Remove unused dependency from Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,10 +71,6 @@
 
 [[constraint]]
   branch = "release-1.14"
-  name = "k8s.io/apiextensions-apiserver"
-
-[[constraint]]
-  branch = "release-1.14"
   name = "k8s.io/apimachinery"
 
 [[constraint]]


### PR DESCRIPTION
**What this PR does / why we need it**:
This change removes the unused dependency
`k8s.io/apiextensions-apiserver` from Gopkg.toml which was causing a
warning when running `dep ensure`.

This package was no longer needed after #689 and the package was
removed from `vendor/` in #739.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>