### PR TITLE
Add kind and dep to PATH in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ script:
 - ./travis-ci.sh
 before_install:
 - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64
-  --output kind && chmod +x kind
-- ./kind create cluster --config kind-config.yaml
-- export KUBECONFIG="$(./kind get kubeconfig-path --name="kind")"
+  --output $HOME/bin/kind && chmod +x $HOME/bin/kind
+- kind create cluster --config kind-config.yaml
+- export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 - curl -L https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 --output
-  dep && chmod +x dep
+  $HOME/bin/dep && chmod +x $HOME/bin/dep
 before_deploy:
 - if [ ! -d ${HOME}/google-cloud-sdk ]; then curl https://sdk.cloud.google.com | bash
   /dev/stdin --disable-prompts; fi

--- a/Makefile
+++ b/Makefile
@@ -184,9 +184,7 @@ clean:
 	done
 
 deploy_kind:
-	# FIXME: This assumes kind is in cwd; intended to work with our other CI scripts and
-	# is a bit wonky for general use.
-	./kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true
+	kind load docker-image $(REGISTRY)/$(TARGET):$(IMAGE_VERSION) || true
 
 native:
 	$(GO_BUILD)

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Early detect/fail if deps not correct.
-./dep ensure
+dep ensure
 git_status=$(git status -s)
 if [ -n "$git_status" ]; then
     echo $git_status


### PR DESCRIPTION
Instead of placing kind and dep in the working directory for
the Travis CI build, place them in a location which is in the 
PATH so they can be easily used elsewhere.
It also allows us to fix the `deploy_kind` target in our Makefile
which assumed that kind was in the current directory.