### PR TITLE
Add a small test which runs a basic plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install: true
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
-- VERBOSE=true make test stress int
+- VERBOSE=true make test stress
+- ./scripts/run_integration_tests.sh
 - ./travis-ci.sh
 before_install:
 - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTS_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+DIR=$(cd $SCRIPTS_DIR; cd ..; pwd)
+
+cluster="integration"
+testImage="sonobuoy/testimage:v0.1"
+
+if ! kind get clusters | grep -q "^$cluster$"; then
+    kind create cluster --name $cluster
+    # Although the cluster has been created, not all the pods in kube-system are created/available
+    sleep 20
+fi
+
+# Build and load the test plugin image
+make -C $DIR/test/integration/testImage
+kind load docker-image --name $cluster $testImage
+
+# Build and load the sonobuoy image and run integration tests
+make -C $DIR KIND_CLUSTER=$cluster deploy_kind
+KUBECONFIG="$(kind get kubeconfig-path --name="$cluster")" VERBOSE=true make -C $DIR int

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -40,7 +40,7 @@ if [ $e2eCode -ne 0 ]; then
     mkdir results; tar xzf $outFile -C results
 
     echo "Full contents of tarball:"
-    find results 
+    find results
 
     echo "Printing data on the following files:"
     find results/plugins -type f


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a simple test and mostly provides scaffolding to be
able to write further tests using the changes introduced in #907.

It adds a new script `run_integration_tests.sh` which creates a separate
cluster if necessary and then runs the tests on it.