### PR TITLE
Adds the results format as a flag parameter for gen plugin

### DIFF
--- a/cmd/sonobuoy/app/gen_plugin_def.go
+++ b/cmd/sonobuoy/app/gen_plugin_def.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/heptio/sonobuoy/pkg/client/results"
 	"github.com/heptio/sonobuoy/pkg/errlog"
 	"github.com/heptio/sonobuoy/pkg/plugin"
 	"github.com/heptio/sonobuoy/pkg/plugin/driver"
@@ -79,6 +80,11 @@ func NewCmdGenPluginDef() *cobra.Command {
 	genPluginSet.VarP(
 		&genPluginOpts.driver, "type", "t",
 		"Plugin Driver (job or daemonset)",
+	)
+
+	genPluginSet.StringVarP(
+		&genPluginOpts.def.SonobuoyConfig.ResultFormat, "format", "f", results.ResultFormatRaw,
+		"Result format (junit or raw)",
 	)
 
 	genPluginSet.StringVarP(


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating a plugin, one of the most common things you may
want to do is leverage the new result processing capabilities by
specifying if the results should be treated as raw files or as
structured junit (and eventually other formats).

This PR adds the new flag; no testing updates were required
since this does not change default behavior and any tests would
really just test the fact that the flag was added at all, being
trivial.

**Which issue(s) this PR fixes**
Related to #668 

**Special notes for your reviewer**:

**Release note**:
```
Added a new flag `--format` to the `sonobuoy gen plugin` command which allows you to specify if the plugin generates structured junit results. Defaults to `raw` meaning no structure is assumed.
```
