### PR TITLE
Prints all plugins when invoking `sonobuoy results` by default

### DIFF
--- a/cmd/sonobuoy/app/results_test.go
+++ b/cmd/sonobuoy/app/results_test.go
@@ -21,7 +21,10 @@ import (
 
 func ExampleNewCmdResults() {
 	cmd := NewCmdResults()
-	cmd.SetArgs([]string{filepath.Join("testdata", "testResultsOutput.tar.gz")})
+	cmd.SetArgs([]string{
+		filepath.Join("testdata", "testResultsOutput.tar.gz"),
+		"--plugin=e2e",
+	})
 	cmd.Execute()
 	// Output:
 	// Plugin: e2e
@@ -39,7 +42,7 @@ func ExampleNewCmdResults_detailed() {
 	cmd := NewCmdResults()
 	cmd.SetArgs([]string{
 		filepath.Join("testdata", "testResultsOutput.tar.gz"),
-		"--mode", "detailed",
+		"--mode", "detailed", "--plugin=e2e",
 	})
 	cmd.Execute()
 	// Output:

--- a/pkg/client/results/reader.go
+++ b/pkg/client/results/reader.go
@@ -53,6 +53,10 @@ const (
 	defaultNodesFile          = "Nodes.json"
 	defaultServerVersionFile  = "serverversion.json"
 	defaultServerGroupsFile   = "servergroups.json"
+
+	// InfoFile contains data not that isn't strictly in another location
+	// but still relevent to post-processing or understanding the run in some way.
+	InfoFile = "info.json"
 )
 
 // Versions corresponding to Kubernetes minor version values. We used to
@@ -321,6 +325,13 @@ func ConfigFile(version string) string {
 	default:
 		return "meta/config.json"
 	}
+}
+
+// RunInfoFile returns the path to the Sonobuoy RunInfo file which is extra metadata about the run.
+// This was added in v0.16.1. The function will return the same string even for earlier
+// versions where that file does not exist.
+func (r *Reader) RunInfoFile() string {
+	return path.Join(metadataDir, InfoFile)
 }
 
 // PluginResultsItem returns the results file from the given plugin if found, error otherwise.


### PR DESCRIPTION
**What this PR does / why we need it**:
If given a tarball, there is not a way to detect which plugins
were actually run without opening it up first. This means that the
`sonobuoy results` command is less useful since you have to have
preexisting knowledge about the tarball/run. You'd also have to
manually execute the command numerous times if you want all the
summaries of the plugins.

This change:
 -  makes the default value for the `--plugin` flag the
empty string
 - when a string value is given, it will print a single report
like the existing behavior
 - when the default, empty string is used, we will list the report
for each plugin
 - adds a new file, meta/info.json which will contain the list of
plugins that were actually run so that it is easier to grab this
list (rather than more complicated logic using the other data in
the tarball)

**Which issue(s) this PR fixes**
Fixes #905

**Special notes for your reviewer**:
If you target an old tarball with the new CLI you'll get a message about the plugins not being discernable from either the flags or the `meta/info.json`. I could fallback to trying the `e2e` by default at that point but I think it is a bit confusing to twist the default behavior since the error message in some cases may not reflect what was the intended behavior (e.g. they want to list all plugins and then get an error msg about e2e)

If you target a new tarball with an old CLI, no difference in behavior.

If you target a new tarball (e.g. a tarball made by the new image) with the new CLI then you'll get the new behavior.

**Release note**:
```
`sonobuoy results results.tar.gz` now defaults to printing information on all the plugins that were run. You may still print just the e2e plugin information by setting the existing flag `--plugin e2e`.
```
