### PR TITLE
Default to using the golang-based conformance runner

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -304,6 +304,7 @@ func e2eManifest(cfg *GenConfig) *manifest.Manifest {
 					{Name: "E2E_FOCUS", Value: cfg.E2EConfig.Focus},
 					{Name: "E2E_SKIP", Value: cfg.E2EConfig.Skip},
 					{Name: "E2E_PARALLEL", Value: cfg.E2EConfig.Parallel},
+					{Name: "E2E_USE_GO_RUNNER", Value: "true"},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/pkg/client/gen_test.go
+++ b/pkg/client/gen_test.go
@@ -333,6 +333,16 @@ func TestGenerateManifestGolden(t *testing.T) {
 			},
 			goldenFile: filepath.Join("testdata", "default-pod-spec.golden"),
 		}, {
+			name: "E2E_USE_GO_RUNNER can be overridden/removed",
+			inputcm: &client.GenConfig{
+				E2EConfig:      &client.E2EConfig{},
+				DynamicPlugins: []string{"e2e"},
+				PluginEnvOverrides: map[string]map[string]string{
+					"e2e": {"E2E_USE_GO_RUNNER": ""},
+				},
+			},
+			goldenFile: filepath.Join("testdata", "goRunnerRemoved.golden"),
+		}, {
 			name: "Existing pod spec is not modified if default pod spec is requested",
 			inputcm: &client.GenConfig{
 				E2EConfig:          &client.E2EConfig{},

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -50,6 +50,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -35,14 +35,9 @@ data:
       command:
       - /run_e2e.sh
       env:
-      - name: E2E_DRYRUN
-        value: "true"
       - name: E2E_FOCUS
       - name: E2E_PARALLEL
       - name: E2E_SKIP
-        value: override
-      - name: E2E_USE_GO_RUNNER
-        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -38,6 +38,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       name: e2e
       resources: {}
       volumeMounts:

--- a/pkg/client/testdata/ssh.golden
+++ b/pkg/client/testdata/ssh.golden
@@ -52,6 +52,8 @@ data:
       - name: E2E_FOCUS
       - name: E2E_SKIP
       - name: E2E_PARALLEL
+      - name: E2E_USE_GO_RUNNER
+        value: "true"
       - name: LOCAL_SSH_KEY
         value: id_rsa
       - name: AWS_SSH_KEY


### PR DESCRIPTION
**What this PR does / why we need it**:
In Kubernetes 1.16.0 a problem in the bash runner of the conformance
tests caused the plugin to fail to report results whenever a test
failure occured.

This problem does not impact the golang-based runner which was
introduced also in Kubernetes 1.16.0. By default we would like to use
this feature as a result. It is a new feature but has been shown
so far to be functional and an improvement over the bash-based
runner (e.g. like this issue in general).

Users of Sonobuoy v0.16.0 should update to a version which utilizes
this env var by default, but they can also specify
--plugin-env e2e.E2E_USE_GO_RUNNER=true to workaround the issue.

If users of new versions of Sonobuoy wish to NOT use the go runner
they can also set --plugin-env e2e.E2E_USE_GO_RUNNER to unset the value.

**Which issue(s) this PR fixes**
Fixes #910

**Special notes for your reviewer**:
You can test this on older clusters but just use `--kube-conformance-image-version=v1.16.0`

If you want to repro, use current Sonobuoy master with this command:
```
sonobuoy gen --e2e-focus "SCHNAKE" --kube-conformance-image-version=v1.16.0 -n issue910 |sed 's/SCHNAKE/"\*"/' | kubectl apply -f -
```

That command will provide a bad regexp to the tests and they will immediately fail. On master, the container fails and 5 min later Sonobuoy will acknowledge that the container failed and stop waiting for the results to come in.

If you try the same command with this branch or by adding `--plugin-env e2e.E2E_USE_GO_RUNNER=true` you will see that the plugin completes but has unknown results since it submitted results but does not provide any xml since it never even got to test invocation.

**Release note**:
```
The default for running the E2E conformance tests will include setting E2E_USE_GO_RUNNER=true. There shouldn't be a large functional difference for most users but it should provide better error handling, better logging, and the ability for advanced users to provide additional flags to the test suite.
```
