### PR TITLE
Tweak readme with info about results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ results=$(sonobuoy retrieve)
 Inspect results for test failures.  This will list the number of tests failed and their names:
 
 ```bash
-sonobuoy e2e $results
+sonobuoy results $results
 ```
+
+> Note: The `results` command has lots of useful options for various situations. See the [results page][results] for more details.
 
 You can also extract the entire contents of the file to get much more [detailed data][snapshot] about your cluster.
 
@@ -164,6 +166,7 @@ See [the list of releases][releases] to find out about feature changes.
 [plugins]: https://sonobuoy.io/docs/plugins
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 [releases]: https://github.com/heptio/sonobuoy/releases
+[results]: https://sonobuoy.io/docs/results.md
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
 [snapshot]:https://sonobuoy.io/docs/snapshot
 [sonobuoyconfig]: https://sonobuoy.io/docs/sonobuoy-config

--- a/site/_data/master-toc.yml
+++ b/site/_data/master-toc.yml
@@ -5,10 +5,10 @@ toc:
         url: /index.html
       - page: Config
         url: /sonobuoy-config
+      - page: Checking Results
+        url: /results
       - page: Snapshot layout
         url: /snapshot
-      - page: ImagePullSecrects
-        url: /pullsecrets
   - title: Use cases
     subfolderitems:
       - page: Conformance testing
@@ -17,6 +17,8 @@ toc:
         url: /airgap
       - page: Plugins
         url: /plugins
+      - page: Using Private Images
+        url: /pullsecrets
   - title: Next steps
     subfolderitems:
       - page: Customization

--- a/site/_data/v0-16-0toc.yml
+++ b/site/_data/v0-16-0toc.yml
@@ -5,10 +5,10 @@ toc:
         url: /index.html
       - page: Config
         url: /sonobuoy-config
+      - page: Checking Results
+        url: /results
       - page: Snapshot layout
         url: /snapshot
-      - page: ImagePullSecrects
-        url: /pullsecrets
   - title: Use cases
     subfolderitems:
       - page: Conformance testing
@@ -17,11 +17,13 @@ toc:
         url: /airgap
       - page: Plugins
         url: /plugins
+      - page: Using Private Images
+        url: /pullsecrets
   - title: Next steps
     subfolderitems:
       - page: Customization
         url: /gen
-      - page: Make your own plugins
+      - page: Example Plugins
         url: /examples
         github: true
       - page: Cut a Release

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -63,8 +63,10 @@ results=$(sonobuoy retrieve)
 Inspect results for test failures.  This will list the number of tests failed and their names:
 
 ```bash
-sonobuoy e2e $results
+sonobuoy results $results
 ```
+
+> Note: The `results` command has lots of useful options for various situations. See the [results page][results] for more details.
 
 You can also extract the entire contents of the file to get much more [detailed data][snapshot] about your cluster.
 
@@ -164,6 +166,7 @@ See [the list of releases][releases] to find out about feature changes.
 [plugins]: plugins
 [quickstart]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 [releases]: https://github.com/heptio/sonobuoy/releases
+[results]: results.md
 [slack]: https://kubernetes.slack.com/messages/sonobuoy
 [snapshot]:snapshot
 [sonobuoyconfig]: sonobuoy-config


### PR DESCRIPTION
**What this PR does / why we need it**:
A recent issue made me take a look at our docs and I noticed that
we were still referencing the `e2e` command instead of the
`results` command. It was actually hard to find a link to that page
which should be more visible.

**Which issue(s) this PR fixes**
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
```
NONE
```
