### PR TITLE
 Combine gen and run flags

### DIFF
--- a/cmd/sonobuoy/app/run.go
+++ b/cmd/sonobuoy/app/run.go
@@ -18,66 +18,18 @@ package app
 
 import (
 	"fmt"
-	"os"
-	"time"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"os"
 
 	"github.com/vmware-tanzu/sonobuoy/pkg/client"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 )
 
-type runFlags struct {
-	genFlags
-	skipPreflight bool
-	wait          int
-	waitOutput    WaitOutputMode
-	genFile       string
-}
-
 var (
 	allowedGenFlagsWithRunFile = []string{kubeconfig, kubecontext}
 )
-
-func RunFlagSet(cfg *runFlags) *pflag.FlagSet {
-	runset := pflag.NewFlagSet("run", pflag.ExitOnError)
-	// Default to detect since we need kubeconfig regardless
-	runset.AddFlagSet(GenFlagSet(&cfg.genFlags, DetectRBACMode))
-	AddSkipPreflightFlag(&cfg.skipPreflight, runset)
-	AddRunWaitFlag(&cfg.wait, runset)
-	if featureEnabled(FeatureWaitOutputProgressByDefault) {
-		AddWaitOutputFlag(&cfg.waitOutput, runset, ProgressOutputMode)
-	} else {
-		AddWaitOutputFlag(&cfg.waitOutput, runset, SilentOutputMode)
-	}
-
-	runset.StringVarP(
-		&cfg.genFile, "file", "f", "",
-		"If set, loads the file as if it were the output from sonobuoy gen. Set to `-` to read from stdin.",
-	)
-
-	return runset
-}
-
-func (r *runFlags) Config() (*client.RunConfig, error) {
-	runcfg := &client.RunConfig{
-		Wait:       time.Duration(r.wait) * time.Minute,
-		WaitOutput: r.waitOutput.String(),
-		GenFile:    r.genFile,
-	}
-
-	if r.genFile == "" {
-		gencfg, err := r.genFlags.Config()
-		if err != nil {
-			return nil, err
-		}
-		runcfg.GenConfig = *gencfg
-	}
-
-	return runcfg, nil
-}
 
 func givenAnyGenConfigFlags(fs *pflag.FlagSet, allowedFlagNames []string) bool {
 	changed := false
@@ -93,8 +45,8 @@ func givenAnyGenConfigFlags(fs *pflag.FlagSet, allowedFlagNames []string) bool {
 }
 
 func NewCmdRun() *cobra.Command {
-	var f runFlags
-	fs := RunFlagSet(&f)
+	var f genFlags
+	fs := GenFlagSet(&f, DetectRBACMode)
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Starts a Sonobuoy run by launching the Sonobuoy aggregator and plugin pods.",
@@ -109,14 +61,14 @@ func NewCmdRun() *cobra.Command {
 	return cmd
 }
 
-func checkFlagValidity(fs *pflag.FlagSet, rf runFlags) error {
+func checkFlagValidity(fs *pflag.FlagSet, rf genFlags) error {
 	if rf.genFile != "" && givenAnyGenConfigFlags(fs, allowedGenFlagsWithRunFile) {
 		return fmt.Errorf("setting the --file flag is incompatible with any other options besides %v", allowedGenFlagsWithRunFile)
 	}
 	return nil
 }
 
-func submitSonobuoyRun(f *runFlags) func(cmd *cobra.Command, args []string) {
+func submitSonobuoyRun(f *genFlags) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		sbc, err := getSonobuoyClientFromKubecfg(f.kubecfg)
 		if err != nil {
@@ -124,7 +76,7 @@ func submitSonobuoyRun(f *runFlags) func(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		runCfg, err := f.Config()
+		runCfg, err := f.RunConfig()
 		if err != nil {
 			errlog.LogError(errors.Wrap(err, "could not retrieve E2E config"))
 			os.Exit(1)

--- a/test/integration/testdata/gen-rerunfailed-missing.golden
+++ b/test/integration/testdata/gen-rerunfailed-missing.golden
@@ -17,6 +17,7 @@ Flags:
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
+  -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.
   -h, --help                                     help for gen
       --image-pull-policy string                 Set the ImagePullPolicy for the Sonobuoy image and all plugins. Valid options are Always, IfNotPresent, Never. (default "IfNotPresent")
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
@@ -31,11 +32,14 @@ Flags:
       --rerun-failed tar.gz file                 Read the given tarball and set the E2E_FOCUS to target all the failed tests
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
+      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.
       --systemd-logs-image image                 Container image override for the systemd-logs plugin. Shorthand for --plugin-image=systemd-logs:<string> (default map[])
       --timeout int                              How long (in seconds) Sonobuoy aggregator will wait for plugins to complete before exiting. 0 indicates no timeout. (default 21600)
+      --wait int[=1440]                          How long (in minutes) for the CLI to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. If specified, the default wait time is 1 day.
+      --wait-output string                       Specify the type of output Sonobuoy should produce when --wait is used. Valid modes are silent, spinner, or progress (default "Progress")
 
 Global Flags:
       --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)

--- a/test/integration/testdata/gen-rerunfailed-no-failures.golden
+++ b/test/integration/testdata/gen-rerunfailed-no-failures.golden
@@ -17,6 +17,7 @@ Flags:
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
+  -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.
   -h, --help                                     help for gen
       --image-pull-policy string                 Set the ImagePullPolicy for the Sonobuoy image and all plugins. Valid options are Always, IfNotPresent, Never. (default "IfNotPresent")
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
@@ -31,11 +32,14 @@ Flags:
       --rerun-failed tar.gz file                 Read the given tarball and set the E2E_FOCUS to target all the failed tests
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
+      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.
       --systemd-logs-image image                 Container image override for the systemd-logs plugin. Shorthand for --plugin-image=systemd-logs:<string> (default map[])
       --timeout int                              How long (in seconds) Sonobuoy aggregator will wait for plugins to complete before exiting. 0 indicates no timeout. (default 21600)
+      --wait int[=1440]                          How long (in minutes) for the CLI to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. If specified, the default wait time is 1 day.
+      --wait-output string                       Specify the type of output Sonobuoy should produce when --wait is used. Valid modes are silent, spinner, or progress (default "Progress")
 
 Global Flags:
       --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)

--- a/test/integration/testdata/gen-rerunfailed-not-tarball.golden
+++ b/test/integration/testdata/gen-rerunfailed-not-tarball.golden
@@ -17,6 +17,7 @@ Flags:
       --e2e-focus envModifier                    Specify the E2E_FOCUS value for the e2e plugin, specifying which tests to run. Shorthand for --plugin-env=e2e.E2E_FOCUS=<string> (default \[Conformance\])
       --e2e-repo-config yaml-filepath            Specify a yaml file acting as KUBE_TEST_REPO_LIST, overriding registries for test images.
       --e2e-skip envModifier                     Specify the E2E_SKIP value for the e2e plugin, specifying which tests to skip. Shorthand for --plugin-env=e2e.E2E_SKIP=<string> (default \[Disruptive\]|NoExecuteTaintManager)
+  -f, --file -                                   If set, loads the file as if it were the output from sonobuoy gen. Set to - to read from stdin.
   -h, --help                                     help for gen
       --image-pull-policy string                 Set the ImagePullPolicy for the Sonobuoy image and all plugins. Valid options are Always, IfNotPresent, Never. (default "IfNotPresent")
       --kube-conformance-image image             Container image override for the e2e plugin. Shorthand for --plugin-image=e2e:<string> (default map[])
@@ -31,11 +32,14 @@ Flags:
       --rerun-failed tar.gz file                 Read the given tarball and set the E2E_FOCUS to target all the failed tests
       --security-context-mode string             Type of security context to use for the aggregator pod. Allowable values are [none, nonroot] (default "nonroot")
       --show-default-podspec                     If true, include the default pod spec used for plugins in the output.
+      --skip-preflight                           If true, skip all checks before starting the sonobuoy run.
       --sonobuoy-image string                    Container image override for the sonobuoy worker and aggregator. (default "sonobuoy/sonobuoy:*STATIC_FOR_TESTING*")
       --ssh-key yamlFile                         Path to the private key enabling SSH to cluster nodes. May be required by some tests from the e2e plugin.
       --ssh-user envModifier                     SSH user for ssh-key. Required if running e2e plugin with certain tests that require SSH access to nodes.
       --systemd-logs-image image                 Container image override for the systemd-logs plugin. Shorthand for --plugin-image=systemd-logs:<string> (default map[])
       --timeout int                              How long (in seconds) Sonobuoy aggregator will wait for plugins to complete before exiting. 0 indicates no timeout. (default 21600)
+      --wait int[=1440]                          How long (in minutes) for the CLI to wait for sonobuoy run to be completed or fail, where 0 indicates do not wait. If specified, the default wait time is 1 day.
+      --wait-output string                       Specify the type of output Sonobuoy should produce when --wait is used. Valid modes are silent, spinner, or progress (default "Progress")
 
 Global Flags:
       --level level   Log level. One of {panic, fatal, error, warn, info, debug, trace} (default info)


### PR DESCRIPTION
Moves wait/wait-output/skip-preflight to the gen
flag set and not just run's. This allows gen and run to
both process all the flags so that you can use `gen` to
test any `run` command without having to add/remove flags
when you go back and forth.

The new values do not impact gen in any way unless you provide
the `-f` flag, in which case gen will just print the file.

**Which issue(s) this PR fixes**
- Fixes #1453 

**Release note**:
```
Added missing flags to `sonobuoy gen` (as compared to `sonobuoy run`) such as --wait and --skip-preflight so that you can easily switch between running `sonobuoy gen` and `sonobuoy run` without modifying the flags.
```
