### PR TITLE
Add go-json output support for results

### DIFF
--- a/pkg/client/results/gojson.go
+++ b/pkg/client/results/gojson.go
@@ -1,0 +1,165 @@
+/*
+Copyright Sonobuoy contributors 2021
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package results
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// the test has started running
+	actionRun = "run"
+	// the test has been paused
+	actionPause = "pause"
+	// the test has continued running
+	actionCont = "cont"
+	// the test passed
+	actionPass = "pass"
+	// the benchmark printed log output but did not fail
+	actionBench = "bench"
+	// the test or benchmark failed
+	actionFail = "fail"
+	// the test printed output
+	actionOutput = "output"
+	// the test was skipped or the package contained no tests
+	actionSkip = "skip"
+)
+
+// testEvent is a single message emitted from test2json.
+// Stolen from https://golang.org/cmd/test2json/ and github.com/cdr/gott
+type testEvent struct {
+	Time    time.Time // encodes as an RFC3339-format string
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+func gojsonProcessFile(pluginDir, currentFile string) (Item, error) {
+	relPath, err := filepath.Rel(pluginDir, currentFile)
+	if err != nil {
+		logrus.Errorf("Error making path %q relative to %q: %v", pluginDir, currentFile, err)
+		relPath = currentFile
+	}
+
+	resultObj := Item{
+		Name:   filepath.Base(currentFile),
+		Status: StatusUnknown,
+		Metadata: map[string]string{
+			MetadataFileKey: relPath,
+			MetadataTypeKey: MetadataTypeFile,
+		},
+	}
+
+	infile, err := os.Open(currentFile)
+	if err != nil {
+		resultObj.Metadata["error"] = err.Error()
+		resultObj.Status = StatusUnknown
+
+		return resultObj, errors.Wrapf(err, "opening file %v", currentFile)
+	}
+	defer infile.Close()
+
+	resultObj, err = gojsonProcessReader(
+		infile,
+		resultObj.Name,
+		resultObj.Metadata,
+	)
+	if err != nil {
+		return resultObj, errors.Wrap(err, "error processing gojson")
+	}
+
+	return resultObj, nil
+}
+
+func gojsonProcessReader(r io.Reader, name string, metadata map[string]string) (Item, error) {
+	rootItem := Item{
+		Name:     name,
+		Status:   StatusPassed,
+		Metadata: metadata,
+	}
+
+	if r == nil {
+		rootItem.Status = StatusUnknown
+		if rootItem.Metadata == nil {
+			rootItem.Metadata = map[string]string{}
+		}
+		rootItem.Metadata["error"] = "no data source for gojson"
+		return rootItem, errors.New("no data source for gojson")
+	}
+
+	decoder := json.NewDecoder(r)
+	currentTest := testEvent{}
+	for {
+		if err := decoder.Decode(&currentTest); err == io.EOF {
+			break
+		} else if err != nil {
+			rootItem.Status = StatusUnknown
+			if rootItem.Metadata == nil {
+				rootItem.Metadata = map[string]string{}
+			}
+			rootItem.Metadata["error"] = err.Error()
+			return rootItem, errors.Wrap(err, "decoding gojson")
+		}
+
+		if i := gojsonEventToItem(currentTest); i != nil {
+			rootItem.Items = append(rootItem.Items, *i)
+		}
+	}
+	return rootItem, nil
+}
+
+func gojsonEventToItem(event testEvent) *Item {
+	if contains([]string{
+		actionCont, actionBench, actionOutput, actionPause, actionRun,
+	}, event.Action) {
+		logrus.WithField("action", event.Action).WithField("test", event.Test).Trace("Skipping gojson event")
+		return nil
+	}
+
+	i := &Item{
+		Name: event.Test,
+	}
+	switch event.Action {
+	case actionPass:
+		i.Status = StatusPassed
+	case actionSkip:
+		i.Status = StatusSkipped
+	case actionFail:
+		i.Status = StatusFailed
+	default:
+		i.Status = StatusUnknown
+	}
+	return i
+}
+
+func contains(list []string, target string) bool {
+	for _, s := range list {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/client/results/gojson_test.go
+++ b/pkg/client/results/gojson_test.go
@@ -1,0 +1,126 @@
+package results
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func Test_GojsonEventToItem(t *testing.T) {
+	tests := []struct {
+		name  string
+		event testEvent
+		want  *Item
+	}{
+		{
+			name:  "Empty is unknown",
+			event: testEvent{},
+			want:  &Item{Status: StatusUnknown},
+		}, {
+			name:  "Pass",
+			event: testEvent{Action: actionPass},
+			want:  &Item{Status: StatusPassed},
+		}, {
+			name:  "Failure",
+			event: testEvent{Action: actionFail},
+			want:  &Item{Status: StatusFailed},
+		}, {
+			name:  "Skip",
+			event: testEvent{Action: actionSkip},
+			want:  &Item{Status: StatusSkipped},
+		}, {
+			name:  "Others unknown",
+			event: testEvent{Action: "weirdvalue"},
+			want:  &Item{Status: StatusUnknown},
+		}, {
+			name:  "Name is correct",
+			event: testEvent{Action: actionPass, Test: "testname"},
+			want:  &Item{Status: StatusPassed, Name: "testname"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gojsonEventToItem(tt.event); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("gojsonEventToItem() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GojsonProcessReader(t *testing.T) {
+	type args struct {
+		r        io.Reader
+		name     string
+		metadata map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Item
+		wantErr bool
+	}{
+		{
+			name: "Not JSON returns error",
+			args: args{
+				r:    strings.NewReader(`{`),
+				name: "suite",
+			},
+			want:    Item{Name: "suite", Status: StatusUnknown, Metadata: map[string]string{"error": "unexpected EOF"}},
+			wantErr: true,
+		}, {
+			name: "Single tests get parsed",
+			args: args{
+				r:    strings.NewReader(`{"action":"pass", "test":"test1"}`),
+				name: "suite",
+			},
+			want: Item{
+				Name: "suite", Status: StatusPassed,
+				Items: []Item{
+					{Name: "test1", Status: StatusPassed},
+				},
+			},
+		}, {
+			name: "Multiple tests get parsed in order",
+			args: args{
+				r:    strings.NewReader(`{"action":"pass", "test":"test1"}{"action":"pass", "test":"test2"}`),
+				name: "suite",
+			},
+			want: Item{
+				Name: "suite", Status: StatusPassed,
+				Items: []Item{
+					{Name: "test1", Status: StatusPassed},
+					{Name: "test2", Status: StatusPassed},
+				},
+			},
+		}, {
+			name: "Aggregation doesnt happen in this method FYI",
+			args: args{
+				r:    strings.NewReader(`{"action":"fail", "test":"test1"}{"action":"pass", "test":"test2"}`),
+				name: "suite",
+			},
+			want: Item{
+				Name: "suite", Status: StatusPassed,
+				Items: []Item{
+					{Name: "test1", Status: StatusFailed},
+					{Name: "test2", Status: StatusPassed},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gojsonProcessReader(tt.args.r, tt.args.name, tt.args.metadata)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("gojsonProcessReader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("gojsonProcessReader() diff: %v", pretty.Compare(got, tt.want))
+			}
+		})
+	}
+}

--- a/pkg/client/results/processing.go
+++ b/pkg/client/results/processing.go
@@ -38,6 +38,7 @@ import (
 const (
 	ResultFormatJUnit  = "junit"
 	ResultFormatE2E    = "e2e"
+	ResultFormatGoJSON = "gojson"
 	ResultFormatRaw    = "raw"
 	ResultFormatManual = "manual"
 )
@@ -158,6 +159,9 @@ func PostProcessPlugin(p plugin.Interface, dir string) (Item, []error) {
 	case ResultFormatE2E, ResultFormatJUnit:
 		logrus.WithField("plugin", p.GetName()).Trace("Using junit post-processor")
 		i, errs = processPluginWithProcessor(p, dir, junitProcessFile, fileOrExtension(p.GetResultFiles(), ".xml"))
+	case ResultFormatGoJSON:
+		logrus.WithField("plugin", p.GetName()).Trace("Using gojson post-processor")
+		i, errs = processPluginWithProcessor(p, dir, gojsonProcessFile, fileOrExtension(p.GetResultFiles(), ".json"))
 	case ResultFormatRaw:
 		logrus.WithField("plugin", p.GetName()).Trace("Using raw post-processor")
 		i, errs = processPluginWithProcessor(p, dir, rawProcessFile, fileOrAny(p.GetResultFiles()))


### PR DESCRIPTION
**What this PR does / why we need it**:
This will work with the output from go test --json

This is particularly important since we want to work
with the new upstream e2e-test-framework which structures
tests so they are go-testable.

**Which issue(s) this PR fixes**
- Fixes #1459 

**Special notes for your reviewer**:
TODO:
 - test cases
 - a stretch goal would be to include output for the tests as needed. Currently it just deals with the stream one by one and only saves the pass/fail tests. Would have to see output and then lookup/store all the data as we go. Doable but doesn't have to be done to merge.
 - 
**Release note**:
```
JSON output from `go test --json` is now parsable as its own results type for plugins. This means you can set `result-type` on your plugin as `gojson` and its results will be parsed and inspectable from `sonobuoy status --json` and `sonobuoy results`.
```
