### PR TITLE
Clarify plugin list output surrounding name/file

### DIFF
--- a/cmd/sonobuoy/app/pluginCache.go
+++ b/cmd/sonobuoy/app/pluginCache.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -140,8 +141,8 @@ func listInstalledPlugins(installedDir string) error {
 		if !first {
 			prefix = "---\n"
 		}
-		fmt.Printf("%vfilename: %v\nplugin name: %v\nsource URL: %v\ndescription: %v\n",
-			prefix, filename, p.SonobuoyConfig.PluginName, p.SonobuoyConfig.SourceURL, p.SonobuoyConfig.Description)
+		fmt.Printf("%vRun as: %v\nFilename: %v\nPlugin name (in aggregator): %v\nSource URL: %v\nDescription: %v\n",
+			prefix, strings.TrimSuffix(filepath.Base(filename), ".yaml"), filename, p.SonobuoyConfig.PluginName, p.SonobuoyConfig.SourceURL, p.SonobuoyConfig.Description)
 		first = false
 	}
 

--- a/test/integration/testdata/plugin-install-delete.golden
+++ b/test/integration/testdata/plugin-install-delete.golden
@@ -1,16 +1,19 @@
 Installed plugin plugin into file *STATIC_FOR_TESTING*/foo.yaml from source ./testdata/plugins/good/hello-world.yaml
 Installed plugin plugin into file *STATIC_FOR_TESTING*/foo2.yaml from source ./testdata/plugins/good/hello-world.yaml
-filename: *STATIC_FOR_TESTING*/foo.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: foo
+Filename: *STATIC_FOR_TESTING*/foo.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.
 ---
-filename: *STATIC_FOR_TESTING*/foo2.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: foo2
+Filename: *STATIC_FOR_TESTING*/foo2.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.
 Uninstalled plugin file *STATIC_FOR_TESTING*/foo.yaml
-filename: *STATIC_FOR_TESTING*/foo2.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: foo2
+Filename: *STATIC_FOR_TESTING*/foo2.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.

--- a/test/integration/testdata/plugin-install.golden
+++ b/test/integration/testdata/plugin-install.golden
@@ -1,5 +1,6 @@
 Installed plugin plugin into file *STATIC_FOR_TESTING*/foo.yaml from source ./testdata/plugins/good/hello-world.yaml
-filename: *STATIC_FOR_TESTING*/foo.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: foo
+Filename: *STATIC_FOR_TESTING*/foo.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.

--- a/test/integration/testdata/plugin-list-good-bad.golden
+++ b/test/integration/testdata/plugin-list-good-bad.golden
@@ -5,17 +5,20 @@ Installed plugin plugin into file *STATIC_FOR_TESTING*/p3.yaml from source ./tes
 Installed plugin plugin into file *STATIC_FOR_TESTING*/p5.yaml from source ./testdata/plugins/good/hello-world.yaml
 time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p2.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p2.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
 time="STATIC_TIME_FOR_TESTING" level=error msg="failed to load definition from file \"*STATIC_FOR_TESTING*/p4.yaml\": couldn't load plugin definition for file *STATIC_FOR_TESTING*/p4.yaml: couldn't decode yaml for plugin definition: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
-filename: *STATIC_FOR_TESTING*/p1.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: p1
+Filename: *STATIC_FOR_TESTING*/p1.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.
 ---
-filename: *STATIC_FOR_TESTING*/p3.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: p3
+Filename: *STATIC_FOR_TESTING*/p3.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.
 ---
-filename: *STATIC_FOR_TESTING*/p5.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: p5
+Filename: *STATIC_FOR_TESTING*/p5.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.

--- a/test/integration/testdata/plugin-list.golden
+++ b/test/integration/testdata/plugin-list.golden
@@ -1,9 +1,11 @@
-filename: testdata/plugins/good/hello-world.yaml
-plugin name: hello-world
-source URL: foo.com
-description: This is a plugin description.
+Run as: hello-world
+Filename: testdata/plugins/good/hello-world.yaml
+Plugin name (in aggregator): hello-world
+Source URL: foo.com
+Description: This is a plugin description.
 ---
-filename: testdata/plugins/good/hw-2.yaml
-plugin name: hello-world2
-source URL: 
-description: 
+Run as: hw-2
+Filename: testdata/plugins/good/hw-2.yaml
+Plugin name (in aggregator): hello-world2
+Source URL: 
+Description: 


### PR DESCRIPTION
This is a confusing point about the plugins: the filename is what
determines what sonobuoy loads from the command line, but the plugin
name (inside the yaml file) is what the aggregator server sees.

The first feedback from the blog post about this exhibted this confusion
and rightly so. I hope by adding this first line "Run as: <name>" it
will become more clear that _that_ is how you select the plugin.

Signed-off-by: John Schnake <jschnake@vmware.com>

Fixes #1468 