### PR TITLE
Fix plugin nodeSelector issue inc. systemd-logs

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -326,7 +326,7 @@ func mergeEnv(e1, e2 []corev1.EnvVar, removeKeys map[string]struct{}) []corev1.E
 
 func SystemdLogsManifest(cfg *GenConfig) *manifest.Manifest {
 	trueVal := true
-	return &manifest.Manifest{
+	m := &manifest.Manifest{
 		SonobuoyConfig: manifest.SonobuoyConfig{
 			PluginName:   "systemd-logs",
 			Driver:       "DaemonSet",
@@ -364,6 +364,14 @@ func SystemdLogsManifest(cfg *GenConfig) *manifest.Manifest {
 			},
 		},
 	}
+
+	m.PodSpec = &manifest.PodSpec{
+		PodSpec: driver.DefaultPodSpec(m.SonobuoyConfig.Driver),
+	}
+	// systemd-logs only makes sense on linux.
+	// TODO(jschnake): Instead of systemd-logs, make an os-agnostic log gathering plugin.
+	m.PodSpec.PodSpec.NodeSelector = map[string]string{"kubernetes.io/os": "linux"}
+	return m
 }
 
 func E2EManifest(cfg *GenConfig) *manifest.Manifest {

--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -76,6 +76,8 @@ data:
       hostIPC: true
       hostNetwork: true
       hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
       serviceAccountName: sonobuoy-serviceaccount
       tolerations:
       - operator: Exists

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -42,6 +42,21 @@ data:
       name: ""
       resources: {}
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -71,6 +71,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/pkg/plugin/driver/daemonset/daemonset_test.go
+++ b/pkg/plugin/driver/daemonset/daemonset_test.go
@@ -577,6 +577,24 @@ func TestExpectedResults(t *testing.T) {
 		return p
 	}
 
+	pluginWithNodeSelector := func(key, val string) *Plugin {
+		p := &Plugin{
+			Base: driver.Base{
+				Definition: manifest.Manifest{
+					SonobuoyConfig: manifest.SonobuoyConfig{PluginName: "myPlugin"},
+				},
+			},
+		}
+		if len(key) > 0 {
+			p.Base.Definition.PodSpec = &manifest.PodSpec{
+				PodSpec: corev1.PodSpec{
+					NodeSelector: map[string]string{key: val},
+				},
+			}
+		}
+		return p
+	}
+
 	testCases := []struct {
 		desc   string
 		p      *Plugin
@@ -638,6 +656,12 @@ func TestExpectedResults(t *testing.T) {
 				{Key: "foo", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"bar", "baz"}},
 				{Key: "foo", Operator: corev1.NodeSelectorOpIn, Values: []string{"bar"}},
 			}),
+		}, {
+			desc: "Can use nodeSelector field",
+			expect: []plugin.ExpectedResult{
+				{NodeName: "node2", ResultType: "myPlugin"},
+			},
+			p: pluginWithNodeSelector("foo", "bar"),
 		},
 	}
 	for _, tc := range testCases {

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -123,6 +123,21 @@ data:
       - mountPath: /tmp/sonobuoy/config
         name: sonobuoy-e2e-vol
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -112,6 +112,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -109,6 +109,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -114,6 +114,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-security-context-none.golden
+++ b/test/integration/testdata/gen-security-context-none.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -111,6 +111,21 @@ data:
       - mountPath: /tmp/results
         name: results
   plugin-1.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: systemd-logs


### PR DESCRIPTION
- Makes systemd-logs only run on linux nodes
- Fixes logic for plugins with nodeSelector so that only
matching nodes are expected to return results

Signed-off-by: John Schnake <jschnake@vmware.com>

**Which issue(s) this PR fixes**
- Fixes #1452 

**Release note**:
```
Fixes a bug which caused a plugins nodeSelector to not work properly.
```
