### PR TITLE
Fix logs bug causing aggregator to be dropped

### DIFF
--- a/cmd/sonobuoy/app/logs.go
+++ b/cmd/sonobuoy/app/logs.go
@@ -54,7 +54,7 @@ func NewCmdLogs() *cobra.Command {
 	)
 	AddKubeconfigFlag(&f.kubeconfig, cmd.Flags())
 	AddNamespaceFlag(&f.namespace, cmd.Flags())
-	cmd.Flags().StringVarP(&f.plugin, pluginFlag, "p", "", "Show logs only for a specific plugin")
+	cmd.Flags().StringVarP(&f.plugin, pluginFlag, "p", "", "Show logs only for a specific plugin. If 'sonobuoy' is provided, only shows the aggregator logs.")
 	return cmd
 }
 


### PR DESCRIPTION
A race condition existed between the reader/writer
of the channel even though it was an unbuffered channel.

Also added a special value "sonobuoy" so that if you try
and `sonobuoy logs -p sonobuoy` we will just get the
aggregator logs.

Signed-off-by: John Schnake <jschnake@vmware.com>


Fixes #1477 

**Release note**:
```
Fixed a bug in `sonobuoy logs` that sometimes caused logs from random containers to not be gathered.
```
