### PR TITLE
Add `sonobuoy wait` command

### DIFF
--- a/cmd/sonobuoy/app/root.go
+++ b/cmd/sonobuoy/app/root.go
@@ -19,6 +19,7 @@ package app
 import (
 	"flag"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
 
@@ -60,6 +61,7 @@ func NewSonobuoyCommand() *cobra.Command {
 	cmds.AddCommand(NewCmdImages())
 	cmds.AddCommand(NewCmdResults())
 	cmds.AddCommand(NewCmdSplat())
+	cmds.AddCommand(NewCmdWait())
 
 	cmds.AddCommand(NewCmdPlugin())
 

--- a/cmd/sonobuoy/app/waitCmd.go
+++ b/cmd/sonobuoy/app/waitCmd.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/sonobuoy/pkg/errlog"
+)
+
+func NewCmdWait() *cobra.Command {
+	var f genFlags
+	fs := GenFlagSet(&f, DetectRBACMode)
+	cmd := &cobra.Command{
+		Use:   "wait",
+		Short: "Waits on the Sonobuoy run in the targeted namespace.",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkFlagValidity(fs, f)
+		},
+		Run:  waitOnRun(&f),
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().AddFlagSet(fs)
+	return cmd
+}
+
+func waitOnRun(f *genFlags) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		sbc, err := getSonobuoyClientFromKubecfg(f.kubecfg)
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "could not create sonobuoy client"))
+			os.Exit(1)
+		}
+
+		runCfg, err := f.RunConfig()
+		if err != nil {
+			errlog.LogError(errors.Wrap(err, "could not retrieve E2E config"))
+			os.Exit(1)
+		}
+
+		if err := sbc.WaitForRun(runCfg); err != nil {
+			errlog.LogError(errors.Wrap(err, "error attempting to run sonobuoy"))
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
You can now 'attach' to a running sonobuoy run with the
sonobuoy wait comand.

Signed-off-by: John Schnake <jschnake@vmware.com>

Fixes #1478 

**Release note**:
```
Added a new command `sonobuoy wait` which allows you to wait on Sonobuoy runs even if you failed to add `--wait` at the time the run was started.
```
