### PR TITLE
Fix issues related to logging and plugin cache

### DIFF
--- a/cmd/sonobuoy/app/gen.go
+++ b/cmd/sonobuoy/app/gen.go
@@ -98,14 +98,6 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 	AddKubeConformanceImage(&cfg.pluginTransforms, genset)
 	AddSystemdLogsImage(&cfg.pluginTransforms, genset)
 
-	// This bit of logic enables the plugin management features of Sonobuoy which are currently
-	// in development. By placing it here we will impact any command that wants a full set of flags
-	// like the `gen` command. Meanwhile, if you just use an empty `pluginList` then caching will
-	// be disabled.
-	if featureEnabled(FeaturePluginInstallation) {
-		cfg.plugins.InstallDir = getPluginCacheLocation()
-	}
-
 	AddSecurityContextMode(&cfg.sonobuoyConfig.SecurityContextMode, genset)
 
 	AddSkipPreflightFlag(&cfg.skipPreflight, genset)
@@ -120,7 +112,7 @@ func GenFlagSet(cfg *genFlags, rbac RBACMode) *pflag.FlagSet {
 		&cfg.genFile, "file", "f", "",
 		"If set, loads the file as if it were the output from sonobuoy gen. Set to `-` to read from stdin.",
 	)
-	
+
 	return genset
 }
 

--- a/cmd/sonobuoy/app/pluginCache.go
+++ b/cmd/sonobuoy/app/pluginCache.go
@@ -102,9 +102,14 @@ func NewCmdPlugin() *cobra.Command {
 func getPluginCacheLocation() string {
 	usePath := os.Getenv(SonobuoyDirEnvKey)
 	if len(usePath) == 0 {
+		logrus.Tracef("No %v was set, using default: %v", SonobuoyDirEnvKey, defaultSonobuoyDir)
 		usePath = defaultSonobuoyDir
+	} else {
+		logrus.Tracef("%v set to %v", SonobuoyDirEnvKey, usePath)
 	}
 	expandedPath, err := expandPath(usePath)
+	logrus.Tracef("%v:%v expanded to: %v", SonobuoyDirEnvKey, usePath, expandedPath)
+
 	if err != nil {
 		logrus.Errorf("failed to expand sonobuoy directory %q: %v", usePath, err)
 		return ""
@@ -231,7 +236,11 @@ func installPlugin(installedDir, filename, src string) error {
 	}
 
 	newPath := filepath.Join(installedDir, filename)
+
+	// Disable plugin caching on this temporary pluginList value by saying it has already bin initialized to the empty string.
 	var pl pluginList
+	pl.initInstallDir = true
+
 	if err := pl.Set(src); err != nil {
 		return err
 	}

--- a/cmd/sonobuoy/app/pluginList_test.go
+++ b/cmd/sonobuoy/app/pluginList_test.go
@@ -120,6 +120,9 @@ func TestSetPluginList(t *testing.T) {
 				// No error
 			}
 
+			// We don't want to worry about diffs in the plugin cache location so just ignore those fields here.
+			tc.list.InstallDir, tc.list.initInstallDir = "", false
+
 			if diff := pretty.Compare(tc.expect, tc.list); diff != "" {
 				t.Fatalf("\n\n%s\n", diff)
 			}

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -211,6 +211,10 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate, progres
 			Name:  "SONOBUOY_PROGRESS_PORT",
 			Value: progressPort,
 		},
+		{
+			Name:  "SONOBUOY_DIR",
+			Value: "/tmp/sonobuoy",
+		},
 	}
 
 	return envVars

--- a/pkg/plugin/driver/daemonset/daemonset.go
+++ b/pkg/plugin/driver/daemonset/daemonset.go
@@ -78,9 +78,7 @@ func NewPlugin(dfn manifest.Manifest, namespace, sonobuoyImage, imagePullPolicy,
 
 // ExpectedResults returns the list of results expected for this daemonset.
 func (p *Plugin) ExpectedResults(nodes []v1.Node) []plugin.ExpectedResult {
-
 	nodes = p.filterByNodeSelector(nodes)
-	logrus.Errorf("schnake expected results! nodes %v", nodes)
 	ret := make([]plugin.ExpectedResult, 0, len(nodes))
 
 	for _, node := range nodes {
@@ -197,7 +195,7 @@ func (p *Plugin) createDaemonSetDefinition(hostname string, cert *tls.Certificat
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy", "worker", "single-node", "-v=5", "--logtostderr", "--sleep=" + defaultSleepSeconds}, []string{}, progressPort),
+		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy", "worker", "single-node", "--level=trace", "-v=6", "--logtostderr", "--sleep=" + defaultSleepSeconds}, []string{}, progressPort),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -116,7 +116,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 	podSpec.Containers = append(podSpec.Containers,
 		p.Definition.Spec.Container,
-		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "-v", "5", "--logtostderr"}, progressPort),
+		p.CreateWorkerContainerDefintion(hostname, cert, []string{"/sonobuoy"}, []string{"worker", "global", "--level=trace", "-v=6", "--logtostderr"}, progressPort),
 	)
 
 	if len(p.ImagePullSecrets) > 0 {


### PR DESCRIPTION
- Moved logic for loading plugin cache to later in flow
- Hardcoded workers into trace mode; they don't have access
to the log level and, considering their small size as well as
their impact if they break, making them trace by default is a
reasonable approach for now
- Added more trace logging to the lookup/resolution of the cache
install location

Signed-off-by: John Schnake <jschnake@vmware.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
- Fixes #1486 
- Fixes #1484 

**Special notes for your reviewer**:
The moving of the getpluginCacheLocation() is what resolves the unnecessary errors in aggregators/workers. They don't really use that value so it doesn't have to get resolved at all now that it is done lazily. This also prevents hitting that piece of code multiple times before the commands actually run.

**Release note**:
```
Increased logging level of sonobuoy-worker sidecars by default from -v=5 to -v=6 and --level=trace.

Increased trace level logging surrounding the resolution of the plugin installation directory.

Fixed a small bug that caused the plugin installation directory to unnecessarily get resolved when running the aggregator, leading to odd-looking errors in the logs that were unimportant.
```
