### PR TITLE
Fix build image push issue

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -148,6 +148,8 @@ jobs:
         run: |
           docker load -i build/linux/amd64/sonobuoy-img-linux-amd64-${{ github.run_id }}.tar
           docker load -i build/linux/arm64/sonobuoy-img-linux-arm64-${{ github.run_id }}.tar
+          docker load -i build/linux/ppc64le/sonobuoy-img-linux-ppc64le-${{ github.run_id }}.tar
+          docker load -i build/linux/s390x/sonobuoy-img-linux-s390x-${{ github.run_id }}.tar
           docker image ls
       - name: Login to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
New archs were not being loaded before pushed even though
they'd been saved into the tarball.

Signed-off-by: John Schnake <jschnake@vmware.com>

Fixes #1491 