### PR TITLE
Workers report results if plugin exits with 0 code

### DIFF
--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -217,6 +217,22 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate, progres
 		{
 			Name:  "SONOBUOY_DIR",
 			Value: "/tmp/sonobuoy",
+		}, {
+			Name: "SONOBUOY_NS",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				}},
+		}, {
+			Name: "SONOBUOY_PLUGIN_POD",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				}},
+		}, {
+			// Downward-api doesn't support this value so we have to just rely on hardcoding it.
+			Name:  "SONOBUOY_WORKER_CONTAINER",
+			Value: "sonobuoy-worker",
 		},
 	}
 

--- a/test/integration/sonobuoy_integration_test.go
+++ b/test/integration/sonobuoy_integration_test.go
@@ -185,6 +185,22 @@ func TestSimpleRun(t *testing.T) {
 	mustRunSonobuoyCommandWithContext(ctx, t, ns, args)
 }
 
+// TestNoDoneFile runs two plugins which do not write their own done file and we check that the
+// worker realizes this and submits results for them.
+func TestNoDoneFile(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	ns, cleanup := getNamespace(t)
+	defer cleanup()
+
+	args := fmt.Sprintf("run --image-pull-policy IfNotPresent --wait -p testImage/yaml/job-manual-no-done.yaml -p testImage/yaml/ds-manual-no-done.yaml -n %v", ns)
+	mustRunSonobuoyCommandWithContext(ctx, t, ns, args)
+	tb := mustDownloadTarball(ctx, t, ns)
+	tb = saveToArtifacts(t, tb)
+}
+
 // TestRetrieveAndExtractWithPodLogs tests that we are able to extract the files
 // from the tarball via the retrieve command. It also ensures that we dont
 // regress on #1415, that plugin pod logs should be gathered.

--- a/test/integration/testImage/src/go.mod
+++ b/test/integration/testImage/src/go.mod
@@ -5,5 +5,4 @@ go 1.14
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
-	github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d
 )

--- a/test/integration/testImage/src/go.sum
+++ b/test/integration/testImage/src/go.sum
@@ -7,6 +7,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -26,8 +27,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d h1:Z8Bp/K+wf1+IUvu5Vk2Ml/mMI7fmZTT7rQjkLC8pAmQ=
-github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d/go.mod h1:8uo3DXfN526YN7JjAp4JkOMm4foTW4vPzPHaAzb4xiY=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/integration/testImage/src/main.go
+++ b/test/integration/testImage/src/main.go
@@ -45,6 +45,10 @@ func init() {
 
 func main() {
 	rootCmd := &cobra.Command{Use: "testImage", Version: "0.0.1"}
+	rootCmd.PersistentFlags().Bool(
+		"no-done", false,
+		"Use this if you want the plugin to exit without writing the done file to the worker.",
+	)
 	rootCmd.AddCommand(cmdSingleFile)
 	rootCmd.AddCommand(cmdTarFile)
 	rootCmd.Execute()

--- a/test/integration/testImage/src/tarResults.go
+++ b/test/integration/testImage/src/tarResults.go
@@ -65,6 +65,12 @@ func reportTarFile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Report location to Sonobuoy.
+	if cmd.Flags().Lookup("no-done").Value.String() == "true" {
+		fmt.Println("no-done is set, exiting without writing done file")
+		return nil
+	}
+
+	// Report location to Sonobuoy.
 	err = ioutil.WriteFile(doneFile, []byte(tb), os.FileMode(0666))
 	return errors.Wrap(err, "failed to write to done file")
 }

--- a/test/integration/testImage/yaml/ds-manual-no-done.yaml
+++ b/test/integration/testImage/yaml/ds-manual-no-done.yaml
@@ -1,0 +1,20 @@
+sonobuoy-config:
+  driver: DaemonSet
+  plugin-name: ds-manual
+  result-format: manual
+  result-files:
+    - manual-results-1.yaml
+    - manual-results-2.yaml
+spec:
+  args:
+  - single-file
+  - /resources/manual-results-1.yaml
+  - --no-done
+  command:
+  - /testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results

--- a/test/integration/testImage/yaml/job-manual-no-done.yaml
+++ b/test/integration/testImage/yaml/job-manual-no-done.yaml
@@ -1,0 +1,22 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: job-manual
+  result-format: manual
+  result-files:
+    - manual-results-1.yaml
+    - manual-results-2.yaml
+spec:
+  args:
+  - single-file
+  - /resources/manual-results-1.yaml
+  - /resources/manual-results-2.yaml
+  - --no-done
+  command:
+  - /testImage
+  image: sonobuoy/testimage:v0.1
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results
+


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the basic boilerplate parts of writing any plugin is writing the path to the results into the `done` file before exiting. Many bugs have been generated about this not being properly done, and, as a result, the plugin doesn't report results and Sonobuoy considers it a timeout/failure.

If the sidecar is the only container still running, it should automatically tar up that directory though, and just submit the results. As long as some results are there and the containers all exited with exit code 0, it makes the life of the plugin author much more simple. Especially in the case where you are just writing a plugin that wraps another script or binary.

**Which issue(s) this PR fixes**
- Fixes #1462 

**Special notes for your reviewer**:

**Release note**:
```
Plugins just got even easier! Now you can just output all of your results into the results directory (given by env variable SONOBUOY_RESULTS_DIR) and exit. The sonobuoy worker will automatically upload all of the contents of that folder to the aggregator for you.
```
