### PR TITLE
Upload artifacts from integration tests

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -128,6 +128,12 @@ jobs:
           source ./scripts/build.sh
           load_test_images_into_cluster
           VERBOSE=true SONOBUOY_CLI=../../build/linux/amd64/sonobuoy integration
+      - name: Save artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: sonobuoy-test-archives-${{ github.run_id }}
+          path: |
+            /tmp/artifacts
   push-images:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The artifacts were put in a unique directory with the intent
of uploading them for debugging in github. However, the upload
step was not added into the CI so they are always "dropped" and
not available.

Fixes #1495 