### PR TITLE
Fix bug causing some duplicate gojson tests

### DIFF
--- a/pkg/client/results/gojson.go
+++ b/pkg/client/results/gojson.go
@@ -111,8 +111,8 @@ func gojsonProcessReader(r io.Reader, name string, metadata map[string]string) (
 	}
 
 	decoder := json.NewDecoder(r)
-	currentTest := testEvent{}
 	for {
+		currentTest := testEvent{}
 		if err := decoder.Decode(&currentTest); err == io.EOF {
 			break
 		} else if err != nil {
@@ -136,6 +136,11 @@ func gojsonEventToItem(event testEvent) *Item {
 		actionCont, actionBench, actionOutput, actionPause, actionRun,
 	}, event.Action) {
 		logrus.WithField("action", event.Action).WithField("test", event.Test).Trace("Skipping gojson event")
+		return nil
+	}
+
+	if event.Test == "" {
+		logrus.WithField("action", event.Action).Trace("Skipping gojson event due to no test name attached")
 		return nil
 	}
 


### PR DESCRIPTION
If the object used in decoding the stream isn't reset each time,
some values from a previous event can appear in the next value.
In my specific case, the test name was being left filled and caused
a test to be listed as passing twice.

Signed-off-by: John Schnake <jschnake@vmware.com>

Fixes #1500 