### PR TITLE
Apply results volume mount and env to all containers in plugin

### DIFF
--- a/pkg/client/testdata/default-plugins-via-nil-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-nil-selection.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/default-plugins-via-selection.golden
+++ b/pkg/client/testdata/default-plugins-via-selection.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/default-pod-spec.golden
+++ b/pkg/client/testdata/default-pod-spec.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/default.golden
+++ b/pkg/client/testdata/default.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/e2e-default.golden
+++ b/pkg/client/testdata/e2e-default.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/e2e-progress-custom-port.golden
+++ b/pkg/client/testdata/e2e-progress-custom-port.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "1234"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/e2e-progress-vs-user-defined.golden
+++ b/pkg/client/testdata/e2e-progress-vs-user-defined.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/e2e-progress.golden
+++ b/pkg/client/testdata/e2e-progress.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/envoverrides.golden
+++ b/pkg/client/testdata/envoverrides.golden
@@ -66,6 +66,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/goRunnerRemoved.golden
+++ b/pkg/client/testdata/goRunnerRemoved.golden
@@ -61,6 +61,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/imagePullPolicy-all-plugins.golden
+++ b/pkg/client/testdata/imagePullPolicy-all-plugins.golden
@@ -39,6 +39,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
@@ -61,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/pkg/client/testdata/imagePullSecrets.golden
+++ b/pkg/client/testdata/imagePullSecrets.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-e2e.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -86,6 +88,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
+++ b/pkg/client/testdata/manual-custom-plugin-plus-systemd.golden
@@ -39,6 +39,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
@@ -88,6 +90,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/manual-custom-plugin.golden
+++ b/pkg/client/testdata/manual-custom-plugin.golden
@@ -39,6 +39,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/pkg/client/testdata/manual-e2e.golden
+++ b/pkg/client/testdata/manual-e2e.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing

--- a/pkg/client/testdata/multiple-node-selector.golden
+++ b/pkg/client/testdata/multiple-node-selector.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/plugin-configmaps.golden
+++ b/pkg/client/testdata/plugin-configmaps.golden
@@ -46,6 +46,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
@@ -77,6 +79,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/pkg/client/testdata/plugins-and-pluginSelection.golden
+++ b/pkg/client/testdata/plugins-and-pluginSelection.golden
@@ -39,6 +39,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent
@@ -61,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/pkg/client/testdata/single-node-selector.golden
+++ b/pkg/client/testdata/single-node-selector.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/systemd-logs-default.golden
+++ b/pkg/client/testdata/systemd-logs-default.golden
@@ -63,6 +63,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v99+static.testing
@@ -113,6 +115,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/pkg/client/testdata/use-existing-pod-spec.golden
+++ b/pkg/client/testdata/use-existing-pod-spec.golden
@@ -41,6 +41,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v99+static.testing
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       imagePullPolicy: IfNotPresent

--- a/test/integration/testdata/gen-config-no-flags.golden
+++ b/test/integration/testdata/gen-config-no-flags.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
       image: k8s.gcr.io/conformance:ignore
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-config-then-flags.golden
+++ b/test/integration/testdata/gen-config-then-flags.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
       image: k8s.gcr.io/conformance:ignore
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-issue-1375.golden
+++ b/test/integration/testdata/gen-issue-1375.golden
@@ -113,6 +113,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -165,6 +167,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-issue-1376.golden
+++ b/test/integration/testdata/gen-issue-1376.golden
@@ -104,6 +104,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v9.8.7
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v9.8.7
@@ -154,6 +156,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v9.8.7
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-issue-1388.golden
+++ b/test/integration/testdata/gen-issue-1388.golden
@@ -101,6 +101,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -151,6 +153,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-no-uuid.golden
+++ b/test/integration/testdata/gen-no-uuid.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-plugin-e2e-configmap.golden
+++ b/test/integration/testdata/gen-plugin-e2e-configmap.golden
@@ -38,6 +38,8 @@ spec:
     value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_PROGRESS_PORT
+    value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789

--- a/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
+++ b/test/integration/testdata/gen-plugin-e2e-kube-flag-still-works.golden
@@ -39,6 +39,8 @@ spec:
     value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_PROGRESS_PORT
+    value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789

--- a/test/integration/testdata/gen-plugin-e2e.golden
+++ b/test/integration/testdata/gen-plugin-e2e.golden
@@ -38,6 +38,8 @@ spec:
     value: /tmp/sonobuoy/config
   - name: SONOBUOY_K8S_VERSION
     value: v123.456.789
+  - name: SONOBUOY_PROGRESS_PORT
+    value: "8099"
   - name: SONOBUOY_RESULTS_DIR
     value: /tmp/sonobuoy/results
   image: k8s.gcr.io/conformance:v123.456.789

--- a/test/integration/testdata/gen-plugin-renaming.golden
+++ b/test/integration/testdata/gen-plugin-renaming.golden
@@ -82,6 +82,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/testimage:v0.1
@@ -108,6 +110,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: hello:v9

--- a/test/integration/testdata/gen-rerunfailed-works.golden
+++ b/test/integration/testdata/gen-rerunfailed-works.golden
@@ -106,6 +106,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -156,6 +158,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-security-context-none.golden
+++ b/test/integration/testdata/gen-security-context-none.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-static-only-e2e.golden
+++ b/test/integration/testdata/gen-static-only-e2e.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v123.456.789

--- a/test/integration/testdata/gen-static.golden
+++ b/test/integration/testdata/gen-static.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:v123.456.789
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-subfield-flags.golden
+++ b/test/integration/testdata/gen-subfield-flags.golden
@@ -103,6 +103,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: k8s.gcr.io/conformance:ignore
@@ -153,6 +155,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: ignore
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: sonobuoy/systemd-logs:v0.4

--- a/test/integration/testdata/gen-variable-image.golden
+++ b/test/integration/testdata/gen-variable-image.golden
@@ -79,6 +79,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: hello:v9
@@ -105,6 +107,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: hello:v123.456.789

--- a/test/integration/testdata/plugin-loading-installed.golden
+++ b/test/integration/testdata/plugin-loading-installed.golden
@@ -81,6 +81,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: hello:v9

--- a/test/integration/testdata/plugin-loading-local.golden
+++ b/test/integration/testdata/plugin-loading-local.golden
@@ -81,6 +81,8 @@ data:
         value: /tmp/sonobuoy/config
       - name: SONOBUOY_K8S_VERSION
         value: v123.456.789
+      - name: SONOBUOY_PROGRESS_PORT
+        value: "8099"
       - name: SONOBUOY_RESULTS_DIR
         value: /tmp/sonobuoy/results
       image: hello:v9


### PR DESCRIPTION
**What this PR does / why we need it**:
Required if we want our post-processing model to work easily.

**Which issue(s) this PR fixes**
- Fixes #1485 

**Release note**:
```
Results volume mount and env vars will be applied to all side containers defined in the plugin, not just the primary container.
```
