### PR TITLE
Link to roadmap in main readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ details [here][issue1388]. The simplest way to avoid this is to update your vers
 
 ## Strategy Document
 
-See our current [strategy document][strategy] for context on what our highest priority use cases and work items
+See our current [strategy document][strategy] and [roadmap][roadmap] for context on what our highest priority use cases and work items
 will be. Feel free to make comments on Github or start conversations in Slack.
 
 ## Contributing
@@ -258,3 +258,5 @@ See [the list of releases][releases] to find out about feature changes.
 [strategy]: https://sonobuoy.io/docs/strategy
 
 [aggregator-permissions]: https://sonobuoy.io/docs/aggregator-permissions
+
+[roadmap]: https://github.com/vmware-tanzu/sonobuoy/wiki/Roadmap

--- a/site/content/docs/main/_index.md
+++ b/site/content/docs/main/_index.md
@@ -199,7 +199,7 @@ details [here][issue1388]. The simplest way to avoid this is to update your vers
 
 ## Strategy Document
 
-See our current [strategy document][strategy] for context on what our highest priority use cases and work items
+See our current [strategy document][strategy] and [roadmap][roadmap] for context on what our highest priority use cases and work items
 will be. Feel free to make comments on Github or start conversations in Slack.
 
 ## Contributing
@@ -270,3 +270,6 @@ See [the list of releases][releases] to find out about feature changes.
 [aggregator-permissions]: aggregator-permissions
 
 [clidocs]: cli/sonobuoy
+
+[roadmap]: https://github.com/vmware-tanzu/sonobuoy/wiki/Roadmap
+


### PR DESCRIPTION
The roadmap is meant to be publicly visible and was hard to find
on the wiki. This just raises the visibility of that document.

Fixes #1729

Signed-off-by: John Schnake <jschnake@vmware.com>