### PR TITLE
Skip push image

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -173,7 +173,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: [push-images]
+    needs: [build-linux, build-windows, unit-test-linux, integration-test-on-kind, stress-test-linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip docker image push step in github action since it does not work and is not needed. 
**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
